### PR TITLE
Preserve OSC 8 hyperlinks in HMP state replay

### DIFF
--- a/docs/muxer-protocol.md
+++ b/docs/muxer-protocol.md
@@ -161,6 +161,11 @@ Sent by the server immediately after the Hello frame. Contains a full snapshot o
 
 The payload may be empty if no screen content is available yet.
 
+Viewport cell hyperlinks are replayed with their OSC 8 destinations and parameters,
+including links spanning rows or wide characters. The active hyperlink is restored
+after painting so subsequent output retains its original link state. Sixel damage
+repaint also preserves cell links without changing that active state.
+
 If the snapshot contains graphics, the server queues KGP and Sixel replay after
 `StateSync` and before subsequent live output. The clear-screen sequence in
 `StateSync` would erase graphics sent before it. Graphics use separate `Output`

--- a/src/Hex1b/Automation/Hex1bTerminalSnapshot.cs
+++ b/src/Hex1b/Automation/Hex1bTerminalSnapshot.cs
@@ -57,6 +57,7 @@ public sealed class Hex1bTerminalSnapshot : IHex1bTerminalRegion, IDisposable
         KgpImages = state.KgpImages;
         SixelPlacements = state.SixelPlacements;
         SixelImages = state.SixelImages;
+        ActiveHyperlink = state.ActiveHyperlink;
 
         var scrollbackRows = state.ScrollbackRows;
         ScrollbackLineCount = scrollbackRows.Length;
@@ -150,6 +151,8 @@ public sealed class Hex1bTerminalSnapshot : IHex1bTerminalRegion, IDisposable
     public DateTimeOffset Timestamp { get; }
 
     internal DateTimeOffset KgpAnimationTimestamp { get; }
+
+    internal HyperlinkData? ActiveHyperlink { get; }
 
     /// <summary>
     /// Whether the terminal was in alternate screen mode at snapshot time.

--- a/src/Hex1b/Automation/Hex1bTerminalSnapshotState.cs
+++ b/src/Hex1b/Automation/Hex1bTerminalSnapshotState.cs
@@ -29,4 +29,5 @@ internal sealed record Hex1bTerminalSnapshotState(
     IReadOnlyList<KgpPlacement> KgpPlacements,
     IReadOnlyDictionary<uint, KgpImageData> KgpImages,
     IReadOnlyList<SixelPlacement> SixelPlacements,
-    IReadOnlyDictionary<byte[], SixelData> SixelImages);
+    IReadOnlyDictionary<byte[], SixelData> SixelImages,
+    HyperlinkData? ActiveHyperlink);

--- a/src/Hex1b/Automation/TerminalRegionAnsiExtensions.cs
+++ b/src/Hex1b/Automation/TerminalRegionAnsiExtensions.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Hex1b.Theming;
+using Hex1b.Tokens;
 
 namespace Hex1b.Automation;
 
@@ -34,7 +35,12 @@ public static class TerminalRegionAnsiExtensions
         return RenderToAnsi(snapshot, options, snapshot.CursorX, snapshot.CursorY);
     }
 
-    private static string RenderToAnsi(IHex1bTerminalRegion region, TerminalAnsiOptions options, int? cursorX, int? cursorY)
+    // Replay preserves OSC 8 without changing the public ANSI export format.
+    internal static string ToAnsi(this Hex1bTerminalSnapshot snapshot, TerminalAnsiOptions options, bool includeHyperlinks)
+        => RenderToAnsi(snapshot, options, snapshot.CursorX, snapshot.CursorY, includeHyperlinks);
+
+    private static string RenderToAnsi(IHex1bTerminalRegion region, TerminalAnsiOptions options, int? cursorX, int? cursorY,
+        bool includeHyperlinks = false)
     {
         var sb = new StringBuilder();
 
@@ -56,6 +62,9 @@ public static class TerminalRegionAnsiExtensions
             sb.Append($"\x1b[{region.Height}A");
         }
 
+        if (includeHyperlinks)
+            sb.Append("\x1b]8;;\x1b\\");
+
         // Group cells by row for efficient row-based rendering
         // Cells are kept in X position order (not sequence order) so that text extraction
         // produces correct results when ANSI escape codes are stripped.
@@ -73,6 +82,7 @@ public static class TerminalRegionAnsiExtensions
         Hex1bColor? currentFg = null;
         Hex1bColor? currentBg = null;
         CellAttributes currentAttrs = CellAttributes.None;
+        HyperlinkData? currentHyperlink = null;
 
         // Render row by row
         for (int row = 0; row < region.Height; row++)
@@ -194,6 +204,15 @@ public static class TerminalRegionAnsiExtensions
                 currentFg = targetFg;
                 currentBg = targetBg;
 
+                var hyperlink = cell.HyperlinkData;
+                if (includeHyperlinks && (hyperlink?.Uri != currentHyperlink?.Uri ||
+                    hyperlink?.Parameters != currentHyperlink?.Parameters))
+                {
+                    sb.Append(AnsiTokenSerializer.Serialize(new OscToken("8",
+                        hyperlink?.Parameters ?? "", hyperlink?.Uri ?? "", UseEscBackslash: true)));
+                    currentHyperlink = hyperlink;
+                }
+
                 // Emit the character (unless hidden, in which case emit space for background)
                 if (isHidden)
                 {
@@ -207,6 +226,9 @@ public static class TerminalRegionAnsiExtensions
                 }
             }
         }
+
+        if (includeHyperlinks && currentHyperlink is not null)
+            sb.Append("\x1b]8;;\x1b\\");
 
         // Reset attributes at the end
         if (options.ResetAtEnd)

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -2040,7 +2040,8 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 kgp.Placements,
                 kgp.Images,
                 sixel.Placements,
-                sixel.Images);
+                sixel.Images,
+                _currentHyperlink?.Data);
         }
     }
 

--- a/src/Hex1b/Hmp1/Hmp1PresentationAdapter.cs
+++ b/src/Hex1b/Hmp1/Hmp1PresentationAdapter.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Text;
+using Hex1b.Tokens;
 using System.Threading.Channels;
 using Hex1b.Automation;
 using Hex1b.Diagnostics;
@@ -364,6 +365,7 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
         IReadOnlyList<KgpPlacement> kgpPlacements;
         IReadOnlyDictionary<uint, KgpImageData> kgpImages;
         DateTimeOffset? kgpAnimationTimestamp;
+        HyperlinkData? activeHyperlink;
         IReadOnlyList<SixelPlacement> sixelPlacements;
         IReadOnlyList<(int Row, int Column, TerminalCell Cell)> sixelDamagedCells;
         int cursorX;
@@ -400,12 +402,13 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
                     // ghosting on every fresh viewer connect or RoleChange-driven
                     // re-StateSync.)
                     IncludeTrailingNewline = false,
-                });
+                }, includeHyperlinks: true);
                 var suffix = BuildStateReplaySuffix(snap);
                 syncBytes = Encoding.UTF8.GetBytes(prefix + ansi + suffix);
                 kgpPlacements = snap.KgpPlacements;
                 kgpImages = snap.KgpImages;
                 kgpAnimationTimestamp = snap.KgpAnimationTimestamp;
+                activeHyperlink = snap.ActiveHyperlink;
                 sixelPlacements = snap.SixelPlacements;
                 sixelDamagedCells = CaptureSixelDamagedCells(snap, sixelPlacements);
                 cursorX = snap.CursorX;
@@ -417,6 +420,7 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
                 kgpPlacements = [];
                 kgpImages = new Dictionary<uint, KgpImageData>();
                 kgpAnimationTimestamp = null;
+                activeHyperlink = null;
                 sixelPlacements = [];
                 sixelDamagedCells = [];
                 cursorX = 0;
@@ -455,7 +459,8 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
                         stream,
                         sixelPlacements,
                         sixelDamagedCells,
-                        session.Cts.Token).ConfigureAwait(false);
+                        session.Cts.Token,
+                        activeHyperlink).ConfigureAwait(false);
                     lock (_sessionsLock)
                     {
                         _lastSixelReplayResult = result;
@@ -603,6 +608,12 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
             sb.Append("\x1b[");
             sb.Append(snapshot.CursorShape);
             sb.Append(" q");
+        }
+
+        if (snapshot.ActiveHyperlink is { } hyperlink)
+        {
+            sb.Append(AnsiTokenSerializer.Serialize(new OscToken("8",
+                hyperlink.Parameters, hyperlink.Uri, UseEscBackslash: true)));
         }
 
         return sb.ToString();

--- a/src/Hex1b/Hmp1/Hmp1SixelStateReplay.cs
+++ b/src/Hex1b/Hmp1/Hmp1SixelStateReplay.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Hex1b.Sixel;
 using Hex1b.Surfaces;
 using Hex1b.Theming;
+using Hex1b.Tokens;
 
 namespace Hex1b;
 
@@ -91,11 +92,13 @@ internal static class Hmp1SixelStateReplay
     /// <param name="placements">The producer's current viewport Sixel placements, captured from the same snapshot as <paramref name="damagedCells"/>.</param>
     /// <param name="damagedCells">Absolute (row, column, cell) triples for every cell any of <paramref name="placements"/> reports as damaged, captured from the same snapshot.</param>
     /// <param name="ct">Cancellation token.</param>
+    /// <param name="activeHyperlink">The captured hyperlink for subsequent producer output.</param>
     internal static async Task<ReplayResult> WriteAsync(
         Stream stream,
         IReadOnlyList<SixelPlacement> placements,
         IReadOnlyList<(int Row, int Column, TerminalCell Cell)> damagedCells,
-        CancellationToken ct)
+        CancellationToken ct,
+        HyperlinkData? activeHyperlink = null)
     {
         if (placements.Count == 0)
             return new ReplayResult(ReplayOutcome.Empty, 0, 0, 0, 0, 0, null);
@@ -170,7 +173,7 @@ internal static class Hmp1SixelStateReplay
         foreach (var (row, column, cell) in damagedCells)
         {
             ct.ThrowIfCancellationRequested();
-            if (!TryAddSequence(BuildDamagePatchSequence(row, column, cell), "damage_payload", out var limit))
+            if (!TryAddSequence(BuildDamagePatchSequence(row, column, cell, activeHyperlink), "damage_payload", out var limit))
             {
                 return new ReplayResult(
                     ReplayOutcome.ResourceLimitExceeded,
@@ -279,7 +282,7 @@ internal static class Hmp1SixelStateReplay
     /// single damaged cell's exact content after its owning placement has
     /// re-blanked it.
     /// </summary>
-    private static string BuildDamagePatchSequence(int row, int column, TerminalCell cell)
+    private static string BuildDamagePatchSequence(int row, int column, TerminalCell cell, HyperlinkData? activeHyperlink)
     {
         var sb = new StringBuilder();
         sb.Append(FormattableString.Invariant($"\x1b[{row + 1};{column + 1}H"));
@@ -308,9 +311,18 @@ internal static class Hmp1SixelStateReplay
         var ch = cell.Character;
         if (!string.IsNullOrEmpty(ch) && ch != "\0" && ch != "\uE000")
         {
+            var hyperlink = cell.HyperlinkData;
+            var hyperlinkChanged = hyperlink?.Uri != activeHyperlink?.Uri ||
+                hyperlink?.Parameters != activeHyperlink?.Parameters;
+            if (hyperlinkChanged)
+                sb.Append(AnsiTokenSerializer.Serialize(new OscToken("8",
+                    hyperlink?.Parameters ?? "", hyperlink?.Uri ?? "", UseEscBackslash: true)));
             sb.Append((attrs & CellAttributes.Hidden) != 0
                 ? new string(' ', DisplayWidth.GetGraphemeWidth(ch))
                 : ch);
+            if (hyperlinkChanged)
+                sb.Append(AnsiTokenSerializer.Serialize(new OscToken("8",
+                    activeHyperlink?.Parameters ?? "", activeHyperlink?.Uri ?? "", UseEscBackslash: true)));
         }
 
         return sb.ToString();

--- a/tests/Hex1b.Tests/Hmp1/Hmp1SixelStateReplayTests.cs
+++ b/tests/Hex1b.Tests/Hmp1/Hmp1SixelStateReplayTests.cs
@@ -141,7 +141,12 @@ public class Hmp1SixelStateReplayTests
     }
 
     [TestMethod]
-    public async Task StateSync_WithDamagedSixelCell_PreservesOverwrittenTextAfterReplay()
+    [DataRow(false, false)]
+    [DataRow(true, false)]
+    [DataRow(false, true)]
+    [DataRow(true, true)]
+    public async Task StateSync_WithDamagedSixelCell_PreservesOverwrittenTextAfterReplay(
+        bool linkedCell, bool activeHyperlink)
     {
         // Regression coverage for the ordering fix: Sixel placement creation
         // blanks its occupied cells (unlike KGP), so the placement-creation
@@ -161,8 +166,11 @@ public class Hmp1SixelStateReplayTests
             "q#1;2;100;0;0#1!11~"u8.ToArray());
         producer.ApplyTokens(AnsiTokenizer.Tokenize(
             "\x1b[1;1H" + Encoding.ASCII.GetString(fixture.StandardBytes)));
-        // Overwrite only the origin cell with plain text, damaging it.
-        producer.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[1;1HX"));
+        // The damaged cell's link can differ from the active link for future output.
+        producer.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[1;1H" +
+            (linkedCell ? "\x1b]8;id=cell;https://example.com/cell\x1b\\" : "") +
+            "X\x1b]8;;\x1b\\" +
+            (activeHyperlink ? "\x1b]8;id=active;https://example.com/active\x1b\\" : "")));
 
         using (var producerState = producer.CreateSnapshot())
         {
@@ -213,12 +221,23 @@ public class Hmp1SixelStateReplayTests
         // step re-applies it after the placement-creation replay re-blanks
         // it.
         Assert.AreEqual("X", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual(linkedCell ? "https://example.com/cell" : null,
+            snapshot.GetCell(0, 0).HyperlinkData?.Uri);
+        Assert.AreEqual(linkedCell ? "id=cell" : null,
+            snapshot.GetCell(0, 0).HyperlinkData?.Parameters);
 
         // The placement itself is still present and still occupies its
         // second cell (never damaged).
         var placement = TestSeq.Single(snapshot.SixelPlacements);
         Assert.AreEqual(0, placement.Row);
         Assert.AreEqual(0, placement.Column);
+
+        viewer.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[3;1HY"));
+        using var continued = viewer.CreateSnapshot();
+        Assert.AreEqual(activeHyperlink ? "https://example.com/active" : null,
+            continued.GetCell(0, 2).HyperlinkData?.Uri);
+        Assert.AreEqual(activeHyperlink ? "id=active" : null,
+            continued.GetCell(0, 2).HyperlinkData?.Parameters);
     }
 
     [TestMethod]

--- a/tests/Hex1b.Tests/Hwt1Hmp1IntegrationTests.cs
+++ b/tests/Hex1b.Tests/Hwt1Hmp1IntegrationTests.cs
@@ -117,6 +117,81 @@ public class Hwt1Hmp1IntegrationTests
     }
 
     [TestMethod]
+    public async Task LateAttachment_Hyperlinks_PreserveDestinationsAcrossReconnect()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var server = new Hmp1PresentationAdapter(20, 10);
+        await using var producer = Hex1bTerminal.CreateBuilder().WithWorkload(workload)
+            .WithPresentation(server).WithDimensions(20, 10).Build();
+
+        foreach (var destination in new[] { "https://example.com/first", "https://example.com/second" })
+        {
+            producer.ApplyTokens(AnsiTokenizer.Tokenize(
+                $"\x1b[H\x1b]8;id=link;{destination}\x1b\\LINK\x1b]8;;\x1b\\ plain" +
+                $"\x1b[2;19H\x1b]8;id=wide;{destination}\x1b\\\u754cAB\x1b]8;;\x1b\\" +
+                $"\x1b[10;20H\x1b]8;id=last;{destination}\x1b\\Z\x1b]8;;\x1b\\\x1b[4;1H"));
+            var connection = await ConnectAsync(server);
+            await using var handle = connection.Handle;
+            await using var client = connection.Client;
+            await using var view = new Hwt1PresentationAdapter(20, 10);
+            await using var mirror = Hex1bTerminal.CreateBuilder().WithWorkload(client)
+                .WithPresentation(view).Build();
+            await WaitForScreenAsync(mirror, snapshot => snapshot.GetLineTrimmed(0) == "LINK plain" &&
+                snapshot.GetLineTrimmed(2) == "AB" && snapshot.GetCell(19, 9).Character == "Z");
+
+            using var expected = producer.CreateSnapshot();
+            using var actual = mirror.CreateSnapshot();
+            for (var row = 0; row < expected.Height; row++)
+            {
+                for (var column = 0; column < expected.Width; column++)
+                {
+                    var expectedLink = expected.GetCell(column, row).HyperlinkData;
+                    var actualLink = actual.GetCell(column, row).HyperlinkData;
+                    Assert.AreEqual(expectedLink?.Uri, actualLink?.Uri, $"Destination at {column},{row}");
+                    Assert.AreEqual(expectedLink?.Parameters, actualLink?.Parameters, $"Parameters at {column},{row}");
+                }
+            }
+
+            var frame = await ReadUntilAsync(view, metadata => PeerId(metadata) is not null);
+            var links = frame.GetProperty("hyperlinks").EnumerateArray().ToArray();
+            Assert.IsNotEmpty(links);
+            Assert.IsTrue(links.All(link => link.GetProperty("uri").GetString() == destination));
+
+            workload.Write(".");
+            await WaitForScreenAsync(mirror, snapshot => snapshot.GetCell(0, 3).Character == ".");
+            using var continued = mirror.CreateSnapshot();
+            Assert.IsNull(continued.GetCell(0, 3).HyperlinkData);
+        }
+    }
+
+    [TestMethod]
+    public async Task LateAttachment_ActiveHyperlink_PreservesSubsequentOutput()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var server = new Hmp1PresentationAdapter(20, 10);
+        await using var producer = Hex1bTerminal.CreateBuilder().WithWorkload(workload)
+            .WithPresentation(server).WithDimensions(20, 10).Build();
+        producer.ApplyTokens(AnsiTokenizer.Tokenize(
+            "\x1b]8;id=active;https://example.com/active\x1b\\A"));
+
+        var connection = await ConnectAsync(server);
+        await using var handle = connection.Handle;
+        await using var client = connection.Client;
+        await using var view = new Hwt1PresentationAdapter(20, 10);
+        await using var mirror = Hex1bTerminal.CreateBuilder().WithWorkload(client)
+            .WithPresentation(view).Build();
+        await WaitForScreenAsync(mirror, snapshot => snapshot.GetLineTrimmed(0) == "A");
+
+        workload.Write("B\x1b]8;;\x1b\\.");
+        await WaitForScreenAsync(mirror, snapshot => snapshot.GetLineTrimmed(0) == "AB.");
+        using var snapshot = mirror.CreateSnapshot();
+        Assert.AreEqual("https://example.com/active", snapshot.GetCell(1, 0).HyperlinkData?.Uri);
+        Assert.AreEqual("id=active", snapshot.GetCell(1, 0).HyperlinkData?.Parameters);
+        Assert.IsNull(snapshot.GetCell(2, 0).HyperlinkData);
+        Assert.IsNull(snapshot.GetCell(3, 0).HyperlinkData);
+    }
+
+    [TestMethod]
     public async Task LateAttachment_SilentRunningAnimation_AdvancesHwtPixelsWithoutFreshOutput()
     {
         var producerTime = new FakeTimeProvider();

--- a/tests/Hex1b.Tests/TerminalAnsiRenderingTests.cs
+++ b/tests/Hex1b.Tests/TerminalAnsiRenderingTests.cs
@@ -1,6 +1,7 @@
 using Hex1b.Input;
 using Hex1b.Layout;
 using Hex1b.Theming;
+using Hex1b.Tokens;
 
 namespace Hex1b.Tests;
 
@@ -11,6 +12,20 @@ namespace Hex1b.Tests;
 [TestClass]
 public class TerminalAnsiRenderingTests
 {
+    [TestMethod]
+    public void ToAnsi_HyperlinkedSnapshot_PreservesPublicExportFormat()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload)
+            .WithHeadless().WithDimensions(20, 10).Build();
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize(
+            "\x1b]8;;https://example.com\x1b\\LINK\x1b]8;;\x1b\\"));
+        using var snapshot = terminal.CreateSnapshot();
+
+        Assert.IsFalse(snapshot.ToAnsi().Contains("\x1b]8;", StringComparison.Ordinal));
+        Assert.IsFalse(((IHex1bTerminalRegion)snapshot).ToAnsi().Contains("\x1b]8;", StringComparison.Ordinal));
+    }
+
     [TestMethod]
     public async Task RenderFullSnapshot_ProducesAnsi()
     {


### PR DESCRIPTION
## Summary

Fix hyperlink destinations being lost when an HMP client attaches or reconnects. Live OSC 8 output was forwarded correctly, but StateSync's ANSI screen replay omitted hyperlink metadata. This affected remote HMP producers viewed through an Hmp1WorkloadAdapter and Hwt1PresentationAdapter, including Aspire's dashboard integration.

- Replay viewport cell hyperlink destinations and parameters through an internal, opt-in ANSI serializer path; public ANSI export behavior remains unchanged.
- Capture and restore the active hyperlink so subsequent live output keeps its original link state.
- Preserve cell hyperlinks and active state while repairing text overwritten by replayed Sixel graphics.
- Document the StateSync behavior and cover reconnects, changed destinations, wide/wrapped and last-cell links, active-link continuation, and Sixel repair combinations.

No public API or HWT wire-format changes. This does not add producer scrollback replay.

## Validation

- 348 targeted Hex1b tests passed across HMP1, HWT1, OSC 8, Sixel state replay, ANSI rendering, and web-terminal projection.
- The new HMP/HWT late-attachment and active-link regressions failed before the fix and pass with it.
- 32 Aspire terminal tests passed against a uniquely versioned local diagnostic package, including the retained hyperlink reconnect regression that fails against published 0.167.0-alpha.1517.1.81d1e3d.
- Isolated real-browser nonsecure-HTTP WebGL2 smoke preserved clickable OSC 8 destinations after a full page reload, existing safe activation policy, keyboard input, Sixel, and KGP.

Aspire's prepared dependency update remains held for a newly published version containing this fix; no local-package overrides or NuGet feed changes are committed there.