### PR TITLE
Fix lost render wakeups for nested KGP placement (#495)

### DIFF
--- a/.github/skills/writing-unit-tests/SKILL.md
+++ b/.github/skills/writing-unit-tests/SKILL.md
@@ -294,6 +294,30 @@ var result = await TestHelpers.CreateTerminalAndRunScenario(
 
 ---
 
+## Scheduler Progress Under Load
+
+For starvation regressions, keep the producer active while asserting input, timer,
+or shutdown progress. A finite output burst followed by `app.Invalidate()` can
+hide a lost wakeup. Use `TestWidget.OnRender` to place events at a known frame:
+
+```csharp
+var observer = new TestWidget().OnRender(args =>
+{
+    app.Invalidate(); // Renew on every frame, including while input is pending.
+    if (args.RenderCount == 3)
+        workload.SendKey(Hex1bKey.A);
+});
+```
+
+This fragment assumes captured `app` and `workload` references. Pair it with
+changing visible content so frames actually render, a bounded completion signal,
+and cancellation in `finally`. See `Hex1bAppSchedulingTests` for full examples.
+Check input ordering with coalescing both enabled and disabled. For cadence,
+measure steady-state intervals rather than using sleeps to synchronize.
+For nested output races, gate later child redraws: their extra notifications can
+mask a lost first-frame notification. These controlled cases supplement, rather
+than prove, responsiveness under arbitrary real-world load.
+
 ## Widget Test Dimensions
 
 When writing tests for widgets, consider all the **dimensions** that affect behavior. Each widget should have tests covering these scenarios:

--- a/.github/skills/writing-unit-tests/SKILL.md
+++ b/.github/skills/writing-unit-tests/SKILL.md
@@ -312,8 +312,12 @@ var observer = new TestWidget().OnRender(args =>
 This fragment assumes captured `app` and `workload` references. Pair it with
 changing visible content so frames actually render, a bounded completion signal,
 and cancellation in `finally`. See `Hex1bAppSchedulingTests` for full examples.
-Check input ordering with coalescing both enabled and disabled. For cadence,
-measure steady-state intervals rather than using sleeps to synchronize.
+Check input ordering with coalescing both enabled and disabled. For exact cadence,
+use the app's internal `FrameTimeProvider` with a fake clock, wait for timer
+registration before advancing it, and assert both the requested delay and elapsed
+virtual time. A fixed wall-clock tolerance around `Task.Delay` is not portable
+across CI runners. Keep real-time full-stack tests alongside deterministic pacing
+coverage rather than widening timing tolerances.
 For nested output races, gate later child redraws: their extra notifications can
 mask a lost first-frame notification. These controlled cases supplement, rather
 than prove, responsiveness under arbitrary real-world load.

--- a/src/Hex1b/Hex1bApp.cs
+++ b/src/Hex1b/Hex1bApp.cs
@@ -642,46 +642,13 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
                 {
                     await PaceFrameAsync(cancellationToken);
                 }
+
+                // The capacity-one channel coalesces pending invalidations. Consume the
+                // signal before building/rendering so invalidations raised during this
+                // frame wake the next iteration, which handles input and frame pacing.
+                _invalidateChannel.Reader.TryRead(out _);
                 await RenderFrameAsync(cancellationToken);
                 _lastRenderTimestamp = Stopwatch.GetTimestamp();
-                
-                // IMPORTANT: Handle race condition where output arrived during render.
-                // If invalidation was signaled while we were rendering, we need to re-render
-                // before blocking on WhenAny, otherwise content may not appear until next input.
-                // Limit to 2 extra renders to prevent animation timer cascades from starving input.
-                int extraRenders = 0;
-                const int maxExtraRenders = 2;
-                
-                while (_invalidateChannel.Reader.TryRead(out _) && extraRenders < maxExtraRenders)
-                {
-                    // If we're already inside the frame budget, defer remaining invalidations
-                    // to the next outer iteration so the render loop honors FrameRateLimitMs.
-                    var elapsedSinceLastRender = TimeSpan.FromSeconds(
-                        (Stopwatch.GetTimestamp() - _lastRenderTimestamp) / (double)Stopwatch.Frequency);
-                    if (elapsedSinceLastRender < _frameRateLimit)
-                        break;
-
-                    // ALWAYS process pending input before each re-render to prevent starvation
-                    while (_adapter.InputEvents.TryRead(out var pendingEvent))
-                    {
-                        await ProcessInputEventAsync(pendingEvent, cancellationToken);
-                        if (_stopRequested || cancellationToken.IsCancellationRequested)
-                            break;
-                    }
-                    
-                    if (_stopRequested || cancellationToken.IsCancellationRequested)
-                        break;
-                    
-                    // Fire any timers that became due
-                    _animationTimer.FireDue();
-                        
-                    await RenderFrameAsync(cancellationToken);
-                    _lastRenderTimestamp = Stopwatch.GetTimestamp();
-                    extraRenders++;
-                }
-                
-                // Drain any remaining invalidations without rendering (will be caught next loop)
-                while (_invalidateChannel.Reader.TryRead(out _)) { }
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)

--- a/src/Hex1b/Hex1bApp.cs
+++ b/src/Hex1b/Hex1bApp.cs
@@ -649,6 +649,44 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
                 _invalidateChannel.Reader.TryRead(out _);
                 await RenderFrameAsync(cancellationToken);
                 _lastRenderTimestamp = Stopwatch.GetTimestamp();
+
+                // IMPORTANT: Handle race condition where output arrived during render.
+                // If invalidation was signaled while we were rendering, we need to re-render
+                // before blocking on WhenAny, otherwise content may not appear until next input.
+                // Limit to 2 extra renders to prevent animation timer cascades from starving input.
+                int extraRenders = 0;
+                const int maxExtraRenders = 2;
+
+                while (extraRenders < maxExtraRenders)
+                {
+                    // Check the budget before consuming the signal. A deferred render
+                    // must leave its invalidation queued to wake the next iteration.
+                    var elapsedSinceLastRender = TimeSpan.FromSeconds(
+                        (Stopwatch.GetTimestamp() - _lastRenderTimestamp) / (double)Stopwatch.Frequency);
+                    if (elapsedSinceLastRender < _frameRateLimit)
+                        break;
+
+                    if (!_invalidateChannel.Reader.TryRead(out _))
+                        break;
+
+                    // ALWAYS process pending input before each re-render to prevent starvation
+                    while (_adapter.InputEvents.TryRead(out var pendingEvent))
+                    {
+                        await ProcessInputEventAsync(pendingEvent, cancellationToken);
+                        if (_stopRequested || cancellationToken.IsCancellationRequested)
+                            break;
+                    }
+
+                    if (_stopRequested || cancellationToken.IsCancellationRequested)
+                        break;
+
+                    // Fire any timers that became due
+                    _animationTimer.FireDue();
+
+                    await RenderFrameAsync(cancellationToken);
+                    _lastRenderTimestamp = Stopwatch.GetTimestamp();
+                    extraRenders++;
+                }
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)

--- a/src/Hex1b/Hex1bApp.cs
+++ b/src/Hex1b/Hex1bApp.cs
@@ -220,6 +220,7 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
 
     // Minimum interval between rendered frames (paces the render loop, not just Schedule()).
     private readonly TimeSpan _frameRateLimit;
+    private readonly TimeProvider _frameTimeProvider;
     // Timestamp of the last frame actually rendered. Used by the render loop
     // to enforce _frameRateLimit so invalidations triggered faster than the
     // configured cadence get coalesced into a single render.
@@ -266,6 +267,7 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
         var frameRateLimitMs = Math.Max(1, options.FrameRateLimitMs);
         _animationTimer = new AnimationTimer(TimeSpan.FromMilliseconds(frameRateLimitMs));
         _frameRateLimit = TimeSpan.FromMilliseconds(frameRateLimitMs);
+        _frameTimeProvider = options.FrameTimeProvider;
         
         // Check if mouse is enabled in options
         _mouseEnabled = options.EnableMouse;
@@ -648,7 +650,7 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
                 // frame wake the next iteration, which handles input and frame pacing.
                 _invalidateChannel.Reader.TryRead(out _);
                 await RenderFrameAsync(cancellationToken);
-                _lastRenderTimestamp = Stopwatch.GetTimestamp();
+                _lastRenderTimestamp = _frameTimeProvider.GetTimestamp();
 
                 // IMPORTANT: Handle race condition where output arrived during render.
                 // If invalidation was signaled while we were rendering, we need to re-render
@@ -661,8 +663,7 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
                 {
                     // Check the budget before consuming the signal. A deferred render
                     // must leave its invalidation queued to wake the next iteration.
-                    var elapsedSinceLastRender = TimeSpan.FromSeconds(
-                        (Stopwatch.GetTimestamp() - _lastRenderTimestamp) / (double)Stopwatch.Frequency);
+                    var elapsedSinceLastRender = _frameTimeProvider.GetElapsedTime(_lastRenderTimestamp);
                     if (elapsedSinceLastRender < _frameRateLimit)
                         break;
 
@@ -684,7 +685,7 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
                     _animationTimer.FireDue();
 
                     await RenderFrameAsync(cancellationToken);
-                    _lastRenderTimestamp = Stopwatch.GetTimestamp();
+                    _lastRenderTimestamp = _frameTimeProvider.GetTimestamp();
                     extraRenders++;
                 }
             }
@@ -913,13 +914,13 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
     {
         if (_lastRenderTimestamp == 0)
             return;
-        var elapsed = TimeSpan.FromSeconds((Stopwatch.GetTimestamp() - _lastRenderTimestamp) / (double)Stopwatch.Frequency);
+        var elapsed = _frameTimeProvider.GetElapsedTime(_lastRenderTimestamp);
         var remaining = _frameRateLimit - elapsed;
         if (remaining > TimeSpan.Zero)
         {
             try
             {
-                await Task.Delay(remaining, cancellationToken);
+                await Task.Delay(remaining, _frameTimeProvider, cancellationToken);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {

--- a/src/Hex1b/Hex1bAppOptions.cs
+++ b/src/Hex1b/Hex1bAppOptions.cs
@@ -158,6 +158,9 @@ public class Hex1bAppOptions
     /// </remarks>
     public int FrameRateLimitMs { get; set; } = 16;
 
+    // Keep frame pacing independently controllable without changing animation/input clocks.
+    internal TimeProvider FrameTimeProvider { get; set; } = TimeProvider.System;
+
     /// <summary>
     /// Whether to enable pooling of temporary <see cref="Surfaces.Surface"/> instances during rendering.
     /// This primarily affects <see cref="Widgets.SurfaceWidget"/> layers and nodes like EffectPanel.

--- a/tests/Hex1b.Tests/Hex1bAppSchedulingTests.cs
+++ b/tests/Hex1b.Tests/Hex1bAppSchedulingTests.cs
@@ -1,0 +1,219 @@
+using System.Diagnostics;
+using Hex1b.Input;
+using Hex1b.Widgets;
+
+namespace Hex1b.Tests;
+
+[TestClass]
+public class Hex1bAppSchedulingTests
+{
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public async Task RunAsync_InputDuringContinuousInvalidation_PreservesOrderAndResize(bool coalesceInput)
+    {
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        using var presentation = new HeadlessPresentationAdapter(24, 6);
+        Hex1bApp? app = null;
+        Hex1bAppWorkloadAdapter? workload = null;
+        var input = "";
+        var frames = new List<(int Number, string Input, int Width, int Height)>();
+        var finished = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var observer = new TestWidget().OnRender(args =>
+        {
+            frames.Add((args.RenderCount, input, args.Node.Parent!.Bounds.Width, args.Node.Parent.Bounds.Height));
+
+            // The producer remains active until shutdown, including while input is queued.
+            for (var i = 0; i < 32; i++)
+                app!.Invalidate();
+
+            if (args.RenderCount < 3)
+                workload!.SendKey(Hex1bKey.W);
+            if (args.RenderCount == 3)
+            {
+                workload!.SendKey(Hex1bKey.A);
+                presentation.TriggerResize(30, 7);
+                workload.SendKey(Hex1bKey.B);
+            }
+            if (input == "AB")
+                finished.TrySetResult();
+        });
+        var builds = 0;
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithHex1bApp(
+                options =>
+                {
+                    workload = TestSeq.IsType<Hex1bAppWorkloadAdapter>(options.WorkloadAdapter);
+                    options.EnableInputCoalescing = coalesceInput;
+                    options.EnableRescue = false;
+                },
+                instance =>
+                {
+                    app = instance;
+                    return _ => new VStackWidget([
+                        new TextBlockWidget($"Frame {++builds}: {input}"),
+                        new ButtonWidget("Focus"),
+                        observer,
+                    ]).InputBindings(bindings =>
+                    {
+                        bindings.Key(Hex1bKey.A).Action(_ => input += "A");
+                        bindings.Key(Hex1bKey.B).Action(_ => input += "B");
+                    });
+                })
+            .WithPresentation(presentation)
+            .WithDimensions(24, 6)
+            .Build();
+
+        var runTask = Task.Run(() => terminal.RunAsync(cancellation.Token), cancellation.Token);
+        try
+        {
+            await finished.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            using var snapshot = await new Hex1bTerminalInputSequenceBuilder()
+                .WaitUntil(s => s.ContainsText("AB") && s.Width == 30 && s.Height == 7,
+                    TimeSpan.FromSeconds(5), "input and resize progressed while invalidations continued")
+                .Build()
+                .ApplyAsync(terminal, TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            cancellation.Cancel();
+            await runTask.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        }
+
+        Assert.AreEqual("AB", input, "Queued keys must be handled in order, exactly once.");
+        Assert.AreEqual(coalesceInput ? "AB" : "A", frames.Single(f => f.Number == 4).Input);
+        Assert.AreEqual("AB", frames.Single(f => f.Number == (coalesceInput ? 4 : 6)).Input);
+        Assert.AreEqual((30, 7), (frames[^1].Width, frames[^1].Height));
+    }
+
+    [TestMethod]
+    [DataRow(16)]
+    [DataRow(100)]
+    public async Task RunAsync_ContinuousInvalidation_RespectsFrameRateLimit(int frameRateLimitMs)
+    {
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        Hex1bApp? app = null;
+        var timestamps = new List<long>();
+        var finished = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var observer = new TestWidget().OnRender(args =>
+        {
+            timestamps.Add(Stopwatch.GetTimestamp());
+            for (var i = 0; i < 32; i++)
+                app!.Invalidate();
+            if (args.RenderCount == 6)
+                finished.TrySetResult();
+        });
+        var builds = 0;
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithHex1bApp(
+                options =>
+                {
+                    options.FrameRateLimitMs = frameRateLimitMs;
+                    options.EnableRescue = false;
+                },
+                instance =>
+                {
+                    app = instance;
+                    return _ => new VStackWidget([new TextBlockWidget($"Frame {++builds}"), observer]);
+                })
+            .WithHeadless()
+            .WithDimensions(24, 6)
+            .Build();
+
+        var runTask = Task.Run(() => terminal.RunAsync(cancellation.Token), cancellation.Token);
+        try
+        {
+            await finished.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            cancellation.Cancel();
+            await runTask.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        }
+
+        // The initial frame has no pacing timestamp. Check steady-state frames only;
+        // allow timer granularity, but not an unpaced repaint storm.
+        for (var i = 2; i < 6; i++)
+        {
+            var elapsed = Stopwatch.GetElapsedTime(timestamps[i - 1], timestamps[i]);
+            Assert.IsTrue(elapsed.TotalMilliseconds >= frameRateLimitMs - 2,
+                $"Frames {i} and {i + 1} were only {elapsed.TotalMilliseconds:F2}ms apart.");
+        }
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public async Task RunAsync_ContinuousInvalidation_ServicesTimerAndShutdown(bool cancel)
+    {
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        Hex1bApp? app = null;
+        Hex1bAppWorkloadAdapter? workload = null;
+        var frames = 0;
+        var timerFrame = 0;
+        var stopFrame = 0;
+        var observer = new TestWidget().OnRender(args =>
+        {
+            frames = args.RenderCount;
+            app!.Invalidate();
+            workload!.SendKey(Hex1bKey.W);
+            if (timerFrame > 0 && frames >= timerFrame + 3 && stopFrame == 0)
+            {
+                stopFrame = frames;
+                if (cancel)
+                    cancellation.Cancel();
+                else
+                    app.RequestStop();
+            }
+        });
+        var timer = new TimerProbeWidget(() => timerFrame = frames);
+        var builds = 0;
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithHex1bApp(
+                options =>
+                {
+                    workload = TestSeq.IsType<Hex1bAppWorkloadAdapter>(options.WorkloadAdapter);
+                    options.EnableInputCoalescing = false;
+                    options.EnableRescue = false;
+                },
+                instance =>
+                {
+                    app = instance;
+                    return _ => new VStackWidget([
+                        new TextBlockWidget($"Frame {++builds}"), timer, observer,
+                    ]);
+                })
+            .WithHeadless()
+            .WithDimensions(24, 6)
+            .Build();
+
+        var runTask = Task.Run(() => terminal.RunAsync(cancellation.Token), cancellation.Token);
+        try
+        {
+            await runTask.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            Assert.IsGreaterThan(0, timerFrame, "A timer must fire while the producer is still active.");
+            Assert.IsGreaterThan(0, stopFrame, "The app must progress beyond the timer before stopping.");
+            Assert.AreEqual(stopFrame, frames, "Queued invalidations must not prevent shutdown.");
+        }
+        finally
+        {
+            cancellation.Cancel();
+            await runTask.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        }
+    }
+
+    private sealed record TimerProbeWidget(Action Fired) : Hex1bWidget
+    {
+        internal override Task<Hex1bNode> ReconcileAsync(Hex1bNode? existingNode, ReconcileContext context)
+        {
+            if (existingNode is null)
+            {
+                Assert.IsNotNull(context.ScheduleTimerCallback);
+                context.ScheduleTimerCallback(TimeSpan.FromMilliseconds(16), Fired);
+            }
+            return Task.FromResult<Hex1bNode>(existingNode ?? new TestWidgetNode());
+        }
+
+        internal override Type GetExpectedNodeType() => typeof(TestWidgetNode);
+    }
+}

--- a/tests/Hex1b.Tests/Hex1bAppSchedulingTests.cs
+++ b/tests/Hex1b.Tests/Hex1bAppSchedulingTests.cs
@@ -1,6 +1,7 @@
-using System.Diagnostics;
+using System.Threading.Channels;
 using Hex1b.Input;
 using Hex1b.Widgets;
+using Microsoft.Extensions.Time.Testing;
 
 namespace Hex1b.Tests;
 
@@ -92,12 +93,15 @@ public class Hex1bAppSchedulingTests
     public async Task RunAsync_ContinuousInvalidation_RespectsFrameRateLimit(int frameRateLimitMs)
     {
         using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var clock = new FrameTimeProvider();
+        clock.Advance(TimeSpan.FromMilliseconds(1));
+        var interval = TimeSpan.FromMilliseconds(frameRateLimitMs);
         Hex1bApp? app = null;
         var timestamps = new List<long>();
         var finished = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var observer = new TestWidget().OnRender(args =>
         {
-            timestamps.Add(Stopwatch.GetTimestamp());
+            timestamps.Add(clock.GetTimestamp());
             for (var i = 0; i < 32; i++)
                 app!.Invalidate();
             if (args.RenderCount == 6)
@@ -109,6 +113,7 @@ public class Hex1bAppSchedulingTests
                 options =>
                 {
                     options.FrameRateLimitMs = frameRateLimitMs;
+                    options.FrameTimeProvider = clock;
                     options.EnableRescue = false;
                 },
                 instance =>
@@ -123,6 +128,15 @@ public class Hex1bAppSchedulingTests
         var runTask = Task.Run(() => terminal.RunAsync(cancellation.Token), cancellation.Token);
         try
         {
+            // Wait until pacing actually schedules its delay before advancing time.
+            // The first two frames are unpaced; each subsequent frame needs a full budget.
+            for (var i = 2; i < 6; i++)
+            {
+                var delay = await clock.Delays.Reader.ReadAsync(TestContext.Current.CancellationToken)
+                    .AsTask().WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+                Assert.AreEqual(interval, delay, $"Frame {i + 1} must wait for the configured budget.");
+                clock.Advance(interval);
+            }
             await finished.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         }
         finally
@@ -131,13 +145,10 @@ public class Hex1bAppSchedulingTests
             await runTask.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
         }
 
-        // The initial frame has no pacing timestamp. Check steady-state frames only;
-        // allow timer granularity, but not an unpaced repaint storm.
         for (var i = 2; i < 6; i++)
         {
-            var elapsed = Stopwatch.GetElapsedTime(timestamps[i - 1], timestamps[i]);
-            Assert.IsTrue(elapsed.TotalMilliseconds >= frameRateLimitMs - 2,
-                $"Frames {i} and {i + 1} were only {elapsed.TotalMilliseconds:F2}ms apart.");
+            Assert.AreEqual(interval, clock.GetElapsedTime(timestamps[i - 1], timestamps[i]),
+                $"Frames {i} and {i + 1} must be one budget apart.");
         }
     }
 
@@ -199,6 +210,18 @@ public class Hex1bAppSchedulingTests
         {
             cancellation.Cancel();
             await runTask.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        }
+    }
+
+    private sealed class FrameTimeProvider : FakeTimeProvider
+    {
+        public Channel<TimeSpan> Delays { get; } = Channel.CreateUnbounded<TimeSpan>();
+
+        public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+        {
+            var timer = base.CreateTimer(callback, state, dueTime, period);
+            Delays.Writer.TryWrite(dueTime);
+            return timer;
         }
     }
 

--- a/tests/Hex1b.Tests/TerminalWidgetKgpTests.cs
+++ b/tests/Hex1b.Tests/TerminalWidgetKgpTests.cs
@@ -472,30 +472,58 @@ public class TerminalWidgetKgpTests
     public async Task Render_ChildKgpOutputDuringParentFrame_RendersWithoutFurtherInput(int frameRateLimitMs)
     {
         var imageBytes = KgpTestHelper.CreatePixelData(4, 4, fillByte: 0x5A);
-        using var workload = new Hex1bAppWorkloadAdapter();
+        var releaseInnerBuilds = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var innerBuilds = 0;
+        Hex1bApp? innerApp = null;
         await using var innerTerminal = Hex1bTerminal.CreateBuilder()
-            .WithWorkload(workload)
+            .WithHex1bApp(
+                options => options.EnableRescue = false,
+                (Func<Hex1bApp, Func<RootContext, Task<Hex1bWidget>>>)(app =>
+                {
+                    innerApp = app;
+                    return async context =>
+                    {
+                        // Only one child frame may wake the parent; a later startup
+                        // redraw would mask a lost notification from the first frame.
+                        if (++innerBuilds > 1)
+                            await releaseInnerBuilds.Task.WaitAsync(context.CancellationToken);
+                        return new KgpImageWidget(
+                            imageBytes, 4, 4, new TextBlockWidget("[inner fallback]"))
+                            .Width(4).Height(2);
+                    };
+                }))
             .WithDimensions(8, 4)
             .WithTerminalWidget(out var handle)
             .Build();
-        var childOutput = AnsiTokenizer.Tokenize(KgpTestHelper.BuildCommand(
-            "a=T,f=32,s=4,v=4,i=1,c=4,r=2,C=1,q=2", imageBytes));
+        Task? innerRunTask = null;
         var outputDelivered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var afterChild = new TestWidget().OnRender(args =>
         {
             if (args.RenderCount != 2)
                 return;
 
-            // Publish after TerminalNode captured the child, during a non-initial frame.
-            handle.WriteOutputWithImpactsAsync(innerTerminal.ApplyTokensWithImpacts(childOutput))
+            // Hold the parent after its child snapshot until the real inner app finishes
+            // a synchronized KGP frame. Subscribe after TerminalNode so its wakeup is queued.
+            handle.OutputReceived += () =>
+            {
+                if (handle.TryCaptureRenderFrame(0, out var frame) && frame?.KgpPlacements.Count == 1)
+                    outputDelivered.TrySetResult();
+            };
+            innerRunTask = innerTerminal.RunAsync(TestContext.Current.CancellationToken);
+            outputDelivered.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken)
                 .GetAwaiter().GetResult();
-            outputDelivered.SetResult();
+            var childNode = TestSeq.Single(args.Node.Parent!.GetChildren().OfType<TerminalNode>());
+            Assert.IsTrue(childNode.HasPendingOutput, "The parent has not rendered the child's completed frame.");
         });
         var builds = 0;
         Hex1bApp? outerApp = null;
         await using var outerTerminal = Hex1bTerminal.CreateBuilder()
             .WithHex1bApp(
-                options => options.FrameRateLimitMs = frameRateLimitMs,
+                options =>
+                {
+                    options.FrameRateLimitMs = frameRateLimitMs;
+                    options.EnableRescue = false;
+                },
                 app =>
                 {
                     outerApp = app;
@@ -532,8 +560,10 @@ public class TerminalWidgetKgpTests
         }
         finally
         {
+            innerApp?.RequestStop();
+            releaseInnerBuilds.TrySetResult();
             outerApp!.RequestStop();
-            await runTask;
+            await Task.WhenAll(runTask, innerRunTask ?? Task.CompletedTask);
         }
     }
 

--- a/tests/Hex1b.Tests/TerminalWidgetKgpTests.cs
+++ b/tests/Hex1b.Tests/TerminalWidgetKgpTests.cs
@@ -467,6 +467,77 @@ public class TerminalWidgetKgpTests
     }
 
     [TestMethod]
+    [DataRow(16)]
+    [DataRow(1000)] // Exercise a follow-up frame deferred by a slow frame-rate limit.
+    public async Task Render_ChildKgpOutputDuringParentFrame_RendersWithoutFurtherInput(int frameRateLimitMs)
+    {
+        var imageBytes = KgpTestHelper.CreatePixelData(4, 4, fillByte: 0x5A);
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var innerTerminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload)
+            .WithDimensions(8, 4)
+            .WithTerminalWidget(out var handle)
+            .Build();
+        var childOutput = AnsiTokenizer.Tokenize(KgpTestHelper.BuildCommand(
+            "a=T,f=32,s=4,v=4,i=1,c=4,r=2,C=1,q=2", imageBytes));
+        var outputDelivered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var afterChild = new TestWidget().OnRender(args =>
+        {
+            if (args.RenderCount != 2)
+                return;
+
+            // Publish after TerminalNode captured the child, during a non-initial frame.
+            handle.WriteOutputWithImpactsAsync(innerTerminal.ApplyTokensWithImpacts(childOutput))
+                .GetAwaiter().GetResult();
+            outputDelivered.SetResult();
+        });
+        var builds = 0;
+        Hex1bApp? outerApp = null;
+        await using var outerTerminal = Hex1bTerminal.CreateBuilder()
+            .WithHex1bApp(
+                options => options.FrameRateLimitMs = frameRateLimitMs,
+                app =>
+                {
+                    outerApp = app;
+                    return _ => new VStackWidget([
+                        new TextBlockWidget($"Host {++builds}"),
+                        new TerminalWidget(handle)
+                            .Width(SizeHint.Fixed(8))
+                            .Height(SizeHint.Fixed(4)),
+                        afterChild,
+                    ]);
+                })
+            .WithHeadless(KgpCapabilities)
+            .WithDimensions(12, 8)
+            .Build();
+
+        var runTask = outerTerminal.RunAsync(TestContext.Current.CancellationToken);
+        try
+        {
+            await outputDelivered.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            using var childSnapshot = innerTerminal.CreateSnapshot();
+            Assert.HasCount(1, childSnapshot.KgpPlacements);
+            using var snapshot = await new Hex1bTerminalInputSequenceBuilder()
+                .WaitUntil(
+                    current => current.KgpPlacements.Count == 1,
+                    TimeSpan.FromSeconds(5),
+                    "child KGP output arriving during the parent frame was rendered")
+                .Build()
+                .ApplyAsync(outerTerminal, TestContext.Current.CancellationToken);
+
+            var placement = TestSeq.Single(snapshot.KgpPlacements);
+            CollectionAssert.AreEqual(imageBytes, snapshot.KgpImages[placement.ImageId].Data);
+            Assert.AreEqual(1, placement.Row);
+            Assert.AreEqual(0, placement.Column);
+        }
+        finally
+        {
+            outerApp!.RequestStop();
+            await runTask;
+        }
+    }
+
+    [TestMethod]
     public async Task NestedHex1bApp_KgpPlacementMovesAndDeletesWithoutGhosts()
     {
         var state = new NestedKgpState();


### PR DESCRIPTION
Fixes #495

## Result

**Ten additional full Deploy PR reruns passed on unchanged commit `1ea553ac68db77622e2ea1fde1a6b504fbef3521`.** These are [workflow 34202168426, attempts 2–11](https://github.com/mitchdenny/hex1b/actions/runs/34202168426). The initial same-head build also passed and is excluded from the ten-run count. Runs were sequential, with no failed-job-only retries or code changes during the final sample.

| Coverage in the ten additional reruns | Linux | Windows |
|---|---:|---:|
| Full workflow test jobs | 10/10 passed | 10/10 passed |
| Original #495 KGP test | 10/10 passed | 10/10 passed |
| Two real nested-app regression variants | 20/20 passed | 20/20 passed |
| Six scheduler safeguard cases | 60/60 passed | 60/60 passed |
| Main-suite test executions | 97,370 passed | 97,190 passed |
| Analyzer / MCP / tool suites | All three ran and passed 10 times | All three ran and passed 10 times |

No test or infrastructure failures occurred in this final sample. All four .NET projects actually executed on both OSes in every rerun; missing executions were not treated as passes. The main suite retained its existing 23 Linux / 41 Windows skips per run. All other applicable workflow jobs, including the web-terminal build/tests, passed. This is repeated full-suite evidence, not a guarantee against every possible scheduling interleaving.

## Root cause and history

This is a lost render wakeup, not an insufficient test timeout or corrupt KGP placement state. `TerminalNode` preserves pending output when a child finishes after the parent's snapshot. The scheduler nevertheless consumed the invalidation **before** its extra-render pacing guard, then skipped the render. Its final drain also discarded remaining signals, leaving a dirty child with no wakeup.

The original extra-render loop came from #68 (20 January), its two-render bound/input-fairness safeguards from #99 (28 January), and pacing from #332 (29 May). The nested KGP feature and original failing test arrived in #426 (31 August). These safeguards have real purposes and are **retained**.

## Conservative production change

- Consume the capacity-one pending invalidation before the main frame, so notifications raised during the frame remain available.
- Check the extra-render count and pacing budgets **before** consuming a follow-up invalidation.
- Remove the final drain that discarded deferred work without rendering it.

The bounded extra-render loop, `ProcessInputEventAsync` calls, pending-input drain, timer servicing, cancellation/stop checks, input-coalescing behavior and pacing remain in place. The original flaky test, five-second timeout and graphics assertions are unchanged. No retries, synchronization sleeps, public API additions or unrelated fixes.

An internal, system-default frame `TimeProvider` lets the new cadence tests control timestamps and delay completion without changing production pacing policy. Animation/input clocks are unchanged.

## Regression coverage

**Real nested-app reproduction:** An actual inner `Hex1bApp` publishes a complete synchronized KGP frame after the parent has taken its child snapshot. The regression confirms `TerminalNode.HasPendingOutput` and gates subsequent child builds so a later startup redraw cannot mask the lost wakeup. At both 16 ms and 1000 ms parent limits, the old scheduler times out with `Host 2` and no outer placement. The fix renders exact image bytes at row 1 / column 0 without another input or child redraw.

**Scheduling safeguards:** Six cases cover ordered key input and resize under continued invalidation (coalescing on/off), cadence at 16/100 ms, and timer progress followed by stop/cancellation while input and invalidations are still produced. Four input/timer/shutdown characterization cases also pass on the original scheduler. Independent negative mutations of input dispatch and timer servicing fail their corresponding cases.

**Deterministic cadence:** Tests wait for pacing-timer registration, assert the exact requested delay, advance fake time, and assert exact virtual frame intervals. Temporarily halving the delay fails both cases with 8 versus 16 ms and 50 versus 100 ms. The mutation is removed. Real-time nested-app, input, timer, and shutdown coverage remains alongside the deterministic checks.

## Failures investigated before the final sample

The preliminary experiment at superseded `bb3c417b` is preserved in [run 34198688915](https://github.com/mitchdenny/hex1b/actions/runs/34198688915), separately from the final ten-run sample:

- Initial attempt: five Windows process/PTY failures. All five signatures match actual September 2 TRX results tracked by #502/#503/#463, including methods, blank-screen dimensions and assertion/timeout locations. Those paths are unchanged and use raw process workloads rather than the edited app scheduler. No unrelated fix was made.
- Additional rerun 1: full workflow passed.
- Additional rerun 2: Linux exposed this PR's new cadence test's nonportable two-millisecond wall-clock tolerance (97.86 ms observed versus a 98 ms lower bound). This was **not** dismissed as known flakiness. Commit `1ea553ac` replaced that assumption with exact virtual-time assertions rather than widening the tolerance or changing the pacing budget. The final ten-run sample then restarted from scratch.

The original KGP test and both nested regression variants passed on both OSes throughout those three preliminary attempts. Local GitHub API/download connection interruptions during collection caused no extra CI reruns and are not counted as CI failures.

## Local evidence and review hold

Current-head local coverage passed 63 targeted related cases plus ten further scheduler/KGP repetitions (**270/270** cases), on macOS ARM64. The earlier conservative revision additionally passed 135 related cases and 270 repeated cases. Per-attempt metadata, distinct Linux/Windows TRX artifacts, counters, and failure evidence were retained and audited; a detailed ledger is attached to #495.

The unit-test skill documents sustained producers, avoiding extra wakeups, and deterministic cadence testing. Based directly on main at `3085d8bd`, not #494. Sampling PR #494 remains unchanged. **Ready for user review; no merge or auto-merge is authorized.**