### PR TITLE
Fix remote terminal mock-server port collisions

### DIFF
--- a/.github/skills/writing-unit-tests/SKILL.md
+++ b/.github/skills/writing-unit-tests/SKILL.md
@@ -294,6 +294,27 @@ var result = await TestHelpers.CreateTerminalAndRunScenario(
 
 ---
 
+## Network Test Fixtures
+
+Let the server reserve its listening port atomically. Random port selection and
+probing a free port before closing the probe both allow collisions under parallel
+execution. For Kestrel fixtures, configure
+`options.Listen(IPAddress.Loopback, 0)`, await `app.StartAsync()`, then derive client
+URIs from `TestSeq.Single(app.Urls)`. For example:
+
+```csharp
+var wsUri = new UriBuilder(TestSeq.Single(app.Urls))
+{
+    Scheme = "ws",
+    Path = "/ws/attach"
+}.Uri;
+```
+
+Keep the application owned by the fixture before awaiting startup so cleanup can
+dispose it even if startup fails. Cover independently reachable concurrent servers
+and listener release; see `RemoteTerminalWorkloadAdapterTests`. Do not mask port
+collisions with sleeps, retries, or disabled parallelism.
+
 ## Scheduler Progress Under Load
 
 For starvation regressions, keep the producer active while asserting input, timer,

--- a/tests/Hex1b.Tests/RemoteTerminalWorkloadAdapterTests.cs
+++ b/tests/Hex1b.Tests/RemoteTerminalWorkloadAdapterTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Sockets;
 using System.Net.WebSockets;
 using System.Text;
 using System.Text.Json;
@@ -13,7 +14,6 @@ namespace Hex1b.Tests;
 public class RemoteTerminalWorkloadAdapterTests
 {
     private WebApplication? _server;
-    private int _port;
     private readonly List<WebSocket> _connectedClients = new();
     private readonly SemaphoreSlim _clientConnected = new(0);
     private readonly TaskCompletionSource<string?> _authorizationHeader =
@@ -26,8 +26,13 @@ public class RemoteTerminalWorkloadAdapterTests
     [TestInitialize]
     public async Task InitializeAsync()
     {
-        _port = Random.Shared.Next(19000, 19999);
-        _server = await StartMockServerAsync(_port);
+        _server = CreateMockServer();
+        await _server.StartAsync();
+        WsUri = new UriBuilder(TestSeq.Single(_server.Urls))
+        {
+            Scheme = "ws",
+            Path = "/ws/attach"
+        }.Uri;
     }
 
     [TestCleanup]
@@ -48,7 +53,76 @@ public class RemoteTerminalWorkloadAdapterTests
         }
     }
 
-    private Uri WsUri => new($"ws://localhost:{_port}/ws/attach");
+    private Uri WsUri { get; set; } = null!;
+
+    [TestMethod]
+    public async Task InitializeAsync_ConcurrentFixtures_BindDistinctReachableEndpoints()
+    {
+        var fixtures = Enumerable.Range(0, 4)
+            .Select(_ => new RemoteTerminalWorkloadAdapterTests())
+            .ToArray();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        cts.CancelAfter(TimeSpan.FromSeconds(10));
+        using var httpClient = new HttpClient();
+
+        try
+        {
+            await Task.WhenAll(fixtures.Select(fixture => fixture.InitializeAsync()));
+
+            Assert.AreEqual(fixtures.Length, fixtures.Select(fixture => fixture.WsUri).Distinct().Count());
+
+            for (var i = 0; i < fixtures.Length; i++)
+            {
+                var fixture = fixtures[i];
+                var address = new Uri(TestSeq.Single(fixture._server!.Urls));
+                Assert.IsGreaterThan(0, address.Port);
+                Assert.AreEqual(address.Host, fixture.WsUri.Host);
+                Assert.AreEqual(address.Port, fixture.WsUri.Port);
+                Assert.AreEqual("ws", fixture.WsUri.Scheme);
+                Assert.AreEqual("/ws/attach", fixture.WsUri.AbsolutePath);
+
+                using var response = await httpClient.GetAsync(new Uri(address, "/ws/attach"), cts.Token);
+                Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
+
+                var authorization = $"fixture-{i}";
+                await using var adapter = new RemoteTerminalWorkloadAdapter(
+                    fixture.WsUri, options => options.SetRequestHeader("Authorization", authorization));
+                await adapter.ConnectAsync(cts.Token);
+
+                Assert.AreEqual(authorization, await fixture._authorizationHeader.Task.WaitAsync(cts.Token));
+                Assert.AreEqual("/ws/attach", await fixture._requestPathAndQuery.Task.WaitAsync(cts.Token));
+                Assert.AreEqual(120, adapter.RemoteWidth);
+                Assert.AreEqual(30, adapter.RemoteHeight);
+                var initialScreen = await adapter.ReadOutputAsync(cts.Token);
+                Assert.AreEqual("Welcome", Encoding.UTF8.GetString(initialScreen.Span));
+            }
+        }
+        finally
+        {
+            await Task.WhenAll(fixtures.Select(fixture => fixture.DisposeAsync()));
+        }
+    }
+
+    [TestMethod]
+    public async Task DisposeAsync_AfterInitialization_ReleasesListeningEndpoint()
+    {
+        var fixture = new RemoteTerminalWorkloadAdapterTests();
+        IPEndPoint endpoint;
+        try
+        {
+            await fixture.InitializeAsync();
+            var address = new Uri(TestSeq.Single(fixture._server!.Urls));
+            endpoint = new IPEndPoint(IPAddress.Parse(address.Host), address.Port);
+        }
+        finally
+        {
+            await fixture.DisposeAsync();
+        }
+
+        using var listener = new TcpListener(endpoint);
+        listener.Start();
+        Assert.AreEqual(endpoint, listener.LocalEndpoint);
+    }
 
     [TestMethod]
     public async Task Constructor_WithValidUri_CreatesAdapter()
@@ -332,12 +406,13 @@ public class RemoteTerminalWorkloadAdapterTests
 
     // --- Mock WebSocket Server ---
 
-    private async Task<WebApplication> StartMockServerAsync(int port)
+    private WebApplication CreateMockServer()
     {
         var builder = WebApplication.CreateSlimBuilder();
         builder.WebHost.ConfigureKestrel(options =>
         {
-            options.Listen(IPAddress.Loopback, port);
+            // Let the OS assign and reserve the port in the same bind operation.
+            options.Listen(IPAddress.Loopback, 0);
         });
         builder.Logging.ClearProviders();
 
@@ -384,7 +459,6 @@ public class RemoteTerminalWorkloadAdapterTests
             catch (OperationCanceledException) { }
         });
 
-        await app.StartAsync();
         return app;
     }
 


### PR DESCRIPTION
## Summary

Fixes #501.

Replace the random mock-server port with an OS-assigned loopback endpoint. This is a test-fixture-only fix; no production code, callback behavior, initial-screen behavior, disconnect assertions, or parallelism settings change.

## Established cause

`RemoteTerminalWorkloadAdapterTests.InitializeAsync` selected `Random.Shared.Next(19000, 19999)` and passed that unreserved port to Kestrel. The assembly runs tests with `ExecutionScope.MethodLevel`, so independent fixture instances could choose the same one of 999 ports while another instance was still listening. An unrelated process could also occupy the selected port. There was no reservation or availability check.

The fixture at the sampled head `e3a52e89` is byte-for-byte identical to the pre-fix fixture here (Git blob `3779967599196688fe7022785f906dddb37488b3`). The reported initialization stacks for #501, #500, and #499 all reach this same allocation/bind path before their respective test bodies. The exact competing listener in those historical jobs is not identifiable from the available failure evidence; the shared unsafe allocation mechanism is directly reproducible.

## Binding and lifetime changes

- Configure Kestrel with `Listen(IPAddress.Loopback, 0)`: the OS chooses and reserves the port in the actual listening socket's bind operation, with no probe/release/rebind window.
- Await startup, then derive the WebSocket URI's host and assigned port from the single published `WebApplication.Urls` address, preserving `/ws/attach`.
- Store the built application on the fixture before awaiting startup so test cleanup owns it even when startup fails. Existing WebSocket-handler signaling and server stop/disposal remain intact.
- Document the network-fixture pattern in the unit-testing skill, as required by that skill's maintenance guidance.

No retries, sleeps, expanded port ranges, new testing tools, or disabled parallelism were added.

## Regression evidence

Added two tests:

- Concurrently start four fixture instances, assert distinct nonzero endpoints and exact client URI propagation, verify each HTTP endpoint still rejects a non-WebSocket request with 400, and connect a real remote adapter to each server. Unique authorization markers establish independent routing; path, handshake dimensions, and initial `Welcome` output are checked.
- Stop/dispose an initialized fixture and successfully bind a listener to its former endpoint, covering listening-socket release.

Before the fix, the endpoint regression failed on the old hard-coded `localhost` versus the bound `127.0.0.1` address. Separately, a **temporary controlled mutation** replacing the random draw with `19712` forced colliding fixture allocations: the concurrent regression failed with the same `IOException` / `AddressInUseException` at `InitializeAsync` / `StartMockServerAsync`. This demonstrates the collision mechanism, not a claim of spontaneously reproducing the historical failure frequency. The temporary mutation is not in this PR.

After the fix, all **20 remote-terminal fixture tests passed**, followed by **10 complete targeted repetitions: 200/200 passed, 0 failed, 0 skipped**, with method-level parallelism enabled on macOS arm64 / .NET 10. This includes the unchanged assertions named in #501, #500, and #499 plus both new regressions.

```sh
dotnet test tests/Hex1b.Tests/Hex1b.Tests.csproj --no-restore --no-progress \
  --filter "FullyQualifiedName~RemoteTerminalWorkloadAdapterTests" -v q
# Repeated ten times with --no-build added.
```

Local validation is targeted, not a full-suite or Linux/Windows pass claim. The normal PR workflow supplies Linux/Windows full-suite coverage; no repeated full-workflow campaign was initiated.

## Related issues and scope

Related: #500 and #499. Their observed setup failures are addressed by the same shared-fixture change, so no independent functional fixes are needed for those reported symptoms. They are intentionally not auto-closed by this PR; disposition remains for user review.

Based on main `50cc76eb` after #508 and #507; their tree/scheduler fixes are preserved. No other flaky-test issues are included. Leave this PR open for explicit user review; do not merge or enable auto-merge.