### PR TITLE
Fix stale loading spinner after async tree expansion (#388)

### DIFF
--- a/src/Hex1b/Widgets/TreeWidget.cs
+++ b/src/Hex1b/Widgets/TreeWidget.cs
@@ -224,6 +224,8 @@ public sealed record TreeWidget(IReadOnlyList<TreeItemWidget> Items) : Hex1bWidg
             // Compose child widgets
             
             // 1. Expand indicator (or spinner when loading)
+            var wasShowingSpinner = node.LoadingSpinnerNode != null;
+            var previousIndicator = node.ExpandIndicatorNode?.Icon;
             if (node.IsLoading)
             {
                 // Loading: show spinner instead of expand indicator
@@ -246,6 +248,15 @@ public sealed record TreeWidget(IReadOnlyList<TreeItemWidget> Items) : Hex1bWidg
                 // Leaf node: no indicator
                 node.LoadingSpinnerNode = null;
                 node.ExpandIndicatorNode = null;
+            }
+
+            // TreeNode renders these composed nodes itself, outside GetChildren().
+            // Async completion can occur after reconciliation, so its dirty flag may
+            // already have been cleared by a frame that still showed the spinner.
+            if (wasShowingSpinner != (node.LoadingSpinnerNode != null) ||
+                previousIndicator != node.ExpandIndicatorNode?.Icon)
+            {
+                parentTree.MarkDirty();
             }
 
             // Recursively reconcile children FIRST

--- a/tests/Hex1b.Tests/TreeIntegrationTests.cs
+++ b/tests/Hex1b.Tests/TreeIntegrationTests.cs
@@ -1187,9 +1187,9 @@ public class TreeIntegrationTests
     [TestMethod]
     public async Task Tree_AsyncExpansion_ShowsChildrenAfterLoad()
     {
-        var loadCompleted = new TaskCompletionSource<bool>();
-        var loadStarted = new TaskCompletionSource<bool>();
-        var childrenReturned = 0;
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var releaseLoad = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var loadStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         
         using var workload = new Hex1bAppWorkloadAdapter();
         using var terminal = Hex1bTerminal.CreateBuilder()
@@ -1203,84 +1203,136 @@ public class TreeIntegrationTests
                 v.Tree(
                     new TreeItemWidget("Parent").Icon("📁")
                         .OnExpanding(async e => {
-                            loadStarted.TrySetResult(true);
-                            await Task.Delay(100); // Short delay for test
-                            var children = new[] {
+                            loadStarted.TrySetResult();
+                            await releaseLoad.Task.WaitAsync(e.Context.CancellationToken);
+                            return [
                                 new TreeItemWidget("Child1").Icon("📄"),
                                 new TreeItemWidget("Child2").Icon("📄")
-                            };
-                            childrenReturned = children.Length;
-                            loadCompleted.TrySetResult(true);
-                            return children;
+                            ];
                         })
                 ).FillHeight()
             ])),
             new Hex1bAppOptions { WorkloadAdapter = workload }
         );
 
-        var runTask = app.RunAsync(TestContext.Current.CancellationToken);
-
-        // Wait for initial render with Parent visible
-        await new Hex1bTerminalInputSequenceBuilder()
-            .WaitUntil(s => s.ContainsText("Parent"), TimeSpan.FromSeconds(5), "tree to render")
-            .Build()
-            .ApplyAsync(terminal, TestContext.Current.CancellationToken);
-
-        // Verify initial state - Parent should be collapsed (▶)
-        var initialSnapshot = terminal.CreateSnapshot();
-        var initialText = initialSnapshot.GetScreenText();
-        
-        // Check if there's a focus indicator and collapsed indicator
-        Assert.IsTrue(initialSnapshot.ContainsText("▶") || initialSnapshot.ContainsText("Parent"), $"Initial screen should show Parent. Screen:\n{initialText}");
-
-        // Press Tab to ensure tree has focus, then Right arrow to expand
-        await new Hex1bTerminalInputSequenceBuilder()
-            .Key(Hex1bKey.Tab) // Ensure focus
-            .Wait(TimeSpan.FromMilliseconds(100))
-            .Key(Hex1bKey.RightArrow)
-            .Wait(TimeSpan.FromMilliseconds(100))
-            .Build()
-            .ApplyAsync(terminal, TestContext.Current.CancellationToken);
-
-        // Check if load was even triggered
-        var loadTriggered = await Task.WhenAny(
-            loadStarted.Task.WaitAsync(TimeSpan.FromSeconds(5)),
-            Task.Delay(TimeSpan.FromSeconds(5))
-        ) == loadStarted.Task;
-        
-        // If not triggered, capture what the screen looks like now
-        if (!loadTriggered)
+        var runTask = app.RunAsync(cancellation.Token);
+        try
         {
-            var debugSnapshot = terminal.CreateSnapshot();
-            var debugText = debugSnapshot.GetScreenText();
-            Assert.Fail($"OnExpanding handler was not called after Tab+RightArrow. Screen:\n{debugText}");
+            await new Hex1bTerminalInputSequenceBuilder()
+                .WaitUntil(s => s.ContainsText(CollapsedIndicator) && IsFocused(s, "Parent"),
+                    TimeSpan.FromSeconds(5), "collapsed parent to receive focus")
+                .Right()
+                .Build()
+                .ApplyAsync(terminal, TestContext.Current.CancellationToken);
+
+            await loadStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            using var loadingSnapshot = await new Hex1bTerminalInputSequenceBuilder()
+                .WaitUntil(s => s.ContainsText("Parent") && SpinnerStyle.Dots.Frames.Any(s.ContainsText),
+                    TimeSpan.FromSeconds(5), "loading spinner before children are released")
+                .Build()
+                .ApplyAsync(terminal, TestContext.Current.CancellationToken);
+            Assert.IsFalse(loadingSnapshot.ContainsText("Child1"));
+            Assert.IsFalse(loadingSnapshot.ContainsText("Child2"));
+
+            releaseLoad.TrySetResult();
+            using var finalSnapshot = await new Hex1bTerminalInputSequenceBuilder()
+                .WaitUntil(s => s.ContainsText(ExpandedIndicator)
+                    && s.ContainsText("Child1") && s.ContainsText("Child2"),
+                    TimeSpan.FromSeconds(5), "expanded parent and both loaded children")
+                .Capture("async_expansion_loaded")
+                .Build()
+                .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
+
+            var finalText = finalSnapshot.GetScreenText();
+            Assert.IsTrue(finalSnapshot.ContainsText(ExpandedIndicator), $"Parent should show expanded indicator. Screen:\n{finalText}");
+            Assert.IsTrue(finalSnapshot.ContainsText("Child1"), $"Child1 should be visible after expansion. Screen:\n{finalText}");
+            Assert.IsTrue(finalSnapshot.ContainsText("Child2"), $"Child2 should be visible after expansion. Screen:\n{finalText}");
         }
+        finally
+        {
+            cancellation.Cancel();
+            await runTask.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        }
+    }
 
-        // Wait for async load to complete
-        await loadCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        
-        // Give time for render to update - wait longer for async
-        await Task.Delay(500);
+    [TestMethod]
+    public async Task Tree_AsyncExpansion_CompletesAfterReconcile_RendersExpandedIndicator()
+    {
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var releaseLoad = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var expansionCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        TreeNode? treeNode = null;
+        var completionPlaced = false;
 
-        // Capture final state
-        var finalSnapshot = terminal.CreateSnapshot();
-        var finalText = finalSnapshot.GetScreenText();
-        
-        // Exit app
-        await new Hex1bTerminalInputSequenceBuilder()
-            .Ctrl().Key(Hex1bKey.C)
-            .Build()
-            .ApplyAsync(terminal, TestContext.Current.CancellationToken);
+        var tree = new TreeWidget([
+            new TreeItemWidget("Parent").OnExpanding(async e =>
+            {
+                await releaseLoad.Task.WaitAsync(e.Context.CancellationToken);
+                return [new TreeItemWidget("Child1"), new TreeItemWidget("Child2")];
+            })
+        ]).FillHeight().InputBindings(bindings =>
+        {
+            bindings.Key(Hex1bKey.RightArrow).Action(async context =>
+            {
+                treeNode = TestSeq.IsType<TreeNode>(context.FocusedNode);
+                var item = TestSeq.Single(treeNode.Items);
+                var trackedContext = new InputBindingActionContext(
+                    new FocusRing(),
+                    cancellationToken: context.CancellationToken,
+                    invalidate: () =>
+                    {
+                        context.Invalidate();
+                        // Observe the real completion wakeup, after the flattened view is rebuilt.
+                        if (!item.IsLoading && item.IsExpanded)
+                            expansionCompleted.TrySetResult();
+                    });
+                await treeNode.ToggleExpandAsync(item, trackedContext);
+            });
+        });
+        var observer = new TestWidget().OnReconcile(_ =>
+        {
+            if (completionPlaced || treeNode?.Items[0].LoadingSpinnerNode == null)
+                return;
 
-        await runTask;
+            // Finish loading after the spinner is reconciled but before this frame renders.
+            // Do not request another render: only expansion's own wakeup may drive recovery.
+            completionPlaced = true;
+            releaseLoad.TrySetResult();
+            expansionCompleted.Task.WaitAsync(TimeSpan.FromSeconds(5), cancellation.Token)
+                .GetAwaiter().GetResult();
+            Assert.IsFalse(treeNode.Items[0].IsLoading);
+            Assert.AreEqual(3, treeNode.FlattenedItems.Count);
+            Assert.IsNotNull(treeNode.Items[0].LoadingSpinnerNode);
+        });
 
-        // Debug info
-        Assert.IsTrue(childrenReturned == 2, $"Handler should have returned 2 children, got {childrenReturned}");
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithHex1bApp(
+                options => options.EnableRescue = false,
+                _ => _ => new VStackWidget([tree, observer]))
+            .WithHeadless()
+            .WithDimensions(60, 20)
+            .Build();
 
-        // Verify children are now visible
-        Assert.IsTrue(finalSnapshot.ContainsText("▼"), $"Parent should show expanded indicator. Screen:\n{finalText}");
-        Assert.IsTrue(finalSnapshot.ContainsText("Child1"), $"Child1 should be visible after expansion. Screen:\n{finalText}");
-        Assert.IsTrue(finalSnapshot.ContainsText("Child2"), $"Child2 should be visible after expansion. Screen:\n{finalText}");
+        var runTask = Task.Run(() => terminal.RunAsync(cancellation.Token), cancellation.Token);
+        try
+        {
+            using var snapshot = await new Hex1bTerminalInputSequenceBuilder()
+                .WaitUntil(s => s.ContainsText(CollapsedIndicator) && IsFocused(s, "Parent"),
+                    TimeSpan.FromSeconds(5), "collapsed parent to receive focus")
+                .Right()
+                .WaitUntil(s => s.ContainsText(ExpandedIndicator)
+                    && s.ContainsText("Child1") && s.ContainsText("Child2"),
+                    TimeSpan.FromSeconds(5), "expanded parent and both children after completion during reconciliation")
+                .Build()
+                .ApplyAsync(terminal, TestContext.Current.CancellationToken);
+
+            Assert.IsTrue(completionPlaced, "Loading must complete between reconciliation and rendering.");
+        }
+        finally
+        {
+            cancellation.Cancel();
+            await runTask.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        }
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

Fixes #388.

Mark `TreeNode` dirty when reconciliation changes its composed loading/expand indicator. Replace fixed sleeps in `Tree_AsyncExpansion_ShowsChildrenAfterLoad` with a controlled loader and waits for the collapsed parent, loading spinner, and final expanded parent with both children. Add a deterministic full-terminal-stack regression for completion between reconciliation and rendering.

## Root cause

This remains reproducible on main **after #507** (`4076cabca4a87b97c79d41049218a533d705a0b7`, an ancestor of this branch).

Async loading can finish after `TreeWidget` has reconciled the parent to a spinner but before that frame renders. Completion updates the children, expansion state, flattened view, and dirty flag, and requests a render. The current frame can therefore render the new children using the already-composed spinner, then clear the tree's dirty flag.

On the next reconciliation, the spinner is replaced with the expanded icon. However, `TreeNode` renders these composed nodes itself and does not expose them through `GetChildren()`. Changing the icon did not mark the owning tree dirty, so the subsequent frame skipped output and the spinner remained visible even though loading had finished. This is a tree-local dirty-state issue, not another lost scheduler wakeup or merely a slow snapshot.

The fix compares the old and new composed indicators and marks the owning tree dirty only when they change. It leaves the scheduler, async loader, callbacks, cancellation/error behavior, and reconciliation state preservation unchanged.

## Regression evidence

The new `Tree_AsyncExpansion_CompletesAfterReconcile_RendersExpandedIndicator` uses the existing `TestWidget.OnReconcile` hook to release loading after spinner composition and awaits the actual expansion-completion invalidation before letting that frame render. It introduces no extra input or manual invalidation to repair the display.

With unchanged post-#507 production code, the regression **failed** after its 5-second state wait with the exact sampled signature:

```text
⠋ Parent
├─ Child1
└─ Child2
```

With this fix, the same regression passes. The original test still asserts the expanded indicator and both loaded children, and now also verifies that neither child is shown while loading is gated.

## Validation

- Local macOS arm64: all **89** selected tree integration, node, cascade-selection, and guide-alignment cases passed; **0 skipped**.
- Original async expansion test plus controlled regression: **20 additional targeted runs**, **40/40 executions passed**, **0 skipped**.
- The original unmodified test also passed once on the post-#507 baseline; that pass alone was not taken as evidence of resolution.
- Linux/Windows validation is delegated to this PR's normal Deploy workflow. No additional full-CI sampling campaign was started.

Scope is #388 only. This PR is left unmerged for explicit user review.