### PR TITLE
Add WebGL2 fallback and renderer selection for web terminals

### DIFF
--- a/docs/web-terminal.md
+++ b/docs/web-terminal.md
@@ -87,7 +87,7 @@ The demo consumes the library's public presentation adapter without friend acces
 | `Hwt1RenderProjection` (internal to Hex1b) | Projects captured snapshots, computes cell differences, manages image resources, and serializes HWT1 frames. |
 | Sample host / `BrowserSession` | Manages shared instances through HTTP; each WebSocket session owns only its HMP1 peer/view adapter and browser delivery loops. |
 | Mounted `WebTerminal` | Owns its appended shadow-root wrapper, hidden input textarea, coordinate conversion, local fitting, and pointer capture; does not own the caller's container. |
-| Per-view dedicated worker | Owns one WebSocket, decoder, transferred `OffscreenCanvas`, and independent WebGPU/glyph/image caches. |
+| Per-view dedicated worker | Owns one WebSocket, decoder, transferred `OffscreenCanvas`, and independent WebGPU or WebGL2/glyph/image caches. |
 
 ```text
 workload / PTY -> shared Hex1bTerminal + HMP1 producer
@@ -161,6 +161,13 @@ We considered SVG and canvas and chose a worker-owned WebGPU canvas for the
 spike. Canvas is the hosting surface; the main rendering path is not Canvas 2D.
 The renderer uses instanced quads, a glyph atlas, and persistent image textures.
 Canvas 2D is used to rasterize reusable glyphs into the atlas.
+
+The renderer now supports both WebGPU and WebGL2 behind a shared frame-preparation
+layer. Mount-time `renderer: "auto"` prefers WebGPU and falls back to WebGL2 for
+capability/device acquisition failures; `"webgpu"` and `"webgl2"` force a backend.
+WebGPU requires a secure context; WebGL2 permits ordinary HTTP rendering.
+Font/shader errors and runtime device/context loss remain errors, not fallback
+triggers. Stats expose the active renderer and any automatic fallback reason.
 
 This gives us explicit positioning and compositing without a DOM element for
 each cell or image. Text masks and color emoji share an atlas. A font-wide
@@ -250,7 +257,8 @@ by content, and unchanged byte-array identities avoid repeated hashing where
 possible. The placement list itself is still sent in full.
 
 There is at most one state revision in flight per view. The browser acknowledges after
-WebGPU reports submitted work complete. The terminal continues consuming output
+the selected backend reports submitted work complete (WebGPU queue completion
+or a WebGL2 fence). The terminal continues consuming output
 while presentation is busy: intermediate visual states can be skipped, but
 workload bytes are not intentionally dropped.
 
@@ -636,7 +644,7 @@ Scrollback, selection, and reconnect behavior should be designed together.
 | Browser UX | Text scrollback/selection/copy exist. Search, hyperlink activation, full accessibility, and complete touch behavior remain absent. | Build remaining features on server text/history and safe metadata, with keyboard-accessible controls and a real screen-reader strategy rather than only a text mirror. |
 | Recovery | Views can detach and attach to a process-local persistent instance, each with a fresh viewport/selection and baseline. GPU failure is surfaced; there is no automatic reconnect or durable recovery. | Define recovery across transport/device/server failure, resource restoration, authorization, and retention policy beyond the spike's explicit attach/end actions. |
 | Integration | The demo consumes a public experimental adapter, but stable hosting and browser-component APIs remain undefined. | Stabilize embedding and hosting APIs independently of HWT1, which remains internal to the paired server/client implementation. |
-| Compatibility | Exercised mainly in one Chromium/macOS environment. | Establish a browser/OS/GPU matrix, feature detection, and an explicit unsupported-device policy. Choose WebGPU-only support or a fallback backend based on requirements and evidence. |
+| Compatibility | WebGPU-preferred auto selection and explicit WebGPU/WebGL2 modes exist; exercised mainly in one Chromium/macOS environment. | Establish a browser/OS/GPU matrix and qualify backend performance. There is no Canvas2D terminal renderer or automatic runtime device-loss recovery. |
 
 ## Proposed production architecture
 

--- a/samples/WebTerminalDemo/README.md
+++ b/samples/WebTerminalDemo/README.md
@@ -24,7 +24,7 @@ npm ci --prefix samples/WebTerminalDemo
 dotnet run --project samples/WebTerminalDemo -c Release
 ```
 
-Open <http://localhost:5290> in a browser with WebGPU and worker
+Open <http://localhost:5290> in a browser with WebGPU or WebGL2 and worker
 `OffscreenCanvas` support. The .NET build compiles the package and the
 TypeScript playground, then copies the package's complete `dist/` tree to
 `wwwroot/web-terminal/`. The playground consumes the package by its npm name,
@@ -90,7 +90,7 @@ origin:
 | `history.browser.js` | Shared producer history, independent viewports, character/word/logical-line/block selection, held/released wheel scrolling, clipboard intent, capture override, read-only inspection, and eviction. Clipboard writes are intercepted rather than changing the user's clipboard. |
 | `bindings.browser.js` | Per-view input overrides, named actions, Windows-style right-click copy/paste, clipboard failures/races, capture ownership, and native text/paste/IME paths. Clipboard access is mocked. |
 | `selection-ui.browser.js` | Default, augmented, and replaced selection controls; host CSS, highlight parts, canvas alignment, focus/input isolation, action reuse, UI errors, and disposal. |
-| `graphics.browser.js` | Sixel and KGP in two views, cached-image movement, and late attachment to silent server-driven animation. |
+| `graphics.browser.js` | Sixel and KGP in mixed WebGPU/WebGL2 views, renderer controls/diagnostics, cached-image movement, and late attachment to silent server-driven animation. |
 | `cloud-flicker.browser.js` | Real shell-launched Sixel/KGP cloud animations, sampling visible canvas pixels over at least 180 browser frames and ten received updates to detect blank/partial redraws. Build `samples/SixelCloudDemo` and `samples/KgpCloudDemo` in Release first. |
 | `nested-flicker.browser.js` | WindowingDemo's Bash terminal running KittySearch: hover animation must keep painting through unrelated parent redraws, with at least 180 sampled browser frames and five distinct image states. Build `samples/WindowingDemo` and `samples/KittySearch` in Release first. Requires Bash. |
 | `nested-sixel.browser.js` | WindowingDemo's Bash terminal running both SixelCloudDemo modes: native Sixel presentation, overlapping motes, and synchronized frame persistence. Build `samples/WindowingDemo` and `samples/SixelCloudDemo` in Release first. Requires Bash. |
@@ -98,7 +98,16 @@ origin:
 The full-stack fixtures create and delete their own terminal instances. Run them
 against an isolated demo server with capacity available, not a production host.
 Headless Chromium may need `--enable-unsafe-webgpu` in its test launch configuration.
-These fixtures use WebGPU APIs rather than the Node tests' stub GPU interface.
+The GPU fixtures exercise real browser graphics APIs rather than the Node tests'
+stub interfaces.
+
+`renderers.browser.js` compares real WebGPU/WebGL2 pixels, uploads, clipping,
+layering, glyphs, resizing and resource retention. It allows native horizontal
+edge-coverage differences only where geometry ends exactly on a pixel center.
+It also mounts real workers with only their WebSocket transport mocked on an
+ordinary HTTP origin, exercising HWT1 decoding, frame acknowledgements,
+automatic fallback and forced selection without weakening the sample host's
+loopback-only access policy.
 
 The package's Node regressions and TypeScript builds run in CI. The browser
 fixtures remain focused, explicitly invoked checks; they are not a claim of
@@ -136,6 +145,13 @@ existing instance without claiming primary, or creates a mixed instance if the
 registry is empty. A supported `?scene=...` selects a newly created workload.
 `?empty=1` suppresses automatic view creation/attachment for browser checks;
 the normal controls remain available.
+
+**New view renderer** chooses Auto (prefer WebGPU), WebGPU, or WebGL2 for newly
+opened views. `?renderer=webgl2` selects WebGL2 on initial load; `auto` and
+`webgpu` are also accepted. Existing views keep their backend until remounted.
+The selected-view metrics show the active backend and any automatic fallback
+reason. WebGPU requires HTTPS or localhost; the package can use WebGL2 on
+ordinary HTTP, but this demo's loopback-only host policy remains unchanged.
 
 ## Mount in a sized element
 
@@ -706,7 +722,7 @@ hidden or swapped. A one-second watchdog releases a missing end marker, and
 soft/full reset releases it immediately. Repeated begins do not extend the
 deadline. Unmarked output can still produce intermediate snapshots.
 
-At most one revision per view is in flight. The browser acknowledges after WebGPU reports
+At most one revision per view is in flight. The browser acknowledges after the selected GPU backend reports
 submitted work complete. While it is busy, the terminal continues to consume workload output;
 superseded display states coalesce, but workload commands are not discarded.
 Resync and resize establish a complete cell and resource baseline. A resync
@@ -798,8 +814,10 @@ produce frames.
 
 ## Limits and interpretation
 
-- WebGPU only; no software renderer or WebGL fallback. GPU/worker errors are
-  surfaced rather than silently switching rendering implementations.
+- Auto prefers WebGPU and falls back to WebGL2 for capability/device acquisition
+  failures. Explicit backend choices never fall back. Shader, font, unexpected
+  initialization, and runtime GPU/worker errors are surfaced, not hidden by a
+  backend switch. There is no Canvas2D terminal renderer.
 - Fixed 10x20 logical-pixel cells. Device pixel ratio affects browser
   rasterization, not terminal protocol geometry. Local resize/claim requests use
   20..300 columns and 10..100 rows; a native HMP1 primary can establish a larger

--- a/samples/WebTerminalDemo/client/main.ts
+++ b/samples/WebTerminalDemo/client/main.ts
@@ -156,6 +156,8 @@ function metrics(view: Pick<TerminalView, "id" | "stats" | "text"> & { instance:
   window.webTerminalScreenText = view.text || "";
   const number = (value: number | undefined, digits = 1) => Number(value || 0).toFixed(digits);
   byId("metric-fps").textContent = number(stats.fps);
+  byId("metric-renderer").textContent = stats.renderer || "Initializing";
+  byId("metric-renderer").title = stats.rendererFallbackReason || "";
   byId("metric-received").textContent = number(stats.receivedKBps);
   byId("metric-workload").textContent = number(stats.workloadMBps, 2);
   byId("metric-projection").textContent = number(stats.captureMs, 2);
@@ -165,7 +167,10 @@ function metrics(view: Pick<TerminalView, "id" | "stats" | "text"> & { instance:
   byId("metric-atlas").textContent = `${stats.atlasGlyphs || 0} / ${number((stats.atlasBytes ?? 0) / 1048576, 1)}`;
   byId("metric-uploads").textContent = number((stats.imageUploadBytes ?? 0) / 1048576, 2);
   byId("metric-revision").textContent = `${stats.revision || 0} / ${stats.fullFrames || 0}`;
-  byId("warnings").textContent = (stats.warnings || []).join("\n");
+  byId("warnings").textContent = [
+    ...(stats.rendererFallbackReason ? [`WebGL2 fallback: ${stats.rendererFallbackReason}`] : []),
+    ...(stats.warnings || [])
+  ].join("\n");
   byId("screen-mirror").textContent = view.text || "";
   byId("selected-view").textContent = `${view.instance.name} / view ${view.id}`;
 }
@@ -288,7 +293,7 @@ async function openView(instance: TerminalInstance, { primary = false, thumbnail
     </div>
     <div class="terminal-mount"></div>
     <footer class="view-footer">
-      <span class="view-status">Initializing WebGPU...</span>
+      <span class="view-status">Initializing renderer...</span>
       <button class="font-smaller" disabled title="Smaller text; more cells (Auto mode)" aria-label="Decrease terminal font size">-</button>
       <span class="font-size" title="Requested font size in Auto mode; fixed grids scale to fit">Fit</span>
       <button class="font-larger" disabled title="Larger text; fewer cells (Auto mode)" aria-label="Increase terminal font size">+</button>
@@ -342,8 +347,11 @@ async function openView(instance: TerminalInstance, { primary = false, thumbnail
   const url = new URL("/ws", location.href);
   url.search = new URLSearchParams({ instance: instance.id, name: `Web view ${id}` }).toString();
   try {
+    const renderer = select("renderer").value;
+    if (renderer !== "auto" && renderer !== "webgpu" && renderer !== "webgl2") throw new Error("Invalid renderer selection");
     view.terminal = await WebTerminal.mount(elementAt(element, ".terminal-mount", HTMLElement), {
       url, signal: view.controller.signal,
+      renderer,
       scale: select("scale").value === "auto" ? "auto" : Number(select("scale").value),
       font: select("font").value === "monospace" ? { family: "monospace" } : undefined,
       label: `${instance.name}, view ${id}, terminal input`,
@@ -454,11 +462,12 @@ window.addEventListener("pagehide", () => {
 });
 
 try {
-  if (!window.isSecureContext || !("gpu" in navigator) || !navigator.gpu) {
-    button("create").disabled = true;
-    throw new Error("WebTerminal requires a WebGPU-enabled browser over HTTPS or localhost");
-  }
   const parameters = new URLSearchParams(location.search);
+  const renderer = parameters.get("renderer");
+  if (renderer !== null) {
+    if (!["auto", "webgpu", "webgl2"].includes(renderer)) throw new Error("Invalid renderer query parameter");
+    select("renderer").value = renderer;
+  }
   const scene = parameters.get("scene");
   const requestedScene = scene !== null && [...select("scene").options].some(option => option.value === scene);
   if (requestedScene) select("scene").value = scene;

--- a/samples/WebTerminalDemo/tests/fonts.browser.js
+++ b/samples/WebTerminalDemo/tests/fonts.browser.js
@@ -18,7 +18,8 @@ async page => {
       const results = [];
       for (const scale of [1, 1.25, 1.5, 2, 3]) {
         const failures = [];
-        const renderer = await TerminalRenderer.create(canvas, scale, error => failures.push(error.message));
+        const renderer = await TerminalRenderer.create(canvas, scale, error => failures.push(error.message), undefined, "webgpu");
+        const { context, device, format } = renderer.backend;
         try {
           renderer.resize(8, 8);
           const cells = Array.from({ length: 64 }, (_, index) => {
@@ -30,17 +31,17 @@ async page => {
               underlineColor: 0xffffffff, attributes: x >= 4 ? 1 : 0, underlineStyle: 0 };
           });
           renderer.prepareGlyphs(cells);
-          renderer.context.configure({ device: renderer.device, format: renderer.format, alphaMode: "opaque",
+          context.configure({ device, format, alphaMode: "opaque",
             usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC });
           renderer.render(cells, { defaultBackground: 0xff000000,
             cursor: { visible: false }, placements: [] }, true);
           const bytesPerRow = Math.ceil(canvas.width * 4 / 256) * 256;
-          const buffer = renderer.device.createBuffer({ size: bytesPerRow * canvas.height,
+          const buffer = device.createBuffer({ size: bytesPerRow * canvas.height,
             usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ });
-          const encoder = renderer.device.createCommandEncoder();
-          encoder.copyTextureToBuffer({ texture: renderer.context.getCurrentTexture() },
+          const encoder = device.createCommandEncoder();
+          encoder.copyTextureToBuffer({ texture: context.getCurrentTexture() },
             { buffer, bytesPerRow }, [canvas.width, canvas.height]);
-          renderer.device.queue.submit([encoder.finish()]);
+          device.queue.submit([encoder.finish()]);
           await buffer.mapAsync(GPUMapMode.READ);
           const bytes = new Uint8Array(buffer.getMappedRange());
           const ink = (x, y) => bytes[y * bytesPerRow + x * 4] > 64;

--- a/samples/WebTerminalDemo/tests/gpu.browser.js
+++ b/samples/WebTerminalDemo/tests/gpu.browser.js
@@ -9,7 +9,8 @@ async page => {
       const { TerminalRenderer } = await import("/web-terminal/renderer.js");
       const errors = [];
       const canvas = document.querySelector("canvas");
-      const renderer = await TerminalRenderer.create(canvas, 2, error => errors.push(error.message));
+      const renderer = await TerminalRenderer.create(canvas, 2, error => errors.push(error.message), undefined, "webgpu");
+      const { context, device, format } = renderer.backend;
       const check = (condition, message) => { if (!condition) throw new Error(message); };
       try {
         renderer.resize(40, 20, { width: 800, height: 800 });
@@ -18,7 +19,7 @@ async page => {
         await renderer.updateImages([{ key: "native", width: 3, height: 3, format: "rgba", byteLength: bytes.length, bytes }], ["native"]);
         const cells = [{ text: "A", width: 1, foreground: 0xffffffff, background: 0xff000000, underlineColor: 0xffffffff, attributes: 0, underlineStyle: 0 }];
         renderer.prepareGlyphs(cells);
-        renderer.context.configure({ device: renderer.device, format: renderer.format, alphaMode: "opaque",
+        context.configure({ device, format, alphaMode: "opaque",
           usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC });
         const metadata = {
           defaultBackground: 0xff000000,
@@ -29,15 +30,15 @@ async page => {
         };
         renderer.render(cells, metadata, true);
         const bytesPerRow = Math.ceil(canvas.width * 4 / 256) * 256;
-        const readback = renderer.device.createBuffer({ size: bytesPerRow * canvas.height,
+        const readback = device.createBuffer({ size: bytesPerRow * canvas.height,
           usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ });
-        const copy = renderer.device.createCommandEncoder();
-        copy.copyTextureToBuffer({ texture: renderer.context.getCurrentTexture() },
+        const copy = device.createCommandEncoder();
+        copy.copyTextureToBuffer({ texture: context.getCurrentTexture() },
           { buffer: readback, bytesPerRow }, [canvas.width, canvas.height]);
-        renderer.device.queue.submit([copy.finish()]);
+        device.queue.submit([copy.finish()]);
         await readback.mapAsync(GPUMapMode.READ);
         const pixels = new Uint8Array(readback.getMappedRange());
-        const redIndex = renderer.format.startsWith("bgra") ? 2 : 0;
+        const redIndex = format.startsWith("bgra") ? 2 : 0;
         const blueIndex = redIndex === 2 ? 0 : 2;
         const red = [];
         for (let y = 0; y < canvas.height; y++) for (let x = 0; x < canvas.width; x++) {
@@ -59,7 +60,7 @@ async page => {
         check(thumbnail.imageUploadBytes === primary.imageUploadBytes && thumbnail.glyphUploadBytes === primary.glyphUploadBytes, "Viewport change reuploaded graphics or glyphs");
 
         renderer.resize(1000, 200);
-        const large = { columns: renderer.columns, rows: renderer.rows, width: canvas.width, height: canvas.height, limit: renderer.device.limits.maxTextureDimension2D };
+        const large = { columns: renderer.columns, rows: renderer.rows, width: canvas.width, height: canvas.height, limit: renderer.backend.maxCanvasDimension2D };
         check(large.columns === 1000 && large.rows === 200 && large.width <= large.limit && large.height <= large.limit, "Remote grid did not respect framebuffer bounds");
         renderer.resize(40, 20, { width: 0, height: 0 });
         renderer.render(cells, metadata, true);

--- a/samples/WebTerminalDemo/tests/graphics.browser.js
+++ b/samples/WebTerminalDemo/tests/graphics.browser.js
@@ -18,6 +18,7 @@ async page => {
       stage = `${scene}/primary`;
       await test.waitForFunction(() => webTerminalViews.get("1")?.terminal?.peer.isPrimary &&
         webTerminalViews.get("1").stats.frames >= 12 && webTerminalViews.get("1").stats.imageCount > 0, null, { timeout: 30000 });
+      await test.selectOption("#renderer", "webgl2");
       await test.locator('.terminal-window[data-view="1"] .thumbnail').click();
       stage = `${scene}/thumbnail`;
       await test.waitForFunction(() => webTerminalViews.get("2")?.terminal?.connected &&
@@ -28,11 +29,15 @@ async page => {
         before.map(stats => stats.frames));
       const after = await test.evaluate(() => [...webTerminalViews.values()].map(view => view.terminal.stats));
       check(after.every(stats => stats.gpu === "ready" && stats.imageCount > 0 && stats.warnings.length === 0), `${scene}: graphics warnings or disconnection`);
+      check(after[0].renderer === "webgpu" && after[1].renderer === "webgl2" &&
+        after.every(stats => !stats.rendererFallbackReason), "Default WebGPU or forced WebGL2 selection was ignored");
+      check(await test.locator("#metric-renderer").textContent() === "webgl2", "Selected-view renderer diagnostic is incorrect");
       if (scene === "kgp") check(after.every((stats, index) => stats.imageUploadBytes === before[index].imageUploadBytes),
         "KGP movement retransmitted cached image pixels");
       if (scene === "animation") check(after.every((stats, index) => stats.workloadBytes === before[index].workloadBytes),
         "Animation relied on fresh HMP workload traffic");
       results.push({ scene, views: after.map(stats => ({
+        renderer: stats.renderer,
         frames: stats.frames, images: stats.imageCount, textureBytes: stats.textureBytes,
         imageUploadBytes: stats.imageUploadBytes, backingScale: stats.backingScale,
         backingWidth: stats.backingWidth, backingHeight: stats.backingHeight

--- a/samples/WebTerminalDemo/tests/mount.browser.js
+++ b/samples/WebTerminalDemo/tests/mount.browser.js
@@ -29,6 +29,7 @@ async page => {
         constructor() { super(); this.id = String(workers.length + 1); workers.push(this); }
         postMessage(message) {
           if (message.type === "init") {
+            this.renderer = message.renderer;
             if (window.holdWorker) {
               queueMicrotask(() => {
                 this.dispatchEvent(new MessageEvent("message", { data: { type: "connected" } }));
@@ -58,10 +59,12 @@ async page => {
       const { WebTerminal } = await import("/web-terminal/index.js");
       window.WebTerminal = WebTerminal;
       window.a = await WebTerminal.mount(document.getElementById("a"), { url: "/ws" });
-      window.b = await WebTerminal.mount(document.getElementById("b"), { url: "/ws" });
+      window.b = await WebTerminal.mount(document.getElementById("b"), { url: "/ws", renderer: "webgl2" });
       window.c = await WebTerminal.mount(document.getElementById("c"), { url: "/ws", readOnly: true });
     });
     await test.waitForFunction(() => a.geometry.columns === 60 && a.geometry.rows === 20);
+    check(await test.evaluate(() => workers[0].renderer === "auto" && workers[1].renderer === "webgl2"),
+      "Mount did not forward default and explicit renderer preferences to the worker");
     check(await test.evaluate(() => !!document.getElementById("keep")), "Mount replaced caller-owned children");
     check(await test.evaluate(() => b.geometry.columns === 60 && b.geometry.rows === 20), "Secondary missed initial authoritative geometry");
     const firstFit = await test.evaluate(() => {

--- a/samples/WebTerminalDemo/tests/renderers.browser.js
+++ b/samples/WebTerminalDemo/tests/renderers.browser.js
@@ -1,0 +1,287 @@
+async page => {
+  const origin = page.url().match(/^https?:\/\/[^/]+/)?.[0] || "http://localhost:5290";
+  const browser = page.context().browser();
+  const context = await browser.newContext({ viewport: { width: 1000, height: 900 }, deviceScaleFactor: 2 });
+  const test = await context.newPage();
+  const errors = [];
+  test.on("pageerror", error => errors.push(error.message));
+  const check = (condition, message) => { if (!condition) throw new Error(message); };
+  try {
+    await test.goto(`${origin}/health`);
+    const parity = await test.evaluate(async () => {
+      const { TerminalRenderer } = await import("/web-terminal/renderer.js");
+      const check = (condition, message) => { if (!condition) throw new Error(message); };
+      async function pixels(renderer) {
+        const { backend, canvas } = renderer;
+        const result = new Uint8Array(canvas.width * canvas.height * 4);
+        if (backend.kind === "webgl2") {
+          const raw = new Uint8Array(result.length);
+          const gl = backend.gl;
+          gl.readPixels(0, 0, canvas.width, canvas.height, gl.RGBA, gl.UNSIGNED_BYTE, raw);
+          check(gl.getError() === gl.NO_ERROR, "WebGL2 readback failed");
+          for (let y = 0; y < canvas.height; y++) {
+            result.set(raw.subarray((canvas.height - 1 - y) * canvas.width * 4,
+              (canvas.height - y) * canvas.width * 4), y * canvas.width * 4);
+          }
+        } else {
+          const { device, context, format } = backend;
+          const bytesPerRow = Math.ceil(canvas.width * 4 / 256) * 256;
+          const buffer = device.createBuffer({ size: bytesPerRow * canvas.height,
+            usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ });
+          try {
+            const encoder = device.createCommandEncoder();
+            encoder.copyTextureToBuffer({ texture: context.getCurrentTexture() },
+              { buffer, bytesPerRow }, [canvas.width, canvas.height]);
+            device.queue.submit([encoder.finish()]);
+            await buffer.mapAsync(GPUMapMode.READ);
+            const raw = new Uint8Array(buffer.getMappedRange());
+            const red = format.startsWith("bgra") ? 2 : 0;
+            for (let y = 0; y < canvas.height; y++) for (let x = 0; x < canvas.width; x++) {
+              const source = y * bytesPerRow + x * 4, target = (y * canvas.width + x) * 4;
+              result.set([raw[source + red], raw[source + 1], raw[source + 2 - red], 255], target);
+            }
+          } finally { buffer.destroy(); }
+        }
+        await renderer.idle();
+        return result;
+      }
+      const rgba = new Uint8Array([
+        255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255,
+        255, 255, 0, 128, 255, 0, 255, 128, 0, 255, 255, 128,
+        255, 255, 255, 255, 128, 64, 32, 255, 255, 0, 0, 0
+      ]);
+      const pngCanvas = new OffscreenCanvas(3, 3);
+      pngCanvas.getContext("2d").putImageData(new ImageData(new Uint8ClampedArray(rgba), 3, 3), 0, 0);
+      const png = new Uint8Array(await (await pngCanvas.convertToBlob({ type: "image/png" })).arrayBuffer());
+      const images = [
+        { key: "rgba", width: 3, height: 3, format: "rgba", bytes: rgba, byteLength: rgba.length },
+        { key: "png", width: 3, height: 3, format: "png", bytes: png, byteLength: png.length }
+      ];
+      const cells = Array.from({ length: 96 }, (_, index) => ({
+        index, text: ["A", "\u250c", "\u2500", "\u2510", "\ue0b0", "\uf120", "\u2588", "\ud83d\ude00"][index % 8],
+        width: index % 12 === 10 ? 2 : index % 12 === 11 ? 0 : 1,
+        foreground: 0xffb4dcf0, background: index < 12 ? 0xff203040 : 0x80304050,
+        underlineColor: 0xff40e080, attributes: [0, 1, 4, 2, 16, 64, 128, 256][Math.floor(index / 12)],
+        underlineStyle: index % 6
+      }));
+      const placement = (key, x, y, width, height, z) => ({
+        key, kind: "kgp", x, y, width, height, sourceX: 0, sourceY: 0, sourceWidth: 3, sourceHeight: 3,
+        clipX: 0, clipY: 0, clipWidth: 120, clipHeight: 160, z
+      });
+      const metadata = {
+        defaultBackground: 0xff081018, cursor: { visible: true, shape: 2, x: 5, y: 5 },
+        placements: [
+          placement("rgba", 0, 0, 120, 160, -2147483648),
+          { ...placement("png", 40, 40, 35, 35, -1), kind: "sixel" },
+          placement("rgba", 100, 4, 3, 3, 1),
+          placement("png", 75, 100, 33, 33, 2),
+          { ...placement("rgba", 90, 110, 35, 35, 3), sourceX: -1, sourceY: 1,
+            sourceWidth: 5, sourceHeight: 3, clipX: 100, clipY: 105, clipWidth: 17, clipHeight: 30 },
+          placement("png", 12, 60, 15, 20, 4)
+        ]
+      };
+      const reports = [];
+      for (const scale of [1, 1.25, 1.5, 2, 3]) {
+        const rendered = [];
+        const frameEdges = [];
+        for (const kind of ["webgpu", "webgl2"]) {
+          const canvas = document.createElement("canvas");
+          document.body.append(canvas);
+          const failures = [];
+          const renderer = await TerminalRenderer.create(canvas, scale, error => failures.push(error.message), undefined, kind);
+          try {
+            check(renderer.metrics().renderer === kind && !renderer.metrics().rendererFallbackReason, "Forced renderer was ignored");
+            renderer.resize(12, 8);
+            if (kind === "webgpu") {
+              const { device, context, format } = renderer.backend;
+              context.configure({ device, format, alphaMode: "opaque",
+                usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC });
+            }
+            await renderer.updateImages(images, ["rgba", "png"]);
+            renderer.prepareGlyphs(cells);
+            const frames = [];
+            const capture = async () => {
+              if (kind === "webgpu") {
+                const sx = canvas.width / renderer.width, sy = canvas.height / renderer.height;
+                const edges = [];
+                for (let i = 0; i < renderer.quadCount; i++) {
+                  const [x, y, width, height] = renderer.instances.subarray(i * 16, i * 16 + 4);
+                  edges.push([x * sx, (x + width) * sx, y * sy], [x * sx, (x + width) * sx, (y + height) * sy]);
+                }
+                frameEdges.push({ width: canvas.width, edges });
+              }
+              frames.push(await pixels(renderer));
+            };
+            for (const blink of [true, false]) {
+              renderer.render(cells, metadata, blink);
+              await capture();
+            }
+            if (scale === 1 || scale === 2) {
+              const offset = (4 * scale * canvas.width + 100 * scale) * 4;
+              check(frames[0][offset] > 240 && frames[0][offset + 1] < 10 && frames[0][offset + 2] < 10,
+                `${kind} raw image orientation/position changed`);
+            }
+            const initial = renderer.metrics();
+            await renderer.updateImages([], ["rgba", "png"]);
+            renderer.prepareGlyphs(cells);
+            renderer.resize(12, 8, { width: 60, height: 80 });
+            renderer.render(cells, metadata, true);
+            await capture();
+            const thumbnail = renderer.metrics();
+            check(thumbnail.imageUploadBytes === initial.imageUploadBytes &&
+              thumbnail.glyphUploadBytes === initial.glyphUploadBytes, "Resize reuploaded retained resources");
+            renderer.resize(1000, 200);
+            check(canvas.width <= renderer.backend.maxCanvasDimension2D &&
+              canvas.height <= renderer.backend.maxCanvasDimension2D, "Canvas exceeded backend limits");
+            renderer.resize(12, 8, { width: 0, height: 0 });
+            renderer.render(cells, metadata, true);
+            await renderer.idle();
+            check(canvas.width === 1 && canvas.height === 1, "Hidden canvas was not bounded");
+            renderer.resize(12, 8);
+            renderer.render(cells, metadata, true);
+            await capture();
+            await renderer.updateImages([], []);
+            check(renderer.metrics().textureBytes === 0, "Released image textures were retained");
+            check(failures.length === 0, failures.join("; "));
+            rendered.push(frames);
+          } finally { renderer.dispose(); canvas.remove(); }
+        }
+        let maxDifference = 0;
+        let edgeTiePixels = 0;
+        for (let f = 0; f < rendered[0].length; f++) {
+          const a = rendered[0][f], b = rendered[1][f];
+          check(a.length === b.length, "Framebuffer dimensions differ");
+          for (let i = 0; i < a.length; i += 4) {
+            const difference = Math.max(...[0, 1, 2, 3].map(channel => Math.abs(a[i + channel] - b[i + channel])));
+            if (difference <= 2) { maxDifference = Math.max(maxDifference, difference); continue; }
+            const { width, edges } = frameEdges[f];
+            const x = (i / 4) % width + .5, y = Math.floor(i / 4 / width) + .5;
+            // WebGPU and OpenGL include opposite horizontal edges when a quad
+            // ends exactly on a pixel center. Only those rasterization ties may differ.
+            const tie = edges.some(([left, right, edge]) => x >= left && x <= right && Math.abs(y - edge) < .00001);
+            check(tie, `Non-edge pixel differs by ${difference} at scale ${scale}, frame ${f}, (${x}, ${y}): ` +
+              `${[...a.slice(i, i + 4)]} vs ${[...b.slice(i, i + 4)]}`);
+            edgeTiePixels++;
+          }
+        }
+        reports.push({ scale, frames: rendered[0].length, maxNonEdgeChannelDifference: maxDifference, edgeTiePixels });
+      }
+      return reports;
+    });
+
+    // Serve the same first-party assets under an untrustworthy HTTP origin, without
+    // exposing the shell demo or changing the browser's secure-context settings.
+    const httpOrigin = "http://terminal-renderer.test";
+    await context.route(`${httpOrigin}/**`, async route => {
+      const path = route.request().url().slice(httpOrigin.length);
+      const response = await route.fetch({ url: `${origin}${path}` });
+      await route.fulfill({ response });
+    });
+    let workerSource;
+    {
+      const metadata = {
+        version: 1, revision: 1, baseRevision: 0, full: true,
+        columns: 20, rows: 10, cellWidth: 10, cellHeight: 20, mouseTracking: 0,
+        peer: { id: null, primaryId: null, isPrimary: true },
+        cursor: { x: 0, y: 0, visible: false, shape: 0 }, history: null,
+        images: [], retainedImages: [], placements: [], warnings: [],
+        stats: { workloadBytes: 0, outputBatches: 0, captureMs: 0, elapsedMs: 0 }
+      };
+      const json = Uint8Array.from(JSON.stringify(metadata), character => character.charCodeAt(0));
+      const cellCount = metadata.columns * metadata.rows;
+      const bytes = new Uint8Array(8 + json.length + 4 + cellCount * 23);
+      const view = new DataView(bytes.buffer);
+      view.setUint32(0, 0x31545748, true);
+      view.setUint32(4, json.length, true);
+      bytes.set(json, 8);
+      const offset = 8 + json.length;
+      view.setUint32(offset, cellCount, true);
+      for (let i = 0; i < cellCount; i++) {
+        const cell = offset + 4 + i * 23;
+        view.setUint32(cell, i, true);
+        view.setUint32(cell + 4, 0xffffffff, true);
+        view.setUint32(cell + 8, 0xff000000, true);
+        view.setUint8(cell + 18, 1);
+        view.setUint16(cell + 20, 1, true);
+        bytes[cell + 22] = i === 0 ? 65 : 32;
+      }
+      // Playwright WebSocket routing does not reliably intercept dedicated-worker
+      // sockets. Mock only that transport; run the actual HWT1 worker and GPU code.
+      workerSource = `
+          const pending = [];
+          const capture = event => pending.push(event.data);
+          self.addEventListener("message", capture);
+          self.WebSocket = class extends EventTarget {
+            static OPEN = 1;
+            readyState = 0;
+            constructor() {
+              super();
+              queueMicrotask(() => {
+                this.readyState = 1;
+                this.dispatchEvent(new Event("open"));
+                this.dispatchEvent(new MessageEvent("message", {
+                  data: new Uint8Array(${JSON.stringify([...bytes])}).buffer
+                }));
+              });
+            }
+            send(message) {
+              if (JSON.parse(message).type === "ack") self.postMessage({
+                type: "status", message: "Fixture frame acknowledged", level: "info"
+              });
+            }
+            close() { this.readyState = 3; }
+          };
+          await import("${httpOrigin}/web-terminal/terminal-worker.js");
+          self.removeEventListener("message", capture);
+          for (const data of pending) self.dispatchEvent(new MessageEvent("message", { data }));
+        `;
+    }
+    await test.goto(`${httpOrigin}/health`);
+    const http = await test.evaluate(async workerSource => {
+      if (isSecureContext || navigator.gpu) throw new Error("HTTP fixture unexpectedly has WebGPU privileges");
+      const { WebTerminal } = await import("/web-terminal/index.js");
+      const results = [];
+      const workerUrl = URL.createObjectURL(new Blob([workerSource], { type: "text/javascript" }));
+      try {
+        for (const preference of ["auto", "webgl2", "webgpu"]) {
+          const host = document.createElement("div");
+          host.style.cssText = "width:200px;height:200px";
+          document.body.append(host);
+          try {
+            if (preference === "webgpu") {
+              let message;
+              try { await WebTerminal.mount(host, { url: "/ws", renderer: preference }); }
+              catch (error) { message = error.message; }
+              if (!message?.includes("HTTPS") || host.children.length) throw new Error("Forced WebGPU did not fail cleanly on HTTP");
+              results.push({ preference, error: message });
+            } else {
+              const status = [];
+              let terminal;
+              try {
+                terminal = await WebTerminal.mount(host, {
+                  url: "/ws", workerUrl, renderer: preference,
+                  onStatus: message => status.push(message)
+                });
+              } catch (error) {
+                throw new Error(`${preference}: ${error.message}; status: ${status.join("; ")}`);
+              }
+              try {
+                const stats = terminal.stats;
+                if (stats.renderer !== "webgl2" || terminal.screenText.trim() !== "A") {
+                  throw new Error(`HTTP worker did not present WebGL2 content: ${JSON.stringify(stats)}`);
+                }
+                if (!!stats.rendererFallbackReason !== (preference === "auto")) throw new Error("Incorrect fallback diagnostics");
+                if (!status.includes("Fixture frame acknowledged")) throw new Error("Worker did not acknowledge its rendered frame");
+                results.push({ preference, renderer: stats.renderer, fallback: stats.rendererFallbackReason, frames: stats.frames });
+              } finally { terminal.dispose(); }
+              if (host.children.length) throw new Error("Disposed mount leaked its wrapper");
+            }
+          } finally { host.remove(); }
+        }
+        return results;
+      } finally { URL.revokeObjectURL(workerUrl); }
+    }, workerSource);
+    check(errors.length === 0, errors.join("; "));
+    return { passed: true, parity, http };
+  } finally { await context.close(); }
+}

--- a/samples/WebTerminalDemo/wwwroot/index.html
+++ b/samples/WebTerminalDemo/wwwroot/index.html
@@ -124,7 +124,7 @@
   <main>
     <header>
       <h1>WebTerminalDemo</h1>
-      <p>HMP1 shared terminals · HWT1 WebGPU views · primary-owned geometry</p>
+      <p>HMP1 shared terminals · HWT1 GPU-rendered views · primary-owned geometry</p>
     </header>
     <section class="panel controls" aria-label="Terminal controls">
       <label>Scene
@@ -152,6 +152,13 @@
           <option value="monospace">System monospace</option>
         </select>
       </label>
+      <label>New view renderer
+        <select id="renderer">
+          <option value="auto">Auto (prefer WebGPU)</option>
+          <option value="webgpu">WebGPU</option>
+          <option value="webgl2">WebGL2</option>
+        </select>
+      </label>
       <button id="create" class="primary">New terminal</button>
       <div class="instance-controls">
         <label>Existing terminal <select id="instances"></select></label>
@@ -168,6 +175,7 @@
     <details class="panel">
       <summary>Selected view: <span id="selected-view">none</span> — metrics and text mirror</summary>
       <dl class="metrics">
+        <div><dt>Renderer</dt><dd id="metric-renderer">Initializing</dd></div>
         <div><dt>Presented frames / s</dt><dd id="metric-fps">0</dd></div>
         <div><dt>Received KB / s</dt><dd id="metric-received">0</dd></div>
         <div><dt>Mirror workload MB / s</dt><dd id="metric-workload">0</dd></div>

--- a/src/web-terminal/README.md
+++ b/src/web-terminal/README.md
@@ -1,6 +1,6 @@
 # @hex1b/web-terminal
 
-The first-party WebGPU browser terminal for Hex1b. It renders server-authoritative
+The first-party GPU-rendered browser terminal for Hex1b. It renders server-authoritative
 cells and graphics in a module worker, with local input routing, producer-backed
 history and selection, clipboard actions, and primary/secondary view sizing.
 There are no runtime package dependencies.
@@ -53,10 +53,42 @@ connection, not the container or server-side shared terminal.
 
 ### Browser and deployment requirements
 
-Use HTTPS or localhost and a browser with WebGPU, module workers, transferable
-OffscreenCanvas, worker animation frames, ResizeObserver, and CSS Font Loading.
-Clipboard access also requires browser permission and, for relevant actions, a
-user gesture. There is no Canvas2D terminal-rendering fallback.
+Use a browser with WebGPU or WebGL2, module workers, transferable OffscreenCanvas,
+worker animation frames, ResizeObserver, and CSS Font Loading. WebGPU requires
+HTTPS or localhost; WebGL2 rendering also works on ordinary HTTP origins.
+Clipboard API access still requires a secure context, browser permission and,
+for relevant actions, a user gesture. There is no Canvas2D terminal-rendering fallback.
+Renderer selection does not change transport security: use HTTPS/WSS to protect
+terminal input and output.
+
+### Renderer selection
+
+Set the mount-time `renderer` option to `"auto"` (the default), `"webgpu"`, or
+`"webgl2"`. Auto prefers WebGPU and uses WebGL2 if the secure context, API,
+adapter, device acquisition, or presentation context is unavailable. Explicit
+modes require that backend and report an error rather than falling back.
+Shader, font, validation, and unexpected initialization errors are not
+compatibility fallbacks. Runtime GPU/context loss terminates the view with an
+error; it does not switch backends behind the caller's back.
+
+```ts
+const terminal = await WebTerminal.mount(container, {
+  url: "/ws/terminal",
+  renderer: "webgl2", // Use WebGL2 even if WebGPU is available.
+  onStats(stats) {
+    console.log(stats.renderer, stats.rendererFallbackReason);
+  }
+});
+```
+
+`stats.renderer` identifies the active backend after initialization.
+`stats.rendererFallbackReason` explains an automatic fallback and is absent
+for explicit selections and successful WebGPU initialization. Both backends
+share glyph rasterization, frame preparation, clipping, and image ordering.
+WebGPU preference is not a performance guarantee; compare representative
+workloads on your target browsers and devices.
+
+### Module and worker deployment
 
 The package contains browser ES modules, not a single bundle. For bare static
 hosting, copy **all of `dist/`**, preserving its directory structure, and import
@@ -100,6 +132,7 @@ workers, fonts, and the intended WebSocket endpoint.
 | --- | --- |
 | `workerUrl` | Optional module-worker entry; useful when worker assets are deployed separately. |
 | `scale` | GPU backing scale `0.5`–`3`, or `"auto"` (default, bounded device pixel ratio). |
+| `renderer` | `"auto"` (prefer WebGPU), `"webgpu"`, or `"webgl2"`; selected once per mount. |
 | `font` | One family and optional downloadable font faces; see below. |
 | `sizing` | `{ mode: "auto", fontSize?: number }` or `{ mode: "fixed", columns, rows, fontSize?: number }`. |
 | `readOnly` | Disable application input while retaining history inspection and selection. |

--- a/src/web-terminal/package.json
+++ b/src/web-terminal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hex1b/web-terminal",
   "version": "0.1.0",
-  "description": "First-party WebGPU browser terminal for Hex1b",
+  "description": "First-party WebGPU and WebGL2 browser terminal for Hex1b",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/web-terminal/src/backend-selection.ts
+++ b/src/web-terminal/src/backend-selection.ts
@@ -1,0 +1,24 @@
+import { RendererUnavailableError } from "./render-backend.js";
+import type { RenderBackend } from "./render-backend.js";
+import { normalizeRenderer } from "./renderer-options.js";
+import { WebGpuBackend } from "./webgpu-backend.js";
+import { WebGl2Backend } from "./webgl2-backend.js";
+import type { TerminalRendererPreference } from "./types.js";
+
+export async function createRenderBackend(canvas: OffscreenCanvas, onFatal: (error: Error) => void,
+  preference: TerminalRendererPreference = "auto"): Promise<{ backend: RenderBackend; fallbackReason?: string }> {
+  const requested = normalizeRenderer(preference);
+  if (requested === "webgl2") return { backend: await WebGl2Backend.create(canvas, onFatal) };
+  try {
+    return { backend: await WebGpuBackend.create(canvas, onFatal) };
+  } catch (error) {
+    if (requested !== "auto" || !(error instanceof RendererUnavailableError)) throw error;
+    try {
+      return { backend: await WebGl2Backend.create(canvas, onFatal), fallbackReason: error.message };
+    } catch (fallbackError) {
+      throw new AggregateError([error, fallbackError],
+        `WebGPU unavailable (${error.message}); WebGL2 initialization failed: ${
+          fallbackError instanceof Error ? fallbackError.message : String(fallbackError)}`);
+    }
+  }
+}

--- a/src/web-terminal/src/render-backend.ts
+++ b/src/web-terminal/src/render-backend.ts
@@ -1,4 +1,5 @@
 export const QUAD_STRIDE = 16;
+
 export type RenderColor = [number, number, number, number];
 export type RenderPixels = Uint8Array<ArrayBuffer> | Uint8ClampedArray<ArrayBuffer>;
 

--- a/src/web-terminal/src/render-backend.ts
+++ b/src/web-terminal/src/render-backend.ts
@@ -1,0 +1,30 @@
+export const QUAD_STRIDE = 16;
+export type RenderColor = [number, number, number, number];
+export type RenderPixels = Uint8Array<ArrayBuffer> | Uint8ClampedArray<ArrayBuffer>;
+
+export interface RenderTexture {
+  readonly width: number;
+  readonly height: number;
+  writePixels(pixels: RenderPixels, width: number, height: number, x?: number, y?: number): void;
+  writeBitmap(bitmap: ImageBitmap): void;
+  destroy(): void;
+}
+
+export interface RenderBatch { resource: RenderTexture; start: number; count: number }
+
+/** Internal graphics boundary; layout, rasterization and ordering belong to TerminalRenderer. */
+export interface RenderBackend {
+  readonly kind: "webgpu" | "webgl2";
+  readonly maxTextureDimension2D: number;
+  readonly maxCanvasDimension2D: number;
+  readonly instanceBufferBytes: number;
+  createTexture(width: number, height: number, label: string): RenderTexture;
+  resize(width: number, height: number): void;
+  submit(instances: Float32Array<ArrayBuffer>, quadCount: number, batches: readonly RenderBatch[],
+    background: RenderColor): void;
+  idle(): Promise<void>;
+  dispose(): void;
+}
+
+/** Only capability/device acquisition failures may trigger automatic backend fallback. */
+export class RendererUnavailableError extends Error {}

--- a/src/web-terminal/src/renderer-options.ts
+++ b/src/web-terminal/src/renderer-options.ts
@@ -1,0 +1,6 @@
+import type { TerminalRendererPreference } from "./types.js";
+
+export function normalizeRenderer(value: unknown = "auto"): TerminalRendererPreference {
+  if (value === "auto" || value === "webgpu" || value === "webgl2") return value;
+  throw new TypeError('renderer must be "auto", "webgpu", or "webgl2"');
+}

--- a/src/web-terminal/src/renderer.ts
+++ b/src/web-terminal/src/renderer.ts
@@ -1,65 +1,26 @@
 import { LIMITS } from "./protocol.js";
 import { loadFont, measureFont, normalizeFont } from "./terminal-font.js";
+import { createRenderBackend } from "./backend-selection.js";
+import { QUAD_STRIDE } from "./render-backend.js";
+import type { RenderBackend, RenderBatch, RenderColor, RenderTexture } from "./render-backend.js";
 import type { FontMetrics, LoadedFont, NormalizedFont } from "./terminal-font.js";
-import type { TerminalFont, TerminalSize } from "./types.js";
+import type { TerminalFont, TerminalRendererPreference, TerminalSize } from "./types.js";
 import type { FrameImage, FrameMetadata, ImagePlacement, TerminalCell } from "./wire-types.js";
 
-type Vector4 = [number, number, number, number];
-interface TextureResource { texture: GPUTexture; bindGroup: GPUBindGroup; width: number; height: number }
+type Vector4 = RenderColor;
+type TextureResource = RenderTexture;
 interface Shelf { x: number; y: number; rowHeight: number }
 interface GlyphPlacement { key: string; cell: TerminalCell; x: number; y: number; width: number; height: number }
 interface Glyph { colored: boolean; u0: number; v0: number; u1: number; v1: number }
-interface Batch { resource: TextureResource; start: number; count: number }
+type Batch = RenderBatch;
 
 const CELL_WIDTH = 10;
 const CELL_HEIGHT = 20;
 const MAX_QUADS = 1024 * 1024;
 const MAX_GLYPHS = 16384;
 const MAX_GLYPH_KEY_UNITS = 1024 * 1024;
-const STRIDE = 16;
+const STRIDE = QUAD_STRIDE;
 const WHITE: Vector4 = [1, 1, 1, 1];
-
-const shader = /* wgsl */ `
-struct Viewport { size: vec2f, padding: vec2f }
-@group(0) @binding(0) var<uniform> viewport: Viewport;
-@group(0) @binding(1) var image: texture_2d<f32>;
-@group(0) @binding(2) var imageSampler: sampler;
-
-struct VertexOut {
-  @builtin(position) position: vec4f,
-  @location(0) uv: vec2f,
-  @location(1) color: vec4f,
-  @location(2) @interpolate(flat) mode: f32,
-}
-
-@vertex fn vertex(
-  @builtin(vertex_index) index: u32,
-  @location(0) rect: vec4f,
-  @location(1) uvRect: vec4f,
-  @location(2) color: vec4f,
-  @location(3) mode: f32,
-) -> VertexOut {
-  let corners = array<vec2f, 6>(
-    vec2f(0, 0), vec2f(1, 0), vec2f(0, 1),
-    vec2f(0, 1), vec2f(1, 0), vec2f(1, 1)
-  );
-  let corner = corners[index];
-  let position = rect.xy + corner * rect.zw;
-  var out: VertexOut;
-  out.position = vec4f(position / viewport.size * vec2f(2, -2) + vec2f(-1, 1), 0, 1);
-  out.uv = mix(uvRect.xy, uvRect.zw, corner);
-  out.color = color;
-  out.mode = mode;
-  return out;
-}
-
-@fragment fn fragment(in: VertexOut) -> @location(0) vec4f {
-  // Explicit LOD avoids derivative-uniformity requirements across solid/mask/image batches.
-  let texel = textureSampleLevel(image, imageSampler, in.uv, 0);
-  if (in.mode < 0.5) { return in.color; }
-  if (in.mode < 1.5) { return vec4f(in.color.rgb, in.color.a * texel.a); }
-  return texel * in.color;
-}`;
 
 function rgba(packed: number): Vector4 {
   return [
@@ -92,15 +53,15 @@ function packGlyphs(glyphs: ReadonlyMap<string, TerminalCell>, size: number, sca
   return { placements, shelf: { x, y, rowHeight } };
 }
 
-/** WebGPU instanced quads; Canvas2D is used only to rasterize reusable glyphs. */
+/** Shared instanced-quad preparation; Canvas2D rasterizes reusable glyphs for either backend. */
 export class TerminalRenderer {
   canvas: OffscreenCanvas;
   scale: number;
   backingScale: number;
-  device: GPUDevice;
+  backend: RenderBackend;
+  fallbackReason?: string;
   fontConfiguration: NormalizedFont;
   fontMetrics: Map<number, FontMetrics>;
-  context: GPUCanvasContext;
   images: Map<string, TextureResource>;
   glyphs: Map<string, Glyph>;
   imageUploadBytes: number;
@@ -109,17 +70,11 @@ export class TerminalRenderer {
   atlasRebuilds: number;
   textureBytes: number;
   instances: Float32Array<ArrayBuffer>;
-  instanceBuffer: GPUBuffer | null;
-  instanceBufferBytes: number;
   disposed: boolean;
   columns: number;
   rows: number;
   // Initialized by create() before the renderer can prepare or submit frames.
   font!: LoadedFont;
-  format!: GPUTextureFormat;
-  uniform!: GPUBuffer;
-  sampler!: GPUSampler;
-  pipeline!: GPURenderPipeline;
   rasterCanvas!: OffscreenCanvas;
   raster!: OffscreenCanvasRenderingContext2D;
   atlas!: TextureResource;
@@ -131,19 +86,13 @@ export class TerminalRenderer {
   quadCount = 0;
   batches: Batch[] = [];
 
-  static async create(canvas: OffscreenCanvas, scale: number, onFatal: (error: Error | GPUError) => void,
-    font: TerminalFont): Promise<TerminalRenderer> {
+  static async create(canvas: OffscreenCanvas, scale: number, onFatal: (error: Error) => void,
+    font?: TerminalFont, preference: TerminalRendererPreference = "auto"): Promise<TerminalRenderer> {
     const normalizedFont = normalizeFont(font);
-    if (!self.isSecureContext) throw new Error("WebGPU requires HTTPS or localhost");
-    if (!navigator.gpu) throw new Error("WebGPU is unavailable in this browser worker");
-    const adapter = await navigator.gpu.requestAdapter();
-    if (!adapter) throw new Error("No WebGPU adapter is available; check browser GPU support");
-    const device = await adapter.requestDevice();
-    const renderer = new TerminalRenderer(canvas, scale, device, normalizedFont);
-    device.lost.then(info => {
-      if (!renderer.disposed) onFatal(new Error(`WebGPU device lost: ${info.message || info.reason}`));
-    });
-    device.addEventListener("uncapturederror", event => onFatal(event.error));
+    if (!Number.isFinite(scale) || scale < 0.5 || scale > 3) throw new Error("Invalid backing scale");
+    const { backend, fallbackReason } = await createRenderBackend(canvas, onFatal, preference);
+    const renderer = new TerminalRenderer(canvas, scale, backend, normalizedFont);
+    renderer.fallbackReason = fallbackReason;
     try {
       await renderer.initialize();
       return renderer;
@@ -153,17 +102,14 @@ export class TerminalRenderer {
     }
   }
 
-  constructor(canvas: OffscreenCanvas, scale: number, device: GPUDevice, font: NormalizedFont) {
+  constructor(canvas: OffscreenCanvas, scale: number, backend: RenderBackend, font: NormalizedFont) {
     if (!Number.isFinite(scale) || scale < 0.5 || scale > 3) throw new Error("Invalid backing scale");
     this.canvas = canvas;
     this.scale = scale;
     this.backingScale = scale;
-    this.device = device;
+    this.backend = backend;
     this.fontConfiguration = font;
     this.fontMetrics = new Map();
-    const context = canvas.getContext("webgpu");
-    if (!context) throw new Error("Could not create an OffscreenCanvas WebGPU context");
-    this.context = context;
     this.images = new Map();
     this.glyphs = new Map();
     this.imageUploadBytes = 0;
@@ -172,8 +118,6 @@ export class TerminalRenderer {
     this.atlasRebuilds = 0;
     this.textureBytes = 0;
     this.instances = new Float32Array(4096 * STRIDE);
-    this.instanceBuffer = null;
-    this.instanceBufferBytes = 0;
     this.disposed = false;
     this.columns = 0;
     this.rows = 0;
@@ -181,71 +125,19 @@ export class TerminalRenderer {
 
   async initialize() {
     this.font = await loadFont(this.fontConfiguration);
-    const device = this.device;
-    this.format = navigator.gpu.getPreferredCanvasFormat();
-    this.context.configure({ device, format: this.format, alphaMode: "opaque" });
-    this.uniform = device.createBuffer({ size: 16, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
-    this.sampler = device.createSampler({ minFilter: "linear", magFilter: "linear" });
-    const module = device.createShaderModule({ code: shader });
-    this.pipeline = await device.createRenderPipelineAsync({
-      layout: "auto",
-      vertex: {
-        module,
-        entryPoint: "vertex",
-        buffers: [{
-          arrayStride: STRIDE * 4,
-          stepMode: "instance",
-          attributes: [
-            { shaderLocation: 0, offset: 0, format: "float32x4" },
-            { shaderLocation: 1, offset: 16, format: "float32x4" },
-            { shaderLocation: 2, offset: 32, format: "float32x4" },
-            { shaderLocation: 3, offset: 48, format: "float32" },
-          ],
-        }],
-      },
-      fragment: {
-        module,
-        entryPoint: "fragment",
-        targets: [{
-          format: this.format,
-          blend: {
-            color: { srcFactor: "src-alpha", dstFactor: "one-minus-src-alpha" },
-            alpha: { srcFactor: "one", dstFactor: "one-minus-src-alpha" },
-          },
-        }],
-      },
-      primitive: { topology: "triangle-list" },
-    });
     this.rasterCanvas = new OffscreenCanvas(1, 1);
     const raster = this.rasterCanvas.getContext("2d", { willReadFrequently: true });
     if (!raster) throw new Error("Worker glyph rasterization is unavailable");
     this.raster = raster;
-    this.resetAtlas(Math.min(2048, device.limits.maxTextureDimension2D));
+    this.resetAtlas(Math.min(2048, this.backend.maxTextureDimension2D));
   }
 
   createTexture(width: number, height: number, label: string): TextureResource {
-    if (width > this.device.limits.maxTextureDimension2D || height > this.device.limits.maxTextureDimension2D) {
-      throw new Error(`${label} exceeds the GPU texture dimension limit`);
-    }
-    const texture = this.device.createTexture({
-      label,
-      size: [width, height],
-      format: "rgba8unorm",
-      usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
-    });
-    const bindGroup = this.device.createBindGroup({
-      layout: this.pipeline.getBindGroupLayout(0),
-      entries: [
-        { binding: 0, resource: { buffer: this.uniform } },
-        { binding: 1, resource: texture.createView() },
-        { binding: 2, resource: this.sampler },
-      ],
-    });
-    return { texture, bindGroup, width, height };
+    return this.backend.createTexture(width, height, label);
   }
 
   resetAtlas(size: number): void {
-    this.atlas?.texture.destroy();
+    this.atlas?.destroy();
     this.atlas = this.createTexture(size, size, "Glyph atlas");
     this.glyphs.clear();
     this.glyphKeyUnits = 0;
@@ -255,7 +147,7 @@ export class TerminalRenderer {
   resize(columns: number, rows: number, viewport?: TerminalSize): void {
     const width = columns * CELL_WIDTH;
     const height = rows * CELL_HEIGHT;
-    const limit = this.device.limits.maxTextureDimension2D;
+    const limit = this.backend.maxCanvasDimension2D;
     const requested = Math.min(this.scale, viewport ? viewport.width / width : Infinity, viewport ? viewport.height / height : Infinity);
     this.canvasLimited = width * requested > limit || height * requested > limit;
     this.backingScale = Math.min(requested, limit / width, limit / height);
@@ -268,7 +160,7 @@ export class TerminalRenderer {
     this.height = height;
     this.canvas.width = backingWidth;
     this.canvas.height = backingHeight;
-    this.device.queue.writeBuffer(this.uniform, 0, new Float32Array([width, height, 0, 0]));
+    this.backend.resize(width, height);
   }
 
   /** Call only between submissions. Missing/over-budget resources terminate the session. */
@@ -284,7 +176,7 @@ export class TerminalRenderer {
     if (projectedBytes > LIMITS.textureBytes) throw new Error("Retained images exceed the 256 MiB texture budget");
     for (const [key, image] of this.images) {
       if (!retained.has(key) || replacements.has(key)) {
-        image.texture.destroy();
+        image.destroy();
         this.textureBytes -= image.width * image.height * 4;
         this.images.delete(key);
       }
@@ -293,12 +185,7 @@ export class TerminalRenderer {
       const resource = this.createTexture(image.width, image.height, `Image ${image.key}`);
       try {
         if (image.format === "rgba") {
-          this.device.queue.writeTexture(
-            { texture: resource.texture },
-            image.bytes,
-            { bytesPerRow: image.width * 4, rowsPerImage: image.height },
-            [image.width, image.height],
-          );
+          resource.writePixels(image.bytes, image.width, image.height);
         } else {
           // Check IHDR before decoding so a tiny PNG cannot claim unbounded decoded dimensions.
           const png = new DataView(image.bytes.buffer, image.bytes.byteOffset, image.bytes.byteLength);
@@ -313,11 +200,7 @@ export class TerminalRenderer {
           });
           try {
             if (bitmap.width !== image.width || bitmap.height !== image.height) throw new Error("Decoded PNG dimension mismatch");
-            this.device.queue.copyExternalImageToTexture(
-              { source: bitmap },
-              { texture: resource.texture, premultipliedAlpha: false },
-              [image.width, image.height],
-            );
+            resource.writeBitmap(bitmap);
           } finally {
             bitmap.close();
           }
@@ -327,7 +210,7 @@ export class TerminalRenderer {
         this.imageUploadBytes += image.width * image.height * 4;
         this.imagePayloadBytes += image.byteLength;
       } catch (error) {
-        resource.texture.destroy();
+        resource.destroy();
         throw error;
       }
     }
@@ -350,7 +233,7 @@ export class TerminalRenderer {
     let plan = metadataFits ? packGlyphs(missing, this.atlas.width, this.scale, this.shelf) : null;
     if (!plan) {
       let size = this.atlas.width;
-      const maxSize = Math.min(4096, this.device.limits.maxTextureDimension2D);
+      const maxSize = Math.min(4096, this.backend.maxTextureDimension2D);
       while (!(plan = packGlyphs(visible, size, this.scale)) && size < maxSize) {
         size = Math.min(size * 2, maxSize);
       }
@@ -389,12 +272,7 @@ export class TerminalRenderer {
         break;
       }
     }
-    this.device.queue.writeTexture(
-      { texture: this.atlas.texture, origin: [x, y] },
-      pixels.data,
-      { bytesPerRow: width * 4, rowsPerImage: height },
-      [width, height],
-    );
+    this.atlas.writePixels(pixels.data, width, height, x, y);
     this.glyphUploadBytes += width * height * 4;
     this.glyphs.set(key, {
       colored,
@@ -531,39 +409,15 @@ export class TerminalRenderer {
         this.solid(x, y, CELL_WIDTH, CELL_HEIGHT, color);
       }
     }
-    const usedBytes = this.quadCount * STRIDE * 4;
-    if (!this.instanceBuffer || usedBytes > this.instanceBufferBytes) {
-      this.instanceBuffer?.destroy();
-      this.instanceBufferBytes = Math.max(256, this.instances.byteLength);
-      this.instanceBuffer = this.device.createBuffer({
-        size: this.instanceBufferBytes,
-        usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
-      });
-    }
-    if (usedBytes) this.device.queue.writeBuffer(this.instanceBuffer, 0, this.instances, 0, this.quadCount * STRIDE);
-    const encoder = this.device.createCommandEncoder();
     const base = rgba(metadata.defaultBackground ?? cells[0]?.background ?? 0xff000000);
-    const pass = encoder.beginRenderPass({
-      colorAttachments: [{
-        view: this.context.getCurrentTexture().createView(),
-        clearValue: { r: base[0], g: base[1], b: base[2], a: 1 },
-        loadOp: "clear",
-        storeOp: "store",
-      }],
-    });
-    pass.setPipeline(this.pipeline);
-    pass.setVertexBuffer(0, this.instanceBuffer);
-    for (const batch of this.batches) {
-      pass.setBindGroup(0, batch.resource.bindGroup);
-      pass.draw(6, batch.count, 0, batch.start);
-    }
-    pass.end();
-    this.device.queue.submit([encoder.finish()]);
+    this.backend.submit(this.instances, this.quadCount, this.batches, base);
     return { cpuMs: performance.now() - start, quads: this.quadCount, drawCalls: this.batches.length };
   }
 
   metrics() {
     return {
+      renderer: this.backend.kind,
+      rendererFallbackReason: this.fallbackReason,
       fontFamily: this.font.family,
       rasterScale: this.scale,
       backingScale: this.backingScale,
@@ -577,24 +431,22 @@ export class TerminalRenderer {
       imageUploadBytes: this.imageUploadBytes,
       imagePayloadBytes: this.imagePayloadBytes,
       glyphUploadBytes: this.glyphUploadBytes,
-      instanceBufferBytes: this.instanceBufferBytes,
+      instanceBufferBytes: this.backend.instanceBufferBytes,
     };
   }
 
   async idle() {
-    await this.device.queue.onSubmittedWorkDone();
+    await this.backend.idle();
   }
 
   dispose() {
+    if (this.disposed) return;
     this.disposed = true;
-    for (const image of this.images.values()) image.texture.destroy();
+    for (const image of this.images.values()) image.destroy();
     this.images.clear();
-    this.atlas?.texture.destroy();
-    this.instanceBuffer?.destroy();
-    this.uniform?.destroy();
+    this.atlas?.destroy();
     this.font?.dispose();
     this.fontMetrics.clear();
-    this.context.unconfigure();
-    this.device.destroy();
+    this.backend.dispose();
   }
 }

--- a/src/web-terminal/src/terminal-worker.ts
+++ b/src/web-terminal/src/terminal-worker.ts
@@ -198,8 +198,8 @@ async function initialize(message: Extract<WorkerInputMessage, { type: "init" }>
   if (typeof self.requestAnimationFrame !== "function") {
     throw new Error("This browser does not support requestAnimationFrame in a dedicated OffscreenCanvas worker");
   }
-  postStatus("Loading terminal font and initializing WebGPU...");
-  renderer = await TerminalRenderer.create(message.canvas, message.scale, fail, message.font);
+  postStatus("Loading terminal font and initializing renderer...");
+  renderer = await TerminalRenderer.create(message.canvas, message.scale, fail, message.font, message.renderer);
   if (failed || stopped) {
     renderer?.dispose();
     return;
@@ -207,7 +207,9 @@ async function initialize(message: Extract<WorkerInputMessage, { type: "init" }>
   stats.gpu = "ready";
   stats.backingScale = message.scale;
   emitStats();
-  postStatus("WebGPU ready. Attaching terminal view...");
+  const rendererName = renderer.backend.kind === "webgpu" ? "WebGPU" : "WebGL2";
+  if (renderer.fallbackReason) postStatus(`Using WebGL2: ${renderer.fallbackReason}`);
+  postStatus(`${rendererName} ready. Attaching terminal view...`);
   const url = new URL(message.url);
   if (!["ws:", "wss:"].includes(url.protocol)) {
     throw new Error("The terminal WebSocket URL must use ws: or wss:");
@@ -218,7 +220,7 @@ async function initialize(message: Extract<WorkerInputMessage, { type: "init" }>
     if (failed || stopped) return;
     stats.connected = true;
     self.postMessage({ type: "connected" });
-    postStatus("Connected · WebGPU worker · server-authoritative cells and graphics", "ready");
+    postStatus(`Connected · ${rendererName} worker · server-authoritative cells and graphics`, "ready");
     emitStats();
   });
   socket.addEventListener("message", event => {

--- a/src/web-terminal/src/types.ts
+++ b/src/web-terminal/src/types.ts
@@ -48,8 +48,15 @@ export type TerminalSelection = (
   copyError: string;
 };
 export type TerminalStatusLevel = "info" | "ready" | "error";
+export type TerminalRendererKind = "webgpu" | "webgl2";
+/** Auto prefers WebGPU and falls back to WebGL2 for capability/device acquisition failures. */
+export type TerminalRendererPreference = "auto" | TerminalRendererKind;
 /** Metrics are initially empty; individual fields appear as initialization and presentation proceed. */
 export interface TerminalStats {
+  /** Active backend; absent until renderer initialization completes. */
+  renderer?: TerminalRendererKind;
+  /** Why auto selected WebGL2 instead of WebGPU; absent for explicit selection or WebGPU. */
+  rendererFallbackReason?: string;
   revision?: number; fullFrames?: number; frames?: number; presentations?: number;
   changedCells?: number; lastChangedCells?: number; discardedFrames?: number;
   imageCount?: number; textureBytes?: number; atlasGlyphs?: number; atlasBytes?: number;
@@ -141,6 +148,8 @@ export interface WebTerminalOptions extends InputPolicyOptions {
   workerUrl?: string | URL;
   signal?: AbortSignal;
   scale?: number | "auto";
+  /** Mount-time backend selection. Defaults to auto; explicit modes never fall back. */
+  renderer?: TerminalRendererPreference;
   font?: TerminalFont;
   sizing?: TerminalSizing;
   label?: string;

--- a/src/web-terminal/src/web-terminal.ts
+++ b/src/web-terminal/src/web-terminal.ts
@@ -1,5 +1,6 @@
 import { captureMouse } from "./mouse-input.js";
 import { normalizeFont } from "./terminal-font.js";
+import { normalizeRenderer } from "./renderer-options.js";
 import { dimensions, normalizeSizing, requestedGrid, fittedScale } from "./terminal-sizing.js";
 import { HistoryState } from "./history-state.js";
 import { terminalThemeCss } from "./terminal-theme.js";
@@ -10,7 +11,7 @@ import { Hyperlinks } from "./hyperlinks.js";
 import type { MouseCapture } from "./mouse-input.js";
 import type { CopySelectionOptions, InputActionHandler, InputDecision, InputBinding,
   TerminalActionName, TerminalGeometry, TerminalInput, TerminalInputContext, TerminalPeer,
-  TerminalSelection, TerminalSizing, TerminalSizingState, TerminalStats, TerminalViewport,
+  TerminalRendererPreference, TerminalSelection, TerminalSizing, TerminalSizingState, TerminalStats, TerminalViewport,
   WebTerminalHandle, WebTerminalOptions } from "./types.js";
 import type { InputCommand, TerminalCommand, WorkerInputMessage, WorkerOutputMessage } from "./wire-types.js";
 import { errorMessage, isRecord } from "./validation.js";
@@ -29,6 +30,7 @@ function requiredElement<T extends Element>(root: ParentNode, selector: string, 
 export class WebTerminal implements WebTerminalHandle {
   readonly element: HTMLDivElement;
   #options: WebTerminalOptions;
+  #renderer: TerminalRendererPreference;
   // DOM and worker fields are initialized by mount before a handle is returned.
   #worker!: Worker;
   #surface!: HTMLDivElement;
@@ -72,7 +74,9 @@ export class WebTerminal implements WebTerminalHandle {
     if (!(container instanceof HTMLElement)) throw new TypeError("A terminal container HTMLElement is required");
     if (!options?.url) throw new TypeError("A terminal WebSocket URL is required");
     if (options.signal?.aborted) throw options.signal.reason;
-    if (!window.isSecureContext || !navigator.gpu) throw new Error("WebTerminal requires WebGPU over HTTPS or localhost");
+    if (normalizeRenderer(options.renderer) === "webgpu" && (!window.isSecureContext || !navigator.gpu)) {
+      throw new Error("The requested WebGPU renderer requires WebGPU over HTTPS or localhost");
+    }
     if (!window.Worker || !window.ResizeObserver || !window.OffscreenCanvas ||
         !HTMLCanvasElement.prototype.transferControlToOffscreen) {
       throw new Error("WebTerminal requires module workers, ResizeObserver, and a transferable OffscreenCanvas");
@@ -89,6 +93,7 @@ export class WebTerminal implements WebTerminalHandle {
 
   private constructor(options: WebTerminalOptions) {
     this.#options = options;
+    this.#renderer = normalizeRenderer(options.renderer);
     if (options.workerUrl !== undefined && !(options.workerUrl instanceof URL) &&
         (typeof options.workerUrl !== "string" || !options.workerUrl.trim()))
       throw new TypeError("workerUrl must be a nonempty URL string or URL");
@@ -248,7 +253,8 @@ export class WebTerminal implements WebTerminalHandle {
     });
     this.#worker.addEventListener("messageerror", () => this.#fail(new Error("Terminal worker message could not be decoded")));
     const canvas = this.#canvas.transferControlToOffscreen();
-    this.#post({ type: "init", canvas, url: url.href, scale, font }, [canvas]);
+    this.#post({ type: "init", canvas, url: url.href, scale, font,
+      renderer: this.#renderer }, [canvas]);
   }
 
   #message(message: WorkerOutputMessage): void {

--- a/src/web-terminal/src/webgl2-backend.ts
+++ b/src/web-terminal/src/webgl2-backend.ts
@@ -1,0 +1,443 @@
+import { QUAD_STRIDE, RendererUnavailableError } from "./render-backend.js";
+import type { RenderBackend, RenderBatch, RenderColor, RenderPixels, RenderTexture } from "./render-backend.js";
+
+const vertexShader = /* glsl */ `#version 300 es
+precision highp float;
+precision highp int;
+
+layout(location = 0) in vec4 rect;
+layout(location = 1) in vec4 uvRect;
+layout(location = 2) in vec4 color;
+layout(location = 3) in float mode;
+uniform vec2 viewport;
+out vec2 fragmentUv;
+out vec4 fragmentTint;
+flat out float fragmentMode;
+
+void main() {
+  const vec2 corners[6] = vec2[6](
+    vec2(0, 0), vec2(1, 0), vec2(0, 1),
+    vec2(0, 1), vec2(1, 0), vec2(1, 1)
+  );
+  vec2 corner = corners[gl_VertexID];
+  vec2 position = rect.xy + corner * rect.zw;
+  gl_Position = vec4(position / viewport * vec2(2, -2) + vec2(-1, 1), 0, 1);
+  fragmentUv = mix(uvRect.xy, uvRect.zw, corner);
+  fragmentTint = color;
+  fragmentMode = mode;
+}`;
+
+const fragmentShader = /* glsl */ `#version 300 es
+precision highp float;
+precision highp int;
+
+uniform highp sampler2D image;
+in vec2 fragmentUv;
+in vec4 fragmentTint;
+flat in float fragmentMode;
+out vec4 fragmentColor;
+
+void main() {
+  vec4 texel = textureLod(image, fragmentUv, 0.0);
+  if (fragmentMode < 0.5) {
+    fragmentColor = fragmentTint;
+  } else if (fragmentMode < 1.5) {
+    fragmentColor = vec4(fragmentTint.rgb, fragmentTint.a * texel.a);
+  } else {
+    fragmentColor = texel * fragmentTint;
+  }
+}`;
+
+function errorFrom(value: unknown): Error {
+  return value instanceof Error ? value : new Error(String(value));
+}
+
+function positiveInteger(value: number): boolean {
+  return Number.isSafeInteger(value) && value > 0;
+}
+
+function prepareUpload(gl: WebGL2RenderingContext): void {
+  gl.pixelStorei(gl.UNPACK_ALIGNMENT, 1);
+  gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+  gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
+  gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
+  gl.pixelStorei(gl.UNPACK_ROW_LENGTH, 0);
+  gl.pixelStorei(gl.UNPACK_SKIP_PIXELS, 0);
+  gl.pixelStorei(gl.UNPACK_SKIP_ROWS, 0);
+}
+
+class WebGl2Texture implements RenderTexture {
+  destroyed = false;
+
+  constructor(readonly owner: WebGl2Backend, private readonly gl: WebGL2RenderingContext,
+    readonly texture: WebGLTexture, readonly width: number, readonly height: number,
+    private readonly assertActive: () => void, private readonly release: (texture: WebGl2Texture) => void) {}
+
+  private bind(): void {
+    this.assertActive();
+    if (this.destroyed) throw new Error("WebGL2 texture is destroyed");
+    this.gl.bindTexture(this.gl.TEXTURE_2D, this.texture);
+    prepareUpload(this.gl);
+  }
+
+  writePixels(pixels: RenderPixels, width: number, height: number, x = 0, y = 0): void {
+    if (!positiveInteger(width) || !positiveInteger(height) ||
+        !Number.isSafeInteger(x) || !Number.isSafeInteger(y) || x < 0 || y < 0 ||
+        x + width > this.width || y + height > this.height || pixels.byteLength < width * height * 4) {
+      throw new Error("Invalid WebGL2 texture upload dimensions or pixel data");
+    }
+    this.bind();
+    this.gl.texSubImage2D(this.gl.TEXTURE_2D, 0, x, y, width, height,
+      this.gl.RGBA, this.gl.UNSIGNED_BYTE, pixels);
+  }
+
+  writeBitmap(bitmap: ImageBitmap): void {
+    if (bitmap.width !== this.width || bitmap.height !== this.height) {
+      throw new Error("WebGL2 bitmap dimensions do not match the texture");
+    }
+    this.bind();
+    // ImageBitmap ignores unpack conversion flags; the shared decoder supplies straight-alpha,
+    // unconverted, top-down bitmaps. Raw RGBA uploads use the explicit unpack state above.
+    this.gl.texSubImage2D(this.gl.TEXTURE_2D, 0, 0, 0, this.gl.RGBA, this.gl.UNSIGNED_BYTE, bitmap);
+  }
+
+  destroy(): void {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    this.release(this);
+    this.gl.deleteTexture(this.texture);
+  }
+}
+
+interface PendingFence {
+  sync: WebGLSync;
+  timer?: ReturnType<typeof setTimeout>;
+  resolve: () => void;
+  reject: (error: Error) => void;
+}
+
+export class WebGl2Backend implements RenderBackend {
+  readonly kind = "webgl2";
+  private textureLimit = 0;
+  private canvasLimit = 0;
+  private bufferBytes = 0;
+  private disposed = false;
+  private lostError?: Error;
+  private program?: WebGLProgram;
+  private instanceBuffer?: WebGLBuffer;
+  private vertexArray?: WebGLVertexArrayObject;
+  private viewport?: WebGLUniformLocation;
+  private readonly shaders = new Set<WebGLShader>();
+  private readonly textures = new Set<WebGl2Texture>();
+  private readonly fences = new Set<PendingFence>();
+  private readonly onContextLost = (event: Event): void => {
+    const message = (event as WebGLContextEvent).statusMessage;
+    this.contextLost(new Error(`WebGL2 context lost${message ? `: ${message}` : ""}`));
+  };
+
+  static async create(canvas: OffscreenCanvas, onFatal: (error: Error) => void): Promise<WebGl2Backend> {
+    const gl = canvas.getContext("webgl2", {
+      alpha: false,
+      antialias: false,
+      depth: false,
+      stencil: false,
+      premultipliedAlpha: false,
+      preserveDrawingBuffer: false,
+    });
+    if (!gl) throw new RendererUnavailableError("Could not create an OffscreenCanvas WebGL2 context");
+    const backend = new WebGl2Backend(canvas, gl, onFatal);
+    try {
+      backend.initialize();
+      return backend;
+    } catch (error) {
+      backend.dispose();
+      throw error;
+    }
+  }
+
+  private constructor(private readonly canvas: OffscreenCanvas, readonly gl: WebGL2RenderingContext,
+    private readonly onFatal: (error: Error) => void) {}
+
+  get maxTextureDimension2D(): number { return this.textureLimit; }
+  get maxCanvasDimension2D(): number { return this.canvasLimit; }
+  get instanceBufferBytes(): number { return this.bufferBytes; }
+
+  private initialize(): void {
+    const gl = this.gl;
+    this.canvas.addEventListener("webglcontextlost", this.onContextLost);
+    this.checkErrors("initialization");
+    this.textureLimit = gl.getParameter(gl.MAX_TEXTURE_SIZE);
+    const viewportLimit = gl.getParameter(gl.MAX_VIEWPORT_DIMS) as Int32Array;
+    this.canvasLimit = Math.min(this.textureLimit, gl.getParameter(gl.MAX_RENDERBUFFER_SIZE),
+      viewportLimit[0], viewportLimit[1]);
+    if (!positiveInteger(this.textureLimit) || !positiveInteger(this.canvasLimit)) {
+      throw new Error("Invalid WebGL2 texture or viewport limits");
+    }
+
+    const vertex = this.compile(gl.VERTEX_SHADER, vertexShader);
+    const fragment = this.compile(gl.FRAGMENT_SHADER, fragmentShader);
+    const program = gl.createProgram();
+    if (!program) throw new Error("Could not allocate a WebGL2 shader program");
+    this.program = program;
+    gl.attachShader(program, vertex);
+    gl.attachShader(program, fragment);
+    gl.linkProgram(program);
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+      throw new Error(`WebGL2 shader link failed: ${gl.getProgramInfoLog(program) || "No diagnostic available"}`);
+    }
+    for (const shader of this.shaders) {
+      gl.detachShader(program, shader);
+      gl.deleteShader(shader);
+    }
+    this.shaders.clear();
+    const viewport = gl.getUniformLocation(program, "viewport");
+    const image = gl.getUniformLocation(program, "image");
+    if (viewport === null || image === null) throw new Error("WebGL2 shader uniforms are unavailable");
+    this.viewport = viewport;
+    const buffer = gl.createBuffer();
+    if (!buffer) throw new Error("Could not allocate a WebGL2 instance buffer");
+    this.instanceBuffer = buffer;
+    const vertexArray = gl.createVertexArray();
+    if (!vertexArray) throw new Error("Could not allocate a WebGL2 vertex array");
+    this.vertexArray = vertexArray;
+
+    gl.useProgram(program);
+    gl.uniform1i(image, 0);
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindVertexArray(vertexArray);
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+    for (let attribute = 0; attribute < 4; attribute++) {
+      gl.enableVertexAttribArray(attribute);
+      gl.vertexAttribDivisor(attribute, 1);
+    }
+    gl.enable(gl.BLEND);
+    gl.blendEquationSeparate(gl.FUNC_ADD, gl.FUNC_ADD);
+    gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+    gl.disable(gl.DEPTH_TEST);
+    gl.disable(gl.STENCIL_TEST);
+    gl.disable(gl.CULL_FACE);
+    gl.disable(gl.SCISSOR_TEST);
+    gl.disable(gl.DITHER);
+    this.resize(this.canvas.width, this.canvas.height);
+  }
+
+  private compile(type: number, source: string): WebGLShader {
+    const gl = this.gl;
+    const shader = gl.createShader(type);
+    if (!shader) throw new Error("Could not allocate a WebGL2 shader");
+    this.shaders.add(shader);
+    gl.shaderSource(shader, source);
+    gl.compileShader(shader);
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+      throw new Error(`WebGL2 shader compilation failed: ${gl.getShaderInfoLog(shader) || "No diagnostic available"}`);
+    }
+    return shader;
+  }
+
+  private assertActive(): void {
+    if (this.disposed) throw new Error("WebGL2 backend is disposed");
+    if (this.lostError) throw this.lostError;
+  }
+
+  private contextLost(error: Error): void {
+    if (this.disposed || this.lostError) return;
+    this.lostError = error;
+    for (const fence of this.fences) this.settleFence(fence, error);
+    this.onFatal(error);
+  }
+
+  private checkErrors(operation: string): void {
+    this.assertActive();
+    const gl = this.gl;
+    const code = gl.getError();
+    if (code === gl.CONTEXT_LOST_WEBGL || gl.isContextLost()) {
+      const error = new Error("WebGL2 context lost");
+      this.contextLost(error);
+      throw error;
+    }
+    if (code !== gl.NO_ERROR) {
+      const name = code === gl.OUT_OF_MEMORY ? "OUT_OF_MEMORY" :
+        code === gl.INVALID_ENUM ? "INVALID_ENUM" :
+        code === gl.INVALID_VALUE ? "INVALID_VALUE" :
+        code === gl.INVALID_OPERATION ? "INVALID_OPERATION" :
+        code === gl.INVALID_FRAMEBUFFER_OPERATION ? "INVALID_FRAMEBUFFER_OPERATION" : `0x${code.toString(16)}`;
+      throw new Error(`WebGL2 ${operation} failed: ${name}`);
+    }
+  }
+
+  createTexture(width: number, height: number, label: string): RenderTexture {
+    this.assertActive();
+    if (!positiveInteger(width) || !positiveInteger(height) ||
+        width > this.textureLimit || height > this.textureLimit) {
+      throw new Error(`${label} has invalid dimensions or exceeds the WebGL2 texture dimension limit`);
+    }
+    const gl = this.gl;
+    const texture = gl.createTexture();
+    if (!texture) {
+      this.checkErrors("texture allocation");
+      throw new Error(`Could not allocate WebGL2 texture: ${label}`);
+    }
+    try {
+      gl.bindTexture(gl.TEXTURE_2D, texture);
+      prepareUpload(gl);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+      // WebGL guarantees zero initialization for null data, including untouched atlas padding.
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA8, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+      this.checkErrors(`texture allocation (${label})`);
+      const resource = new WebGl2Texture(this, gl, texture, width, height,
+        () => this.assertActive(), resource => this.textures.delete(resource));
+      this.textures.add(resource);
+      return resource;
+    } catch (error) {
+      gl.deleteTexture(texture);
+      throw error;
+    }
+  }
+
+  resize(width: number, height: number): void {
+    this.assertActive();
+    if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+      throw new Error("Invalid WebGL2 logical viewport dimensions");
+    }
+    if (!positiveInteger(this.canvas.width) || !positiveInteger(this.canvas.height) ||
+        this.canvas.width > this.canvasLimit || this.canvas.height > this.canvasLimit) {
+      throw new Error("Canvas exceeds the WebGL2 drawing buffer dimension limit");
+    }
+    const gl = this.gl;
+    if (gl.drawingBufferWidth !== this.canvas.width || gl.drawingBufferHeight !== this.canvas.height) {
+      this.checkErrors("drawing buffer resize");
+      throw new Error("WebGL2 could not allocate the requested canvas drawing buffer");
+    }
+    gl.viewport(0, 0, this.canvas.width, this.canvas.height);
+    gl.useProgram(this.program!);
+    gl.uniform2f(this.viewport!, width, height);
+    this.checkErrors("resize");
+  }
+
+  submit(instances: Float32Array<ArrayBuffer>, quadCount: number, batches: readonly RenderBatch[],
+    background: RenderColor): void {
+    this.assertActive();
+    if (!Number.isSafeInteger(quadCount) || quadCount < 0 || quadCount * QUAD_STRIDE > instances.length) {
+      throw new Error("Invalid WebGL2 instance data");
+    }
+    for (const batch of batches) {
+      if (!(batch.resource instanceof WebGl2Texture) || batch.resource.owner !== this) {
+        throw new Error("Texture belongs to a different rendering backend");
+      }
+      if (batch.resource.destroyed) throw new Error("WebGL2 texture is destroyed");
+      if (!Number.isSafeInteger(batch.start) || !Number.isSafeInteger(batch.count) ||
+          batch.start < 0 || batch.count < 0 || batch.start + batch.count > quadCount) {
+        throw new Error("Invalid WebGL2 batch instance range");
+      }
+    }
+    const gl = this.gl;
+    const strideBytes = QUAD_STRIDE * Float32Array.BYTES_PER_ELEMENT;
+    const usedBytes = quadCount * strideBytes;
+    gl.bindVertexArray(this.vertexArray!);
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.instanceBuffer!);
+    if (!this.bufferBytes || usedBytes > this.bufferBytes) {
+      const bytes = Math.max(256, instances.byteLength);
+      gl.bufferData(gl.ARRAY_BUFFER, bytes, gl.DYNAMIC_DRAW);
+      this.checkErrors("instance buffer allocation");
+      this.bufferBytes = bytes;
+    }
+    if (usedBytes) gl.bufferSubData(gl.ARRAY_BUFFER, 0, instances, 0, quadCount * QUAD_STRIDE);
+    gl.useProgram(this.program!);
+    gl.activeTexture(gl.TEXTURE0);
+    gl.clearColor(background[0], background[1], background[2], 1);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    for (const batch of batches) {
+      if (!batch.count) continue;
+      const resource = batch.resource as WebGl2Texture;
+      gl.bindTexture(gl.TEXTURE_2D, resource.texture);
+      // WebGL2 has no baseInstance; rebase all per-instance attributes for each ordered batch.
+      const offset = batch.start * strideBytes;
+      gl.vertexAttribPointer(0, 4, gl.FLOAT, false, strideBytes, offset);
+      gl.vertexAttribPointer(1, 4, gl.FLOAT, false, strideBytes, offset + 16);
+      gl.vertexAttribPointer(2, 4, gl.FLOAT, false, strideBytes, offset + 32);
+      gl.vertexAttribPointer(3, 1, gl.FLOAT, false, strideBytes, offset + 48);
+      gl.drawArraysInstanced(gl.TRIANGLES, 0, 6, batch.count);
+    }
+    // Upload errors are checked once per submission, not once per glyph.
+    this.checkErrors("frame submission");
+  }
+
+  async idle(): Promise<void> {
+    this.checkErrors("GPU completion");
+    const gl = this.gl;
+    const sync = gl.fenceSync(gl.SYNC_GPU_COMMANDS_COMPLETE, 0);
+    if (!sync) {
+      this.checkErrors("GPU fence allocation");
+      throw new Error("Could not allocate a WebGL2 GPU fence");
+    }
+    return new Promise<void>((resolve, reject) => {
+      const fence: PendingFence = { sync, resolve, reject };
+      this.fences.add(fence);
+      try {
+        gl.flush();
+        this.checkErrors("GPU fence submission");
+        this.pollFence(fence);
+      } catch (error) {
+        this.settleFence(fence, errorFrom(error));
+      }
+    });
+  }
+
+  private pollFence(fence: PendingFence): void {
+    if (!this.fences.has(fence)) return;
+    try {
+      this.assertActive();
+      const gl = this.gl;
+      if (gl.isContextLost()) {
+        const error = new Error("WebGL2 context lost");
+        this.contextLost(error);
+        throw error;
+      }
+      const status = gl.clientWaitSync(fence.sync, 0, 0);
+      if (status === gl.ALREADY_SIGNALED || status === gl.CONDITION_SATISFIED) {
+        this.checkErrors("GPU completion");
+        this.settleFence(fence);
+      } else if (status === gl.TIMEOUT_EXPIRED) {
+        fence.timer = setTimeout(() => {
+          fence.timer = undefined;
+          this.pollFence(fence);
+        }, 0);
+      } else {
+        this.checkErrors("GPU fence wait");
+        throw new Error("WebGL2 GPU fence wait failed");
+      }
+    } catch (error) {
+      this.settleFence(fence, errorFrom(error));
+    }
+  }
+
+  private settleFence(fence: PendingFence, error?: Error): void {
+    if (!this.fences.delete(fence)) return;
+    if (fence.timer !== undefined) clearTimeout(fence.timer);
+    this.gl.deleteSync(fence.sync);
+    if (error) fence.reject(error);
+    else fence.resolve();
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.canvas.removeEventListener("webglcontextlost", this.onContextLost);
+    for (const fence of this.fences) this.settleFence(fence, new Error("WebGL2 backend is disposed"));
+    for (const texture of this.textures) texture.destroy();
+    const gl = this.gl;
+    if (this.instanceBuffer) gl.deleteBuffer(this.instanceBuffer);
+    if (this.vertexArray) gl.deleteVertexArray(this.vertexArray);
+    if (this.program) gl.deleteProgram(this.program);
+    for (const shader of this.shaders) gl.deleteShader(shader);
+    this.shaders.clear();
+    this.instanceBuffer = undefined;
+    this.vertexArray = undefined;
+    this.program = undefined;
+    this.bufferBytes = 0;
+    if (!gl.isContextLost()) gl.getExtension("WEBGL_lose_context")?.loseContext();
+  }
+}

--- a/src/web-terminal/src/webgpu-backend.ts
+++ b/src/web-terminal/src/webgpu-backend.ts
@@ -1,0 +1,224 @@
+import { QUAD_STRIDE, RendererUnavailableError } from "./render-backend.js";
+import type { RenderBackend, RenderBatch, RenderColor, RenderPixels, RenderTexture } from "./render-backend.js";
+
+const shader = /* wgsl */ `
+struct Viewport { size: vec2f, padding: vec2f }
+@group(0) @binding(0) var<uniform> viewport: Viewport;
+@group(0) @binding(1) var image: texture_2d<f32>;
+@group(0) @binding(2) var imageSampler: sampler;
+
+struct VertexOut {
+  @builtin(position) position: vec4f,
+  @location(0) uv: vec2f,
+  @location(1) color: vec4f,
+  @location(2) @interpolate(flat) mode: f32,
+}
+
+@vertex fn vertex(
+  @builtin(vertex_index) index: u32,
+  @location(0) rect: vec4f,
+  @location(1) uvRect: vec4f,
+  @location(2) color: vec4f,
+  @location(3) mode: f32,
+) -> VertexOut {
+  let corners = array<vec2f, 6>(
+    vec2f(0, 0), vec2f(1, 0), vec2f(0, 1),
+    vec2f(0, 1), vec2f(1, 0), vec2f(1, 1)
+  );
+  let corner = corners[index];
+  let position = rect.xy + corner * rect.zw;
+  var out: VertexOut;
+  out.position = vec4f(position / viewport.size * vec2f(2, -2) + vec2f(-1, 1), 0, 1);
+  out.uv = mix(uvRect.xy, uvRect.zw, corner);
+  out.color = color;
+  out.mode = mode;
+  return out;
+}
+
+@fragment fn fragment(in: VertexOut) -> @location(0) vec4f {
+  // Explicit LOD avoids derivative-uniformity requirements across solid/mask/image batches.
+  let texel = textureSampleLevel(image, imageSampler, in.uv, 0);
+  if (in.mode < 0.5) { return in.color; }
+  if (in.mode < 1.5) { return vec4f(in.color.rgb, in.color.a * texel.a); }
+  return texel * in.color;
+}`;
+
+class WebGpuTexture implements RenderTexture {
+  constructor(readonly device: GPUDevice, readonly texture: GPUTexture, readonly bindGroup: GPUBindGroup,
+    readonly width: number, readonly height: number) {}
+
+  writePixels(pixels: RenderPixels, width: number, height: number, x = 0, y = 0): void {
+    this.device.queue.writeTexture({ texture: this.texture, origin: [x, y] }, pixels,
+      { bytesPerRow: width * 4, rowsPerImage: height }, [width, height]);
+  }
+
+  writeBitmap(bitmap: ImageBitmap): void {
+    this.device.queue.copyExternalImageToTexture({ source: bitmap },
+      { texture: this.texture, premultipliedAlpha: false }, [this.width, this.height]);
+  }
+
+  destroy(): void { this.texture.destroy(); }
+}
+
+export class WebGpuBackend implements RenderBackend {
+  readonly kind = "webgpu";
+  instanceBufferBytes = 0;
+  instanceBuffer: GPUBuffer | undefined;
+  disposed = false;
+  context?: GPUCanvasContext;
+  format: GPUTextureFormat;
+  uniform: GPUBuffer;
+  sampler: GPUSampler;
+  pipeline?: GPURenderPipeline;
+
+  static async create(canvas: OffscreenCanvas, onFatal: (error: Error) => void): Promise<WebGpuBackend> {
+    if (!globalThis.isSecureContext) throw new RendererUnavailableError("WebGPU requires HTTPS or localhost");
+    if (!navigator.gpu) throw new RendererUnavailableError("WebGPU is unavailable in this browser worker");
+    const adapter = await navigator.gpu.requestAdapter();
+    if (!adapter) throw new RendererUnavailableError("No WebGPU adapter is available");
+    let device: GPUDevice;
+    try {
+      device = await adapter.requestDevice();
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "OperationError") {
+        throw new RendererUnavailableError(`Could not acquire a WebGPU device: ${error.message}`, { cause: error });
+      }
+      throw error;
+    }
+    let backend: WebGpuBackend | undefined;
+    try {
+      backend = new WebGpuBackend(device);
+      const active = backend;
+      device.lost.then(info => {
+        if (!active.disposed) onFatal(new Error(`WebGPU device lost: ${info.message || info.reason}`));
+      });
+      device.addEventListener("uncapturederror", event => {
+        if (!active.disposed) onFatal(new Error(`WebGPU error: ${event.error.message}`));
+      });
+      await backend.initialize(canvas);
+      return backend;
+    } catch (error) {
+      if (backend) backend.dispose();
+      else device.destroy();
+      throw error;
+    }
+  }
+
+  constructor(readonly device: GPUDevice) {
+    this.format = navigator.gpu.getPreferredCanvasFormat();
+    this.uniform = device.createBuffer({ size: 16, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+    this.sampler = device.createSampler({ minFilter: "linear", magFilter: "linear" });
+  }
+
+  get maxTextureDimension2D(): number { return this.device.limits.maxTextureDimension2D; }
+  get maxCanvasDimension2D(): number { return this.maxTextureDimension2D; }
+
+  async initialize(canvas: OffscreenCanvas): Promise<void> {
+    const module = this.device.createShaderModule({ code: shader });
+    this.pipeline = await this.device.createRenderPipelineAsync({
+      layout: "auto",
+      vertex: {
+        module,
+        entryPoint: "vertex",
+        buffers: [{
+          arrayStride: QUAD_STRIDE * 4,
+          stepMode: "instance",
+          attributes: [
+            { shaderLocation: 0, offset: 0, format: "float32x4" },
+            { shaderLocation: 1, offset: 16, format: "float32x4" },
+            { shaderLocation: 2, offset: 32, format: "float32x4" },
+            { shaderLocation: 3, offset: 48, format: "float32" },
+          ],
+        }],
+      },
+      fragment: {
+        module,
+        entryPoint: "fragment",
+        targets: [{
+          format: this.format,
+          blend: {
+            color: { srcFactor: "src-alpha", dstFactor: "one-minus-src-alpha" },
+            alpha: { srcFactor: "one", dstFactor: "one-minus-src-alpha" },
+          },
+        }],
+      },
+      primitive: { topology: "triangle-list" },
+    });
+    // Acquire the presentation surface last. A null context leaves it usable by WebGL2.
+    const context = canvas.getContext("webgpu");
+    if (!context) throw new RendererUnavailableError("Could not create an OffscreenCanvas WebGPU context");
+    this.context = context;
+    context.configure({ device: this.device, format: this.format, alphaMode: "opaque" });
+  }
+
+  createTexture(width: number, height: number, label: string): RenderTexture {
+    if (width > this.maxTextureDimension2D || height > this.maxTextureDimension2D) {
+      throw new Error(`${label} exceeds the GPU texture dimension limit`);
+    }
+    if (!this.pipeline) throw new Error("WebGPU backend is not initialized");
+    const texture = this.device.createTexture({
+      label, size: [width, height], format: "rgba8unorm",
+      usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+    try {
+      const bindGroup = this.device.createBindGroup({
+        layout: this.pipeline.getBindGroupLayout(0),
+        entries: [
+          { binding: 0, resource: { buffer: this.uniform } },
+          { binding: 1, resource: texture.createView() },
+          { binding: 2, resource: this.sampler },
+        ],
+      });
+      return new WebGpuTexture(this.device, texture, bindGroup, width, height);
+    } catch (error) {
+      texture.destroy();
+      throw error;
+    }
+  }
+
+  resize(width: number, height: number): void {
+    this.device.queue.writeBuffer(this.uniform, 0, new Float32Array([width, height, 0, 0]));
+  }
+
+  submit(instances: Float32Array<ArrayBuffer>, quadCount: number, batches: readonly RenderBatch[],
+    background: RenderColor): void {
+    if (this.disposed || !this.context || !this.pipeline) throw new Error("WebGPU backend is not initialized");
+    const usedBytes = quadCount * QUAD_STRIDE * 4;
+    if (!this.instanceBuffer || usedBytes > this.instanceBufferBytes) {
+      this.instanceBuffer?.destroy();
+      this.instanceBufferBytes = Math.max(256, instances.byteLength);
+      this.instanceBuffer = this.device.createBuffer({
+        size: this.instanceBufferBytes, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+      });
+    }
+    if (usedBytes) this.device.queue.writeBuffer(this.instanceBuffer, 0, instances, 0, quadCount * QUAD_STRIDE);
+    const encoder = this.device.createCommandEncoder();
+    const pass = encoder.beginRenderPass({
+      colorAttachments: [{
+        view: this.context.getCurrentTexture().createView(),
+        clearValue: { r: background[0], g: background[1], b: background[2], a: 1 },
+        loadOp: "clear", storeOp: "store",
+      }],
+    });
+    pass.setPipeline(this.pipeline);
+    pass.setVertexBuffer(0, this.instanceBuffer);
+    for (const batch of batches) {
+      if (!(batch.resource instanceof WebGpuTexture)) throw new Error("Texture belongs to a different rendering backend");
+      pass.setBindGroup(0, batch.resource.bindGroup);
+      pass.draw(6, batch.count, 0, batch.start);
+    }
+    pass.end();
+    this.device.queue.submit([encoder.finish()]);
+  }
+
+  async idle(): Promise<void> { await this.device.queue.onSubmittedWorkDone(); }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.instanceBuffer?.destroy();
+    this.uniform.destroy();
+    this.context?.unconfigure();
+    this.device.destroy();
+  }
+}

--- a/src/web-terminal/src/wire-types.ts
+++ b/src/web-terminal/src/wire-types.ts
@@ -1,6 +1,6 @@
 import type { InputModifiers, PointerButton, SelectionMode, SelectionRange,
   TerminalBuffer, TerminalFont, TerminalGeometry, TerminalPeer, TerminalSize, TerminalStats,
-  TerminalStatusLevel } from "./types.js";
+  TerminalRendererPreference, TerminalStatusLevel } from "./types.js";
 
 export type SelectionText =
   | { status: "valid"; text: string }
@@ -61,7 +61,8 @@ export type TerminalCommand = InputCommand
   | { type: "resync" }
   | { type: "ack"; revision: number };
 export type WorkerInputMessage =
-  | { type: "init"; canvas: OffscreenCanvas; url: string; scale: number; font: TerminalFont }
+  | { type: "init"; canvas: OffscreenCanvas; url: string; scale: number; font: TerminalFont;
+      renderer: TerminalRendererPreference }
   | ({ type: "viewport" } & TerminalSize)
   | { type: "command"; command: TerminalCommand }
   | { type: "stop" };

--- a/src/web-terminal/tests/backend-selection.test.mjs
+++ b/src/web-terminal/tests/backend-selection.test.mjs
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createRenderBackend } from "../dist/backend-selection.js";
+import { RendererUnavailableError } from "../dist/render-backend.js";
+import { normalizeRenderer } from "../dist/renderer-options.js";
+import { WebGpuBackend } from "../dist/webgpu-backend.js";
+import { WebGl2Backend } from "../dist/webgl2-backend.js";
+import { TerminalRenderer } from "../dist/renderer.js";
+import { WebTerminal } from "../dist/index.js";
+
+test("Renderer preferences default to auto and reject unsupported values before mounting", () => {
+  assert.equal(normalizeRenderer(), "auto");
+  for (const value of ["auto", "webgpu", "webgl2"]) assert.equal(normalizeRenderer(value), value);
+  for (const value of [null, false, 1, {}, [], "", "WebGPU", "canvas2d"]) {
+    assert.throws(() => normalizeRenderer(value), TypeError);
+    assert.throws(() => new WebTerminal({ url: "/terminal", renderer: value }), /renderer must be/);
+  }
+});
+
+test("Auto and explicit WebGPU use the GPU backend without probing WebGL2", async t => {
+  const backend = { kind: "webgpu" };
+  const canvas = {};
+  const onFatal = () => {};
+  const gpu = t.mock.method(WebGpuBackend, "create", async (...args) => {
+    assert.deepEqual(args, [canvas, onFatal]);
+    return backend;
+  });
+  const gl = t.mock.method(WebGl2Backend, "create");
+  assert.deepEqual(await createRenderBackend(canvas, onFatal), { backend });
+  assert.deepEqual(await createRenderBackend(canvas, onFatal, "webgpu"), { backend });
+  assert.equal(gpu.mock.callCount(), 2);
+  assert.equal(gl.mock.callCount(), 0);
+});
+
+test("Explicit WebGL2 never probes WebGPU even when available", async t => {
+  const backend = { kind: "webgl2" };
+  const gpu = t.mock.method(WebGpuBackend, "create");
+  t.mock.method(WebGl2Backend, "create", async () => backend);
+  assert.deepEqual(await createRenderBackend({}, () => {}, "webgl2"), { backend });
+  assert.equal(gpu.mock.callCount(), 0);
+});
+
+test("Auto falls back only on capability failures and retains their diagnostic", async t => {
+  const backend = { kind: "webgl2" };
+  t.mock.method(WebGpuBackend, "create", async () => { throw new RendererUnavailableError("No WebGPU adapter"); });
+  const gl = t.mock.method(WebGl2Backend, "create", async () => backend);
+  assert.deepEqual(await createRenderBackend({}, () => {}), { backend, fallbackReason: "No WebGPU adapter" });
+  assert.equal(gl.mock.callCount(), 1);
+});
+
+test("Explicit WebGPU fails rather than silently switching backends", async t => {
+  const error = new RendererUnavailableError("WebGPU requires HTTPS");
+  t.mock.method(WebGpuBackend, "create", async () => { throw error; });
+  const gl = t.mock.method(WebGl2Backend, "create");
+  await assert.rejects(createRenderBackend({}, () => {}, "webgpu"), e => e === error);
+  assert.equal(gl.mock.callCount(), 0);
+});
+
+test("Shader, validation and unexpected failures never trigger automatic fallback", async t => {
+  const gl = t.mock.method(WebGl2Backend, "create");
+  for (const error of [new Error("Shader compilation failed"), new TypeError("Invalid pipeline"), new Error("Device lost")]) {
+    const gpu = t.mock.method(WebGpuBackend, "create", async () => { throw error; });
+    await assert.rejects(createRenderBackend({}, () => {}), e => e === error);
+    gpu.mock.restore();
+  }
+  assert.equal(gl.mock.callCount(), 0);
+});
+
+test("Failure of both backends reports both causes", async t => {
+  const gpuError = new RendererUnavailableError("WebGPU requires HTTPS");
+  const glError = new RendererUnavailableError("WebGL2 context unavailable");
+  t.mock.method(WebGpuBackend, "create", async () => { throw gpuError; });
+  t.mock.method(WebGl2Backend, "create", async () => { throw glError; });
+  await assert.rejects(createRenderBackend({}, () => {}), error => {
+    assert.ok(error instanceof AggregateError);
+    assert.deepEqual(error.errors, [gpuError, glError]);
+    assert.match(error.message, /WebGPU requires HTTPS.*WebGL2 context unavailable/);
+    return true;
+  });
+});
+
+test("Insecure contexts fall back before WebGPU or the presentation canvas is touched", async t => {
+  const secure = Object.getOwnPropertyDescriptor(globalThis, "isSecureContext");
+  Object.defineProperty(globalThis, "isSecureContext", { configurable: true, value: false });
+  t.after(() => {
+    if (secure) Object.defineProperty(globalThis, "isSecureContext", secure);
+    else delete globalThis.isSecureContext;
+  });
+  const backend = { kind: "webgl2" };
+  t.mock.method(WebGl2Backend, "create", async () => backend);
+  const result = await createRenderBackend({ getContext() { assert.fail("WebGPU must not acquire this surface"); } }, () => {});
+  assert.equal(result.backend, backend);
+  assert.match(result.fallbackReason, /HTTPS or localhost/);
+});
+
+test("Missing API, absent adapter and device acquisition rejection are capability failures", async t => {
+  const secure = Object.getOwnPropertyDescriptor(globalThis, "isSecureContext");
+  const navigator = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+  Object.defineProperty(globalThis, "isSecureContext", { configurable: true, value: true });
+  const setGpu = gpu => Object.defineProperty(globalThis, "navigator", { configurable: true, value: { gpu } });
+  t.after(() => {
+    if (secure) Object.defineProperty(globalThis, "isSecureContext", secure);
+    else delete globalThis.isSecureContext;
+    if (navigator) Object.defineProperty(globalThis, "navigator", navigator);
+    else delete globalThis.navigator;
+  });
+  const backend = { kind: "webgl2" };
+  t.mock.method(WebGl2Backend, "create", async () => backend);
+  for (const gpu of [undefined, { requestAdapter: async () => null }, {
+    requestAdapter: async () => ({ requestDevice: async () => { throw new DOMException("Unavailable", "OperationError"); } })
+  }]) {
+    setGpu(gpu);
+    const result = await createRenderBackend({}, () => {});
+    assert.equal(result.backend, backend);
+    assert.ok(result.fallbackReason);
+  }
+  const bug = new TypeError("Unexpected device request failure");
+  setGpu({ requestAdapter: async () => ({ requestDevice: async () => { throw bug; } }) });
+  await assert.rejects(createRenderBackend({}, () => {}), error => error === bug);
+});
+
+test("Font initialization failures dispose the selected backend without fallback", async t => {
+  let disposed = 0;
+  t.mock.method(WebGpuBackend, "create", async () => ({ dispose() { disposed++; } }));
+  const gl = t.mock.method(WebGl2Backend, "create");
+  const error = new Error("Could not load terminal font");
+  t.mock.method(TerminalRenderer.prototype, "initialize", async () => { throw error; });
+  await assert.rejects(TerminalRenderer.create({}, 1, () => {}), e => e === error);
+  assert.equal(disposed, 1);
+  assert.equal(gl.mock.callCount(), 0);
+});
+
+test("Invalid scale and font configuration do not allocate a backend", async t => {
+  const gpu = t.mock.method(WebGpuBackend, "create");
+  const gl = t.mock.method(WebGl2Backend, "create");
+  await assert.rejects(TerminalRenderer.create({}, 0, () => {}), /Invalid backing scale/);
+  await assert.rejects(TerminalRenderer.create({}, 1, () => {}, { family: "" }), TypeError);
+  assert.equal(gpu.mock.callCount(), 0);
+  assert.equal(gl.mock.callCount(), 0);
+});
+
+test("Renderer diagnostics distinguish auto fallback from explicit selection", async t => {
+  t.mock.method(WebGpuBackend, "create", async () => { throw new RendererUnavailableError("Adapter disabled"); });
+  t.mock.method(WebGl2Backend, "create", async () => ({ kind: "webgl2", instanceBufferBytes: 0, dispose() {} }));
+  t.mock.method(TerminalRenderer.prototype, "initialize", async function () {
+    this.font = { family: "monospace", dispose() {} };
+    this.atlas = { width: 1, height: 1, destroy() {} };
+  });
+  for (const preference of ["auto", "webgl2"]) {
+    const renderer = await TerminalRenderer.create({ width: 1, height: 1 }, 1, () => {}, undefined, preference);
+    assert.equal(renderer.metrics().renderer, "webgl2");
+    assert.equal(renderer.metrics().rendererFallbackReason, preference === "auto" ? "Adapter disabled" : undefined);
+    renderer.dispose();
+    renderer.dispose();
+  }
+});

--- a/src/web-terminal/tests/package.test.mjs
+++ b/src/web-terminal/tests/package.test.mjs
@@ -33,6 +33,8 @@ test("Packed allowlist ships a complete, registry-neutral browser package", () =
   const paths = new Set(packed.files.map(file => file.path));
   for (const file of ["package.json", "README.md", "LICENSE", "dist/index.js", "dist/index.d.ts",
     "dist/web-terminal.js", "dist/terminal-worker.js", "dist/renderer.js", "dist/protocol.js",
+    "dist/backend-selection.js", "dist/render-backend.js", "dist/renderer-options.js",
+    "dist/webgpu-backend.js", "dist/webgl2-backend.js",
     "dist/fonts/cascadia-mono-nf/CascadiaMonoNF.woff2",
     "dist/fonts/cascadia-mono-nf/LICENSE.txt", "dist/fonts/cascadia-mono-nf/README.md"]) {
     assert.ok(paths.has(file), `Missing ${file}`);

--- a/src/web-terminal/tests/types/consumer.ts
+++ b/src/web-terminal/tests/types/consumer.ts
@@ -1,7 +1,8 @@
 import {
   WebTerminal, InputRoute, TerminalAction, defaultInputBindings, MIN_FONT_SIZE, MAX_FONT_SIZE,
   type WebTerminalOptions, type WebTerminalHandle, type TerminalInput, type InputBinding,
-  type TerminalSelection, type TerminalViewport, type SelectionUIEvent, type TerminalStats
+  type TerminalSelection, type TerminalViewport, type SelectionUIEvent, type TerminalStats,
+  type TerminalRendererKind, type TerminalRendererPreference
 } from "@hex1b/web-terminal";
 
 const container = document.createElement("div");
@@ -14,6 +15,7 @@ const options: WebTerminalOptions = {
   workerUrl: new URL("/web-terminal/terminal-worker.js", "https://example.test"),
   signal: new AbortController().signal,
   scale: "auto",
+  renderer: "auto",
   sizing: { mode: "fixed", columns: 80, rows: 24, fontSize: 16 },
   font: { family: "Terminal Font", faces: [{ url: "/font.woff2", weight: "200 700" }] },
   actions: {
@@ -44,7 +46,9 @@ const options: WebTerminalOptions = {
     const state: TerminalStats = stats;
     const revision: number | undefined = state.revision;
     const mirror: string | undefined = text;
-    console.log(revision, mirror);
+    const renderer: TerminalRendererKind | undefined = stats.renderer;
+    const reason: string | undefined = stats.rendererFallbackReason;
+    console.log(revision, mirror, renderer, reason);
   },
   onSelectionUI(event) {
     const notification: SelectionUIEvent = event;
@@ -70,6 +74,9 @@ const options: WebTerminalOptions = {
 };
 
 const terminal: WebTerminalHandle = await WebTerminal.mount(container, options);
+const forcedRenderer: TerminalRendererPreference = "webgl2";
+const forcedOptions: WebTerminalOptions = { ...options, renderer: forcedRenderer };
+console.log(forcedOptions);
 const copied: string = await terminal.runAction(TerminalAction.CopySelection, { clear: true });
 const pasted: string = await terminal.runAction(TerminalAction.PasteClipboard);
 await terminal.runAction(TerminalAction.ScrollLines, -20);
@@ -99,6 +106,8 @@ const asyncRouting: WebTerminalOptions = { url: "/terminal", onInput: async () =
 const asyncBinding: InputBinding = { id: "async", match: async () => true, route: InputRoute.Consume };
 // @ts-expect-error Worker entries must be URL strings or URL objects.
 const invalidWorker: WebTerminalOptions = { url: "/terminal", workerUrl: 42 };
+// @ts-expect-error Only supported rendering backends are selectable.
+const invalidRenderer: WebTerminalOptions = { url: "/terminal", renderer: "canvas2d" };
 // @ts-expect-error Routing decisions specify exactly one route or action.
 const ambiguous: InputBinding = { id: "both", match: () => true, route: InputRoute.Browser, action: "inspect" };
 // @ts-expect-error Protocol internals are not public package exports.

--- a/src/web-terminal/tests/web-terminal.test.mjs
+++ b/src/web-terminal/tests/web-terminal.test.mjs
@@ -161,8 +161,9 @@ function renderer(scale = 2, limit = 8192) {
   const writes = [];
   const result = Object.create(TerminalRenderer.prototype);
   Object.assign(result, {
-    scale, columns: 0, rows: 0, canvas: { width: 0, height: 0 }, uniform: {},
-    device: { limits: { maxTextureDimension2D: limit }, queue: { writeBuffer: (...args) => writes.push(args[2]) } }
+    scale, columns: 0, rows: 0, canvas: { width: 0, height: 0 },
+    backend: { maxCanvasDimension2D: limit,
+      resize: (width, height) => writes.push(new Float32Array([width, height, 0, 0])) }
   });
   return { result, writes };
 }

--- a/src/web-terminal/tests/webgl2-backend.test.mjs
+++ b/src/web-terminal/tests/webgl2-backend.test.mjs
@@ -1,0 +1,684 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { QUAD_STRIDE, RendererUnavailableError } from "../dist/render-backend.js";
+import { WebGl2Backend } from "../dist/webgl2-backend.js";
+
+function harness(options = {}) {
+  const calls = [];
+  const live = new Set();
+  let nextId = 0;
+  const gl = {
+    ...Object.fromEntries(`MAX_TEXTURE_SIZE MAX_RENDERBUFFER_SIZE MAX_VIEWPORT_DIMS
+      VERTEX_SHADER FRAGMENT_SHADER COMPILE_STATUS LINK_STATUS ARRAY_BUFFER DYNAMIC_DRAW
+      FLOAT TRIANGLES TEXTURE0 TEXTURE_2D RGBA8 RGBA UNSIGNED_BYTE TEXTURE_MIN_FILTER
+      TEXTURE_MAG_FILTER TEXTURE_WRAP_S TEXTURE_WRAP_T LINEAR CLAMP_TO_EDGE
+      UNPACK_ALIGNMENT UNPACK_FLIP_Y_WEBGL UNPACK_PREMULTIPLY_ALPHA_WEBGL
+      UNPACK_COLORSPACE_CONVERSION_WEBGL UNPACK_ROW_LENGTH UNPACK_SKIP_PIXELS UNPACK_SKIP_ROWS
+      BLEND FUNC_ADD SRC_ALPHA ONE_MINUS_SRC_ALPHA ONE DEPTH_TEST STENCIL_TEST CULL_FACE
+      SCISSOR_TEST DITHER COLOR_BUFFER_BIT SYNC_GPU_COMMANDS_COMPLETE ALREADY_SIGNALED
+      CONDITION_SATISFIED TIMEOUT_EXPIRED WAIT_FAILED`.split(/\s+/).map((name, i) => [name, i + 1])),
+    NO_ERROR: 0,
+    NONE: 0,
+    INVALID_ENUM: 0x0500,
+    INVALID_VALUE: 0x0501,
+    INVALID_OPERATION: 0x0502,
+    OUT_OF_MEMORY: 0x0505,
+    INVALID_FRAMEBUFFER_OPERATION: 0x0506,
+    CONTEXT_LOST_WEBGL: 0x9242,
+    errors: [],
+    waitResults: [],
+    lost: false,
+  };
+  class FakeCanvas extends EventTarget {
+    width = options.width ?? 64;
+    height = options.height ?? 32;
+    requests = [];
+    listeners = new Set();
+    getContext(kind, attributes) {
+      this.requests.push({ kind, attributes });
+      if (options.acquisitionError) throw options.acquisitionError;
+      return options.unavailable ? null : gl;
+    }
+    addEventListener(type, callback, ...rest) {
+      this.listeners.add(callback);
+      super.addEventListener(type, callback, ...rest);
+    }
+    removeEventListener(type, callback, ...rest) {
+      this.listeners.delete(callback);
+      super.removeEventListener(type, callback, ...rest);
+    }
+  }
+  const canvas = new FakeCanvas();
+  const emitLoss = (message = "driver reset") => {
+    gl.lost = true;
+    const event = new Event("webglcontextlost");
+    Object.defineProperty(event, "statusMessage", { value: message });
+    canvas.dispatchEvent(event);
+  };
+  const record = (name, implementation = () => {}) => {
+    gl[name] = (...args) => {
+      calls.push({ name, args });
+      if (gl.throwOn === name) throw new Error(`${name} threw`);
+      const result = implementation(...args);
+      if (gl.errorOn === name) gl.errors.push(gl.errorCode ?? gl.INVALID_OPERATION);
+      return result;
+    };
+  };
+  const allocate = (kind, extra = {}) => {
+    if (options.nullResource === kind || gl.nullResource === kind) return null;
+    const handle = { kind, id: ++nextId, ...extra };
+    live.add(handle);
+    return handle;
+  };
+  for (const name of [
+    "shaderSource", "compileShader", "attachShader", "detachShader", "linkProgram", "useProgram",
+    "uniform1i", "uniform2f", "activeTexture", "bindVertexArray", "bindBuffer",
+    "enableVertexAttribArray", "vertexAttribDivisor", "enable", "disable",
+    "blendEquationSeparate", "blendFuncSeparate", "viewport", "bindTexture", "pixelStorei",
+    "texParameteri", "texImage2D", "texSubImage2D", "bufferData", "bufferSubData",
+    "clearColor", "clear", "vertexAttribPointer", "drawArraysInstanced", "flush",
+  ]) record(name);
+  record("createShader", type => allocate("shader", { type }));
+  record("createProgram", () => allocate("program"));
+  record("createBuffer", () => allocate("buffer"));
+  record("createVertexArray", () => allocate("vertexArray"));
+  record("createTexture", () => allocate("texture"));
+  record("fenceSync", () => allocate("sync"));
+  for (const name of ["deleteShader", "deleteProgram", "deleteBuffer", "deleteVertexArray", "deleteTexture", "deleteSync"]) {
+    record(name, handle => live.delete(handle));
+  }
+  record("getShaderParameter", shader => options.compileFailure !== shader.type);
+  record("getShaderInfoLog", () => "test shader diagnostic");
+  record("getProgramParameter", () => !options.linkFailure);
+  record("getProgramInfoLog", () => "test link diagnostic");
+  record("getUniformLocation", (_program, name) => options.missingUniform === name ? null : { name });
+  record("getParameter", parameter => {
+    if (parameter === gl.MAX_TEXTURE_SIZE) return options.textureLimit ?? 8192;
+    if (parameter === gl.MAX_RENDERBUFFER_SIZE) return options.renderbufferLimit ?? 8192;
+    if (parameter === gl.MAX_VIEWPORT_DIMS) return new Int32Array(options.viewportLimit ?? [8192, 8192]);
+    assert.fail(`Unexpected parameter: ${parameter}`);
+  });
+  record("getError", () => gl.errors.shift() ?? gl.NO_ERROR);
+  record("isContextLost", () => gl.lost);
+  record("clientWaitSync", () => gl.waitResults.shift() ?? gl.waitResult ?? gl.ALREADY_SIGNALED);
+  record("loseContext", () => emitLoss("intentional disposal"));
+  record("getExtension", name => {
+    assert.equal(name, "WEBGL_lose_context");
+    return options.noLoseExtension ? null : { loseContext: gl.loseContext };
+  });
+  Object.defineProperties(gl, {
+    drawingBufferWidth: { get: () => gl.bufferWidth ?? canvas.width },
+    drawingBufferHeight: { get: () => gl.bufferHeight ?? canvas.height },
+  });
+  const fatalErrors = [];
+  return {
+    gl, canvas, live, calls, fatalErrors, emitLoss,
+    onFatal: error => fatalErrors.push(error),
+    callsFor: name => calls.filter(call => call.name === name).map(call => call.args),
+  };
+}
+
+test("Create_NullContext_IsUnavailableWithoutAllocatingResources", async () => {
+  const h = harness({ unavailable: true });
+  await assert.rejects(WebGl2Backend.create(h.canvas, h.onFatal), RendererUnavailableError);
+  assert.equal(h.live.size, 0);
+  assert.equal(h.canvas.listeners.size, 0);
+});
+
+test("Create_UnexpectedAcquisitionError_IsNotACapabilityFailure", async () => {
+  const error = new TypeError("unexpected context failure");
+  const h = harness({ acquisitionError: error });
+  await assert.rejects(WebGl2Backend.create(h.canvas, h.onFatal), actual => actual === error);
+});
+
+test("Create_OpaqueCanvas_UsesStraightAlphaBlendingAndTopDownShaders", async t => {
+  const h = harness();
+  const backend = await WebGl2Backend.create(h.canvas, h.onFatal);
+  t.after(() => backend.dispose());
+  const gl = h.gl;
+  assert.equal(backend.kind, "webgl2");
+  assert.equal(backend.gl, gl);
+  assert.deepEqual(h.canvas.requests, [{
+    kind: "webgl2",
+    attributes: {
+      alpha: false, antialias: false, depth: false, stencil: false,
+      premultipliedAlpha: false, preserveDrawingBuffer: false,
+    },
+  }]);
+  assert.deepEqual(h.callsFor("blendFuncSeparate"), [[gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA]]);
+  assert.deepEqual(h.callsFor("blendEquationSeparate"), [[gl.FUNC_ADD, gl.FUNC_ADD]]);
+  assert.deepEqual(h.callsFor("enable"), [[gl.BLEND]]);
+  assert.ok(h.callsFor("disable").some(([flag]) => flag === gl.DITHER));
+  assert.deepEqual(h.callsFor("vertexAttribDivisor"), [[0, 1], [1, 1], [2, 1], [3, 1]]);
+  assert.deepEqual(h.callsFor("enableVertexAttribArray"), [[0], [1], [2], [3]]);
+  const [vertex, fragment] = h.callsFor("shaderSource").map(([, source]) => source);
+  for (const source of [vertex, fragment]) {
+    assert.match(source, /^#version 300 es/);
+    assert.match(source, /precision highp float/);
+    assert.match(source, /precision highp int/);
+  }
+  assert.match(vertex, /corners\[gl_VertexID\]/);
+  assert.match(vertex, /position \/ viewport \* vec2\(2, -2\) \+ vec2\(-1, 1\)/);
+  assert.match(vertex, /mix\(uvRect.xy, uvRect.zw, corner\)/);
+  assert.match(fragment, /textureLod\(image, fragmentUv, 0.0\)/);
+  assert.match(fragment, /fragmentTint.a \* texel.a/);
+  assert.match(fragment, /fragmentColor = texel \* fragmentTint/);
+  assert.equal(h.callsFor("deleteShader").length, 2);
+});
+
+test("Create_CompileAndLinkFailures_ReportDiagnosticsAndFreePartialResources", async () => {
+  const shaderTypes = harness().gl;
+  for (const options of [
+    { compileFailure: shaderTypes.VERTEX_SHADER },
+    { compileFailure: shaderTypes.FRAGMENT_SHADER },
+    { linkFailure: true },
+  ]) {
+    const h = harness(options);
+    await assert.rejects(WebGl2Backend.create(h.canvas, h.onFatal), error => {
+      assert.ok(error instanceof Error);
+      assert.ok(!(error instanceof RendererUnavailableError));
+      assert.match(error.message, /test (shader|link) diagnostic/);
+      return true;
+    });
+    assert.equal(h.live.size, 0);
+    assert.equal(h.canvas.listeners.size, 0);
+    assert.equal(h.callsFor("loseContext").length, 1);
+    assert.deepEqual(h.fatalErrors, []);
+  }
+});
+
+test("Create_AllocationOrUniformFailures_FreeEarlierResources", async () => {
+  for (const options of [
+    { nullResource: "shader" }, { nullResource: "program" }, { nullResource: "buffer" },
+    { nullResource: "vertexArray" }, { missingUniform: "viewport" }, { missingUniform: "image" },
+  ]) {
+    const h = harness(options);
+    await assert.rejects(WebGl2Backend.create(h.canvas, h.onFatal), error =>
+      error instanceof Error && !(error instanceof RendererUnavailableError));
+    assert.equal(h.live.size, 0);
+    assert.equal(h.canvas.listeners.size, 0);
+    assert.deepEqual(h.fatalErrors, []);
+  }
+});
+
+test("Create_GLInitializationError_DisposesContextWithoutFatalCallback", async () => {
+  const h = harness();
+  h.gl.errorOn = "blendFuncSeparate";
+  h.gl.errorCode = h.gl.INVALID_ENUM;
+  await assert.rejects(WebGl2Backend.create(h.canvas, h.onFatal), /INVALID_ENUM/);
+  assert.equal(h.live.size, 0);
+  assert.equal(h.canvas.listeners.size, 0);
+  assert.deepEqual(h.fatalErrors, []);
+});
+
+test("CreateTexture_EmptyAtlas_IsZeroInitializedLinearRgba8WithClampedEdges", async t => {
+  const h = harness();
+  const backend = await WebGl2Backend.create(h.canvas, h.onFatal);
+  t.after(() => backend.dispose());
+  const gl = h.gl;
+  const resource = backend.createTexture(17, 13, "Glyph atlas");
+  assert.equal(resource.width, 17);
+  assert.equal(resource.height, 13);
+  assert.deepEqual(h.callsFor("texImage2D"), [[gl.TEXTURE_2D, 0, gl.RGBA8, 17, 13, 0, gl.RGBA, gl.UNSIGNED_BYTE, null]]);
+  assert.deepEqual(h.callsFor("texParameteri"), [
+    [gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR],
+    [gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR],
+    [gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE],
+    [gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE],
+  ]);
+  assert.equal(h.callsFor("texSubImage2D").length, 0);
+});
+
+test("TextureUploads_RgbaRowsAndBitmaps_PreserveStraightAlphaAndTopDownOrientation", async t => {
+  const h = harness();
+  const backend = await WebGl2Backend.create(h.canvas, h.onFatal);
+  t.after(() => backend.dispose());
+  const gl = h.gl;
+  const resource = backend.createTexture(4, 5, "Image");
+  const errorChecks = h.callsFor("getError").length;
+  const pixels = new Uint8Array([200, 100, 50, 128, 10, 20, 30, 64, 1, 2, 3, 0, 9, 8, 7, 255]);
+  resource.writePixels(pixels, 2, 2, 1, 3);
+  const bitmap = { width: 4, height: 5 };
+  resource.writeBitmap(bitmap);
+  const clamped = new Uint8ClampedArray([20, 30, 40, 127]);
+  resource.writePixels(clamped, 1, 1);
+  assert.deepEqual(h.callsFor("texSubImage2D"), [
+    [gl.TEXTURE_2D, 0, 1, 3, 2, 2, gl.RGBA, gl.UNSIGNED_BYTE, pixels],
+    [gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, bitmap],
+    [gl.TEXTURE_2D, 0, 0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, clamped],
+  ]);
+  assert.equal(h.callsFor("texSubImage2D")[0].at(-1), pixels);
+  assert.equal(h.callsFor("texSubImage2D")[1].at(-1), bitmap);
+  const unpackState = [
+    [gl.UNPACK_ALIGNMENT, 1],
+    [gl.UNPACK_FLIP_Y_WEBGL, false],
+    [gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false],
+    [gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE],
+    [gl.UNPACK_ROW_LENGTH, 0],
+    [gl.UNPACK_SKIP_PIXELS, 0],
+    [gl.UNPACK_SKIP_ROWS, 0],
+  ];
+  assert.deepEqual(h.callsFor("pixelStorei"), Array.from({ length: 4 }, () => unpackState).flat());
+  assert.equal(h.callsFor("getError").length, errorChecks, "Do not synchronize GL errors per glyph upload");
+});
+
+test("CreateTexture_InvalidDimensions_AreRejectedBeforeAllocation", async t => {
+  const h = harness({ textureLimit: 256 });
+  const backend = await WebGl2Backend.create(h.canvas, h.onFatal);
+  t.after(() => backend.dispose());
+  for (const [width, height] of [[0, 1], [-1, 2], [1.5, 2], [1, NaN], [Infinity, 1], [257, 1], [1, 257]]) {
+    assert.throws(() => backend.createTexture(width, height, "Test atlas"), /Test atlas.*dimensions|Test atlas.*limit/);
+  }
+  assert.equal(h.callsFor("createTexture").length, 0);
+  const resource = backend.createTexture(256, 256, "Maximum atlas");
+  assert.equal(resource.width, 256);
+});
+
+test("TextureUploads_InvalidRegionsAndDestroyedTextures_AreRejected", async t => {
+  const h = harness();
+  const backend = await WebGl2Backend.create(h.canvas, h.onFatal);
+  t.after(() => backend.dispose());
+  const resource = backend.createTexture(2, 2, "Image");
+  const pixels = new Uint8Array(16);
+  for (const dimensions of [[3, 2], [2, 2, 1, 0], [2, 2, 0, -1], [0, 1], [1, 1, 0.5, 0]]) {
+    assert.throws(() => resource.writePixels(pixels, ...dimensions), /Invalid WebGL2 texture upload/);
+  }
+  assert.throws(() => resource.writePixels(new Uint8Array(3), 1, 1), /pixel data/);
+  assert.throws(() => resource.writeBitmap({ width: 3, height: 2 }), /bitmap dimensions/);
+  resource.destroy();
+  resource.destroy();
+  assert.throws(() => resource.writePixels(pixels, 2, 2), /destroyed/);
+  assert.throws(() => resource.writeBitmap({ width: 2, height: 2 }), /destroyed/);
+  assert.equal(h.callsFor("texSubImage2D").length, 0);
+  assert.equal(h.callsFor("deleteTexture").length, 1);
+});
+
+test("CreateTexture_NullAllocationAndStorageErrors_DoNotLeakTextureHandles", async t => {
+  const h = harness();
+  const backend = await WebGl2Backend.create(h.canvas, h.onFatal);
+  t.after(() => backend.dispose());
+  const originalResources = h.live.size;
+  h.gl.nullResource = "texture";
+  assert.throws(() => backend.createTexture(1, 1, "Image"), /Could not allocate WebGL2 texture/);
+  delete h.gl.nullResource;
+  h.gl.errorOn = "texImage2D";
+  h.gl.errorCode = h.gl.OUT_OF_MEMORY;
+  assert.throws(() => backend.createTexture(16, 16, "Image"), /OUT_OF_MEMORY/);
+  assert.equal(h.live.size, originalResources);
+  delete h.gl.errorOn;
+  h.gl.throwOn = "texParameteri";
+  assert.throws(() => backend.createTexture(16, 16, "Image"), /texParameteri threw/);
+  assert.equal(h.live.size, originalResources);
+  assert.equal(h.callsFor("deleteTexture").length, 2);
+});
+
+test("Resize_LimitsIncludeTextureRenderbufferAndBothViewportAxes", async () => {
+  for (const limits of [
+    { textureLimit: 512 },
+    { renderbufferLimit: 512 },
+    { viewportLimit: [512, 2048] },
+    { viewportLimit: [2048, 512] },
+  ]) {
+    const h = harness(limits);
+    const backend = await WebGl2Backend.create(h.canvas, h.onFatal);
+    try {
+      assert.equal(backend.maxTextureDimension2D, limits.textureLimit ?? 8192);
+      assert.equal(backend.maxCanvasDimension2D, 512);
+      h.canvas.width = 512;
+      h.canvas.height = 256;
+      backend.resize(20000, 10000);
+      assert.deepEqual(h.callsFor("viewport").at(-1), [0, 0, 512, 256]);
+      assert.deepEqual(h.callsFor("uniform2f").at(-1), [{ name: "viewport" }, 20000, 10000]);
+      h.canvas.width = 513;
+      assert.throws(() => backend.resize(20000, 10000), /drawing buffer dimension limit/);
+      h.canvas.width = 256;
+      h.canvas.height = 513;
+      assert.throws(() => backend.resize(20000, 10000), /drawing buffer dimension limit/);
+    } finally {
+      backend.dispose();
+    }
+  }
+});
+
+test("Resize_InvalidLogicalDimensionsAndUndersizedDrawingBuffer_SurfaceErrors", async t => {
+  const h = harness();
+  const backend = await WebGl2Backend.create(h.canvas, h.onFatal);
+  t.after(() => backend.dispose());
+  for (const dimensions of [[0, 1], [1, -1], [NaN, 1], [1, Infinity]]) {
+    assert.throws(() => backend.resize(...dimensions), /logical viewport dimensions/);
+  }
+  h.gl.bufferWidth = h.canvas.width - 1;
+  assert.throws(() => backend.resize(640, 320), /could not allocate.*drawing buffer/);
+  delete h.gl.bufferWidth;
+  h.canvas.width = 0;
+  assert.throws(() => backend.resize(640, 320), /drawing buffer dimension limit/);
+});
+
+test("Submit_OrderedBatches_RebaseEveryAttributeWithoutBaseInstance", async t => {
+  const h = harness();
+  const backend = await WebGl2Backend.create(h.canvas, h.onFatal);
+  t.after(() => backend.dispose());
+  const gl = h.gl;
+  const atlas = backend.createTexture(1, 1, "Atlas");
+  const image = backend.createTexture(1, 1, "Image");
+  const instances = new Float32Array(8 * QUAD_STRIDE);
+  const batches = [
+    { resource: atlas, start: 0, count: 2 },
+    { resource: image, start: 2, count: 3 },
+    { resource: atlas, start: 5, count: 1 },
+  ];
+  const start = h.calls.length;
+  backend.submit(instances, 6, batches, [0.1, 0.2, 0.3, 0.4]);
+  assert.deepEqual(h.callsFor("vertexAttribPointer"), [0, 2, 5].flatMap(base => [
+    [0, 4, gl.FLOAT, false, 64, base * 64],
+    [1, 4, gl.FLOAT, false, 64, base * 64 + 16],
+    [2, 4, gl.FLOAT, false, 64, base * 64 + 32],
+    [3, 1, gl.FLOAT, false, 64, base * 64 + 48],
+  ]));
+  assert.deepEqual(h.callsFor("drawArraysInstanced"), [
+    [gl.TRIANGLES, 0, 6, 2], [gl.TRIANGLES, 0, 6, 3], [gl.TRIANGLES, 0, 6, 1],
+  ]);
+  const [atlasHandle, imageHandle] = h.callsFor("texImage2D").map((_, i) => h.callsFor("bindTexture")[i][1]);
+  assert.deepEqual(h.calls.slice(start).filter(call => call.name === "bindTexture").map(call => call.args[1]),
+    [atlasHandle, imageHandle, atlasHandle]);
+  assert.deepEqual(h.callsFor("clearColor"), [[0.1, 0.2, 0.3, 1]]);
+  assert.deepEqual(h.callsFor("bufferSubData"), [[gl.ARRAY_BUFFER, 0, instances, 0, 6 * QUAD_STRIDE]]);
+  assert.equal(h.callsFor("bufferSubData")[0][2], instances);
+});
+
+test("Submit_BufferGrowth_UsesSharedArrayCapacityAndOnlyUploadsUsedInstances", async t => {
+  const h = harness();
+  const backend = await WebGl2Backend.create(h.canvas, h.onFatal);
+  t.after(() => backend.dispose());
+  const small = new Float32Array(8 * QUAD_STRIDE);
+  const large = new Float32Array(32 * QUAD_STRIDE);
+  backend.submit(small, 1, [], [0, 0, 0, 1]);
+  assert.equal(backend.instanceBufferBytes, small.byteLength);
+  backend.submit(large, 8, [], [0, 0, 0, 1]);
+  assert.equal(backend.instanceBufferBytes, small.byteLength);
+  backend.submit(large, 9, [], [0, 0, 0, 1]);
+  assert.equal(backend.instanceBufferBytes, large.byteLength);
+  backend.submit(small, 1, [], [0, 0, 0, 1]);
+  assert.equal(backend.instanceBufferBytes, large.byteLength);
+  assert.deepEqual(h.callsFor("bufferData").map(([, bytes]) => bytes), [small.byteLength, large.byteLength]);
+  assert.deepEqual(h.callsFor("bufferSubData").map(args => args.at(-1)), [16, 128, 144, 16]);
+});
+
+test("Submit_EmptyFrame_ClearsOpaqueWithoutUploadingOrDrawing", async t => {
+  const h = harness();
+  const backend = await WebGl2Backend.create(h.canvas, h.onFatal);
+  t.after(() => backend.dispose());
+  backend.submit(new Float32Array(), 0, [], [0.2, 0.4, 0.6, 0]);
+  assert.equal(backend.instanceBufferBytes, 256);
+  assert.deepEqual(h.callsFor("clearColor"), [[0.2, 0.4, 0.6, 1]]);
+  assert.deepEqual(h.callsFor("clear"), [[h.gl.COLOR_BUFFER_BIT]]);
+  assert.equal(h.callsFor("bufferSubData").length, 0);
+  assert.equal(h.callsFor("drawArraysInstanced").length, 0);
+});
+
+test("Submit_ForeignOrDestroyedTextures_AreRejectedBeforeDrawing", async t => {
+  const h = harness();
+  const other = harness();
+  const backend = await WebGl2Backend.create(h.canvas, h.onFatal);
+  const otherBackend = await WebGl2Backend.create(other.canvas, other.onFatal);
+  t.after(() => { backend.dispose(); otherBackend.dispose(); });
+  const instances = new Float32Array(QUAD_STRIDE);
+  const foreign = otherBackend.createTexture(1, 1, "Other context");
+  for (const resource of [{}, foreign]) {
+    assert.throws(() => backend.submit(instances, 1, [{ resource, start: 0, count: 1 }], [0, 0, 0, 1]),
+      /different rendering backend/);
+  }
+  const resource = backend.createTexture(1, 1, "Image");
+  resource.destroy();
+  assert.throws(() => backend.submit(instances, 1, [{ resource, start: 0, count: 1 }], [0, 0, 0, 1]), /destroyed/);
+  assert.equal(h.callsFor("drawArraysInstanced").length, 0);
+});
+
+test("Submit_InvalidInstanceAndBatchRanges_AreRejected", async t => {
+  const h = harness();
+  const backend = await WebGl2Backend.create(h.canvas, h.onFatal);
+  t.after(() => backend.dispose());
+  const instances = new Float32Array(QUAD_STRIDE);
+  const resource = backend.createTexture(1, 1, "Atlas");
+  for (const count of [-1, 0.5, NaN, Infinity, 2]) {
+    assert.throws(() => backend.submit(instances, count, [], [0, 0, 0, 1]), /instance data/);
+  }
+  for (const [start, count] of [[-1, 1], [0, -1], [0, 2], [1, 1], [0.5, 0], [NaN, 1], [0, Infinity]]) {
+    assert.throws(() => backend.submit(instances, 1, [{ resource, start, count }], [0, 0, 0, 1]), /batch instance range/);
+  }
+  backend.submit(instances, 1, [{ resource, start: 1, count: 0 }], [0, 0, 0, 1]);
+  assert.equal(h.callsFor("drawArraysInstanced").length, 0);
+});
+
+test("Submit_DeferredUploadAndDrawErrors_SurfaceAtFrameBoundary", async t => {
+  const h = harness();
+  const backend = await WebGl2Backend.create(h.canvas, h.onFatal);
+  t.after(() => backend.dispose());
+  const resource = backend.createTexture(1, 1, "Atlas");
+  const instances = new Float32Array(QUAD_STRIDE);
+  const batch = { resource, start: 0, count: 1 };
+  backend.submit(instances, 1, [batch], [0, 0, 0, 1]);
+  h.gl.errorOn = "texSubImage2D";
+  resource.writePixels(new Uint8Array(4), 1, 1);
+  assert.throws(() => backend.submit(instances, 1, [batch], [0, 0, 0, 1]), /frame submission failed: INVALID_OPERATION/);
+  h.gl.errorOn = "drawArraysInstanced";
+  h.gl.errorCode = h.gl.INVALID_FRAMEBUFFER_OPERATION;
+  assert.throws(() => backend.submit(instances, 1, [batch], [0, 0, 0, 1]), /INVALID_FRAMEBUFFER_OPERATION/);
+});
+
+test("Submit_BufferAllocationError_DoesNotReportUnallocatedCapacity", async t => {
+  const h = harness();
+  const backend = await WebGl2Backend.create(h.canvas, h.onFatal);
+  t.after(() => backend.dispose());
+  h.gl.errorOn = "bufferData";
+  h.gl.errorCode = h.gl.OUT_OF_MEMORY;
+  assert.throws(() => backend.submit(new Float32Array(QUAD_STRIDE), 1, [], [0, 0, 0, 1]), /OUT_OF_MEMORY/);
+  assert.equal(backend.instanceBufferBytes, 0);
+  assert.equal(h.callsFor("drawArraysInstanced").length, 0);
+});
+
+test("Idle_CompletedFence_FlushesAndDeletesSyncWithoutBlocking", async t => {
+  const h = harness();
+  const backend = await WebGl2Backend.create(h.canvas, h.onFatal);
+  t.after(() => backend.dispose());
+  for (const result of [h.gl.ALREADY_SIGNALED, h.gl.CONDITION_SATISFIED]) {
+    h.gl.waitResults.push(result);
+    await backend.idle();
+  }
+  assert.deepEqual(h.callsFor("fenceSync"), [
+    [h.gl.SYNC_GPU_COMMANDS_COMPLETE, 0], [h.gl.SYNC_GPU_COMMANDS_COMPLETE, 0],
+  ]);
+  assert.equal(h.callsFor("flush").length, 2);
+  assert.equal(h.callsFor("deleteSync").length, 2);
+  for (const [, flags, timeout] of h.callsFor("clientWaitSync")) {
+    assert.equal(flags, 0);
+    assert.equal(timeout, 0);
+  }
+  assert.equal(h.callsFor("finish").length, 0);
+  assert.ok(![...h.live].some(resource => resource.kind === "sync"));
+});
+
+test("Idle_UnsignaledFence_YieldsToEventLoopAndMaintainsBackpressure", async t => {
+  const h = harness();
+  const backend = await WebGl2Backend.create(h.canvas, h.onFatal);
+  t.after(() => backend.dispose());
+  h.gl.waitResult = h.gl.TIMEOUT_EXPIRED;
+  let completed = false;
+  const idle = backend.idle().then(() => { completed = true; });
+  await Promise.resolve();
+  assert.equal(completed, false, "A resolved promise is not GPU completion");
+  assert.equal(h.callsFor("deleteSync").length, 0);
+  assert.equal(h.callsFor("clientWaitSync").length, 1);
+  h.gl.waitResult = h.gl.CONDITION_SATISFIED;
+  await idle;
+  assert.equal(completed, true);
+  assert.equal(h.callsFor("clientWaitSync").length, 2);
+  assert.equal(h.callsFor("deleteSync").length, 1);
+  assert.ok(h.callsFor("clientWaitSync").every(([, flags, timeout]) => flags === 0 && timeout === 0));
+});
+
+test("Idle_ConcurrentWaits_CompleteAndDeleteTheirOwnFences", async t => {
+  const h = harness();
+  const backend = await WebGl2Backend.create(h.canvas, h.onFatal);
+  t.after(() => backend.dispose());
+  h.gl.waitResult = h.gl.TIMEOUT_EXPIRED;
+  const first = backend.idle();
+  const second = backend.idle();
+  assert.equal(h.callsFor("fenceSync").length, 2);
+  h.gl.waitResult = h.gl.ALREADY_SIGNALED;
+  await Promise.all([first, second]);
+  const deleted = h.callsFor("deleteSync").map(([sync]) => sync);
+  assert.equal(new Set(deleted).size, 2);
+  assert.ok(deleted.every(sync => !h.live.has(sync)));
+});
+
+test("Idle_NullFenceAndFailedWait_RejectWithoutSyncLeaks", async t => {
+  const h = harness();
+  const backend = await WebGl2Backend.create(h.canvas, h.onFatal);
+  t.after(() => backend.dispose());
+  h.gl.nullResource = "sync";
+  await assert.rejects(backend.idle(), /Could not allocate.*GPU fence/);
+  delete h.gl.nullResource;
+  h.gl.waitResult = h.gl.WAIT_FAILED;
+  await assert.rejects(backend.idle(), /GPU fence wait failed/);
+  assert.equal(h.callsFor("deleteSync").length, 1);
+  assert.ok(![...h.live].some(resource => resource.kind === "sync"));
+});
+
+test("Idle_UploadOrFenceErrors_RejectAndFreeAllocatedSyncs", async t => {
+  const h = harness();
+  const backend = await WebGl2Backend.create(h.canvas, h.onFatal);
+  t.after(() => backend.dispose());
+  h.gl.errors.push(h.gl.INVALID_VALUE);
+  await assert.rejects(backend.idle(), /INVALID_VALUE/);
+  assert.equal(h.callsFor("fenceSync").length, 0);
+  h.gl.errorOn = "flush";
+  await assert.rejects(backend.idle(), /GPU fence submission failed: INVALID_OPERATION/);
+  delete h.gl.errorOn;
+  h.gl.throwOn = "flush";
+  await assert.rejects(backend.idle(), /flush threw/);
+  delete h.gl.throwOn;
+  h.gl.waitResult = h.gl.WAIT_FAILED;
+  h.gl.errorOn = "clientWaitSync";
+  await assert.rejects(backend.idle(), /GPU fence wait failed: INVALID_OPERATION/);
+  assert.equal(h.callsFor("deleteSync").length, 3);
+  assert.ok(![...h.live].some(resource => resource.kind === "sync"));
+});
+
+test("Idle_ErrorDuringPendingCompletion_IsNotSilentlyIgnored", async t => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const h = harness();
+  const backend = await WebGl2Backend.create(h.canvas, h.onFatal);
+  t.after(() => backend.dispose());
+  h.gl.waitResults.push(h.gl.TIMEOUT_EXPIRED, h.gl.ALREADY_SIGNALED);
+  const idle = backend.idle();
+  const rejected = assert.rejects(idle, /OUT_OF_MEMORY/);
+  h.gl.errors.push(h.gl.OUT_OF_MEMORY);
+  t.mock.timers.tick(1);
+  await rejected;
+  assert.equal(h.callsFor("deleteSync").length, 1);
+});
+
+test("Dispose_PendingIdle_RejectsAllWaitsAndCancelsTheirTimers", async t => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const h = harness();
+  const backend = await WebGl2Backend.create(h.canvas, h.onFatal);
+  h.gl.waitResult = h.gl.TIMEOUT_EXPIRED;
+  const first = assert.rejects(backend.idle(), /disposed/);
+  const second = assert.rejects(backend.idle(), /disposed/);
+  backend.dispose();
+  await Promise.all([first, second]);
+  const polls = h.callsFor("clientWaitSync").length;
+  t.mock.timers.tick(100);
+  assert.equal(h.callsFor("clientWaitSync").length, polls);
+  assert.equal(h.callsFor("deleteSync").length, 2);
+  assert.equal(h.live.size, 0);
+  assert.deepEqual(h.fatalErrors, []);
+});
+
+test("ContextLoss_PendingIdle_ReportsFatalOnceAndCancelsTimersWithoutFallback", async t => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const h = harness();
+  const backend = await WebGl2Backend.create(h.canvas, h.onFatal);
+  t.after(() => backend.dispose());
+  h.gl.waitResult = h.gl.TIMEOUT_EXPIRED;
+  const idle = assert.rejects(backend.idle(), /context lost: driver reset/);
+  h.emitLoss();
+  h.emitLoss("second notification");
+  await idle;
+  t.mock.timers.tick(100);
+  assert.equal(h.fatalErrors.length, 1);
+  assert.match(h.fatalErrors[0].message, /context lost: driver reset/);
+  assert.equal(h.callsFor("clientWaitSync").length, 1);
+  assert.equal(h.callsFor("deleteSync").length, 1);
+  assert.equal(h.canvas.requests.length, 1);
+  assert.throws(() => backend.createTexture(1, 1, "Image"), error => error === h.fatalErrors[0]);
+  assert.throws(() => backend.submit(new Float32Array(), 0, [], [0, 0, 0, 1]), /context lost/);
+  assert.throws(() => backend.resize(640, 320), /context lost/);
+  await assert.rejects(backend.idle(), /context lost/);
+});
+
+test("ContextLoss_BeforeLossEvent_IsDetectedByFencePolling", async t => {
+  t.mock.timers.enable({ apis: ["setTimeout"] });
+  const h = harness();
+  const backend = await WebGl2Backend.create(h.canvas, h.onFatal);
+  t.after(() => backend.dispose());
+  h.gl.waitResult = h.gl.TIMEOUT_EXPIRED;
+  const idle = assert.rejects(backend.idle(), /context lost/);
+  h.gl.lost = true;
+  t.mock.timers.tick(1);
+  await idle;
+  h.emitLoss();
+  t.mock.timers.tick(100);
+  assert.equal(h.fatalErrors.length, 1);
+  assert.equal(h.callsFor("clientWaitSync").length, 1);
+  assert.equal(h.callsFor("deleteSync").length, 1);
+});
+
+test("ContextLoss_GLErrorCode_ReportsFatalBeforeTheEvent", async t => {
+  const h = harness();
+  const backend = await WebGl2Backend.create(h.canvas, h.onFatal);
+  t.after(() => backend.dispose());
+  h.gl.errors.push(h.gl.CONTEXT_LOST_WEBGL);
+  await assert.rejects(backend.idle(), /context lost/);
+  h.emitLoss();
+  assert.equal(h.fatalErrors.length, 1);
+  assert.equal(h.callsFor("fenceSync").length, 0);
+});
+
+test("Dispose_RepeatedDisposal_FreesOwnedResourcesAndSuppressesIntentionalLoss", async () => {
+  const h = harness();
+  const backend = await WebGl2Backend.create(h.canvas, h.onFatal);
+  const first = backend.createTexture(1, 1, "First");
+  const second = backend.createTexture(1, 1, "Second");
+  first.destroy();
+  backend.submit(new Float32Array(QUAD_STRIDE), 1, [{ resource: second, start: 0, count: 1 }], [0, 0, 0, 1]);
+  backend.dispose();
+  backend.dispose();
+  second.destroy();
+  h.emitLoss();
+  assert.equal(h.live.size, 0);
+  assert.equal(backend.instanceBufferBytes, 0);
+  assert.equal(h.callsFor("deleteShader").length, 2);
+  assert.equal(h.callsFor("deleteProgram").length, 1);
+  assert.equal(h.callsFor("deleteBuffer").length, 1);
+  assert.equal(h.callsFor("deleteVertexArray").length, 1);
+  assert.equal(h.callsFor("deleteTexture").length, 2);
+  assert.equal(h.callsFor("loseContext").length, 1);
+  assert.equal(h.canvas.listeners.size, 0);
+  assert.deepEqual(h.fatalErrors, []);
+  assert.throws(() => backend.createTexture(1, 1, "Image"), /disposed/);
+  assert.throws(() => second.writePixels(new Uint8Array(4), 1, 1), /disposed/);
+  assert.throws(() => backend.resize(640, 320), /disposed/);
+  assert.throws(() => backend.submit(new Float32Array(), 0, [], [0, 0, 0, 1]), /disposed/);
+  await assert.rejects(backend.idle(), /disposed/);
+});
+
+test("Dispose_MissingLoseContextExtension_StillFreesAllResources", async () => {
+  const h = harness({ noLoseExtension: true });
+  const backend = await WebGl2Backend.create(h.canvas, h.onFatal);
+  backend.dispose();
+  assert.equal(h.live.size, 0);
+  assert.equal(h.canvas.listeners.size, 0);
+  assert.deepEqual(h.fatalErrors, []);
+});


### PR DESCRIPTION
WebGPU requires HTTPS or a trustworthy local origin, which unnecessarily limits where the web terminal can render. This adds WebGL2 as a compatibility backend while retaining WebGPU as the default preference.

## Approach

- Add `renderer: "auto" | "webgpu" | "webgl2"` to mount options. Auto prefers WebGPU and falls back for capability/device acquisition failures; explicit choices never silently switch.
- Share glyph rasterization, atlas management, frame preparation, clipping, and image ordering. Backends own graphics resources, draw submission, and GPU completion/backpressure.
- Expose the active renderer and fallback reason in stats, and add renderer selection and diagnostics to the demo.
- Update deployment and configuration documentation for both backends.

Shader, font, unexpected initialization, and runtime GPU errors remain errors rather than fallback triggers. Rendering over HTTP does not change transport security or the demo host's loopback-only access policy. Preferring WebGPU is not a performance claim.

## Coverage

Package regressions cover selection, diagnostics, resource lifetime, context loss, and asynchronous WebGL2 fences. Browser fixtures compare both backends across raster scales, exercise ordinary-HTTP workers with mocked socket transport, and run real Sixel/KGP/animation workloads in mixed-backend views. Pixel comparisons account explicitly for native horizontal-edge rasterization ties.

Rebased onto the latest `main` before opening.