### PR TITLE
Fix Windows process-output tests and drain output before shutdown (#503)

### DIFF
--- a/.github/skills/writing-unit-tests/SKILL.md
+++ b/.github/skills/writing-unit-tests/SKILL.md
@@ -343,6 +343,18 @@ For nested output races, gate later child redraws: their extra notifications can
 mask a lost first-frame notification. These controlled cases supplement, rather
 than prove, responsiveness under arbitrary real-world load.
 
+## Process Output Completion
+
+Process exit and terminal output consumption are separate events. For a controlled
+regression, start a `StandardProcessWorkloadAdapter` and await its exit before
+constructing a terminal with an already-completed run callback. Gate the first
+presentation write with a `TaskCompletionSource`: `RunAsync` and lifecycle
+completion must remain pending until the gate is released and both stdout and
+stderr reach the snapshot. See `StandardProcessOutputTests` for raw and filtered
+output, cancellation, and pump-failure cases. Keep ordinary `WithProcess` tests
+alongside this ordering test; do not keep a one-shot child alive or wait for visible
+output before awaiting `RunAsync` in a drain regression, since that hides the race.
+
 ## Widget Test Dimensions
 
 When writing tests for widgets, consider all the **dimensions** that affect behavior. Each widget should have tests covering these scenarios:

--- a/.github/skills/writing-unit-tests/SKILL.md
+++ b/.github/skills/writing-unit-tests/SKILL.md
@@ -354,6 +354,9 @@ stderr reach the snapshot. See `StandardProcessOutputTests` for raw and filtered
 output, cancellation, and pump-failure cases. Keep ordinary `WithProcess` tests
 alongside this ordering test; do not keep a one-shot child alive or wait for visible
 output before awaiting `RunAsync` in a drain regression, since that hides the race.
+For echo/transport tests, use an already-available executable (`cmd /d /c echo` on
+Windows, `/bin/echo` on Unix). Runtime-compiling a temporary C# program with
+`dotnet run` puts SDK startup and compilation inside the output deadline.
 
 ## Widget Test Dimensions
 

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -569,6 +569,11 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
     /// workload lifecycle.
     /// </para>
     /// <para>
+    /// For <see cref="StandardProcessWorkloadAdapter"/> workloads, normal completion
+    /// also waits for redirected output to be applied to the terminal and sent to
+    /// the presentation adapter. Cancellation can interrupt this drain.
+    /// </para>
+    /// <para>
     /// For terminals created with a raw workload adapter and no run callback, this method
     /// waits for the workload to disconnect.
     /// </para>
@@ -596,13 +601,10 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 startedAdapter.TerminalStarted();
             }
 
-            // Execute the run callback or wait for workload disconnect
-            var runTask = _runCallback != null
-                ? _runCallback(ct)
-                : WaitForWorkloadDisconnectWithExitCodeAsync(ct);
+            var runTask = RunWorkloadAsync(ct);
 
-            var completedTask = await Task.WhenAny(runTask, _pumpFaultTcs.Task);
-            if (completedTask == _pumpFaultTcs.Task)
+            await Task.WhenAny(runTask, _pumpFaultTcs.Task);
+            if (_pumpFaultTcs.Task.IsCompleted)
             {
                 var (pumpName, error) = await _pumpFaultTcs.Task;
                 throw new InvalidOperationException($"The {pumpName} failed.", error);
@@ -638,6 +640,22 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 }
             }
         }
+    }
+
+    private async Task<int> RunWorkloadAsync(CancellationToken ct)
+    {
+        var exitCode = _runCallback != null
+            ? await _runCallback(ct)
+            : await WaitForWorkloadDisconnectWithExitCodeAsync(ct);
+
+        // Process exit drains stdout/stderr into the adapter's channel, not into
+        // the terminal. Finish applying and presenting those bytes before shutdown.
+        if (_workload is StandardProcessWorkloadAdapter && _outputProcessingTask is not null)
+        {
+            await _outputProcessingTask.WaitAsync(ct);
+        }
+
+        return exitCode;
     }
 
     /// <summary>
@@ -1282,6 +1300,11 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
 
                     // Channel empty - this is a frame boundary
                     await NotifyWorkloadFiltersFrameCompleteAsync();
+
+                    // Standard process reads return empty only at EOF (or cancellation).
+                    // Other workloads can return empty between frames and must keep pumping.
+                    if (_workload is StandardProcessWorkloadAdapter)
+                        break;
                     
                     // Small delay to prevent busy-waiting in headless mode
                     await Task.Delay(10, ct);

--- a/tests/Hex1b.Tests/Hex1bTerminalBuilderTests.cs
+++ b/tests/Hex1b.Tests/Hex1bTerminalBuilderTests.cs
@@ -604,16 +604,15 @@ public class Hex1bTerminalBuilderTests
     [TestMethod]
     public async Task WithProcess_ExecutesProcess()
     {
-        // Inline C# echo script
-        const string script = """Console.WriteLine(string.Join(" ", args));""";
-        
-        using var workspace = TestWorkspace.Create("process_exec");
-        var scriptFile = workspace.CreateCSharpProgram("echo.cs", script);
-        
+        // Test process output, not on-demand SDK compilation inside the output deadline.
+        var (fileName, arguments) = OperatingSystem.IsWindows()
+            ? ("cmd.exe", new[] { "/d", "/c", "echo", "Hello", "from", "process" })
+            : ("/bin/echo", new[] { "Hello", "from", "process" });
+
         var pattern = new CellPatternSearcher().Find("Hello from process");
         
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithProcess("dotnet", "run", scriptFile.FullName, "Hello", "from", "process")
+            .WithProcess(fileName, arguments)
             .WithHeadless()
             .WithDimensions(60, 10)
             .Build();
@@ -653,14 +652,10 @@ public class Hex1bTerminalBuilderTests
     [TestMethod]
     public async Task WithProcess_ProcessStartInfo_AdapterCapturesOutput()
     {
-        // Inline C# echo script
-        const string script = """Console.WriteLine(string.Join(" ", args));""";
-        
-        using var workspace = TestWorkspace.Create("adapter_output");
-        var scriptFile = workspace.CreateCSharpProgram("echo.cs", script);
-        
-        var startInfo = new ProcessStartInfo("dotnet", $"run {scriptFile.FullName} AdapterTestOutput");
-        var adapter = new StandardProcessWorkloadAdapter(startInfo);
+        var startInfo = OperatingSystem.IsWindows()
+            ? new ProcessStartInfo("cmd.exe", "/d /c echo AdapterTestOutput")
+            : new ProcessStartInfo("/bin/echo", "AdapterTestOutput");
+        await using var adapter = new StandardProcessWorkloadAdapter(startInfo);
         
         await adapter.StartAsync();
         
@@ -680,7 +675,6 @@ public class Hex1bTerminalBuilderTests
         }
         
         var exitCode = await adapter.WaitForExitAsync();
-        await adapter.DisposeAsync();
         
         Assert.AreEqual(0, exitCode);
         Assert.Contains("AdapterTestOutput", output.ToString());

--- a/tests/Hex1b.Tests/StandardProcessOutputTests.cs
+++ b/tests/Hex1b.Tests/StandardProcessOutputTests.cs
@@ -1,0 +1,247 @@
+using System.Diagnostics;
+using System.Text;
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests;
+
+[TestClass]
+public class StandardProcessOutputTests
+{
+    [TestMethod]
+    [DataRow(0, false)]
+    [DataRow(7, false)]
+    [DataRow(0, true)]
+    [DataRow(7, true)]
+    public async Task RunAsync_ProcessAlreadyExited_DrainsOutputBeforeCompleting(int exitCode, bool filtered)
+    {
+        await using var adapter = new StandardProcessWorkloadAdapter(CreateStartInfo(exitCode));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await adapter.StartAsync(cts.Token);
+        Assert.AreEqual(exitCode, await adapter.WaitForExitAsync(cts.Token));
+
+        var presentation = new GatedPresentationAdapter();
+        var options = new Hex1bTerminalOptions
+        {
+            WorkloadAdapter = adapter,
+            PresentationAdapter = presentation,
+            RunCallback = _ => Task.FromResult(adapter.ExitCode)
+        };
+        if (filtered)
+            options.PresentationFilters.Add(new PassthroughPresentationFilter());
+        await using var terminal = new Hex1bTerminal(options);
+
+        var runTask = terminal.RunAsync(cts.Token);
+        try
+        {
+            // The child has exited, but the first write and all subsequent reads
+            // are deliberately blocked until the test releases the presentation.
+            Assert.IsFalse(runTask.IsCompleted, "Process exit must not complete the terminal before output is drained.");
+            await presentation.WriteStarted.Task.WaitAsync(cts.Token);
+            Assert.IsNull(presentation.CompletedExitCode);
+
+            presentation.ReleaseWrite.TrySetResult();
+            Assert.AreEqual(exitCode, await runTask.WaitAsync(cts.Token));
+            Assert.AreEqual(exitCode, presentation.CompletedExitCode);
+            Assert.IsTrue(presentation.CompletedAfterOutput);
+            Assert.Contains("FirstOutput", presentation.Output.ToString());
+            Assert.Contains("FinalOutput", presentation.Output.ToString());
+            Assert.Contains("ErrorOutput", presentation.Output.ToString());
+            var snapshot = terminal.CreateSnapshot();
+            Assert.IsTrue(snapshot.ContainsText("FirstOutput"));
+            Assert.IsTrue(snapshot.ContainsText("FinalOutput"));
+            Assert.IsTrue(snapshot.ContainsText("ErrorOutput"));
+        }
+        finally
+        {
+            presentation.ReleaseWrite.TrySetResult();
+            await cts.CancelAsync();
+        }
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public async Task RunAsync_WhileDrainingOutput_PropagatesCancellationOrPumpFailure(bool failOutput)
+    {
+        await using var adapter = new StandardProcessWorkloadAdapter(CreateStartInfo(0));
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        using var runCts = CancellationTokenSource.CreateLinkedTokenSource(timeout.Token);
+        await adapter.StartAsync(timeout.Token);
+        await adapter.WaitForExitAsync(timeout.Token);
+
+        var presentation = new GatedPresentationAdapter();
+        await using var terminal = new Hex1bTerminal(new Hex1bTerminalOptions
+        {
+            WorkloadAdapter = adapter,
+            PresentationAdapter = presentation,
+            RunCallback = _ => Task.FromResult(adapter.ExitCode)
+        });
+
+        var runTask = terminal.RunAsync(runCts.Token);
+        try
+        {
+            await presentation.WriteStarted.Task.WaitAsync(timeout.Token);
+            if (failOutput)
+            {
+                var error = new IOException("Synthetic output failure after process exit.");
+                presentation.WriteError = error;
+                presentation.ReleaseWrite.TrySetResult();
+                var exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+                    () => runTask.WaitAsync(timeout.Token));
+                Assert.AreSame(error, exception.InnerException);
+                Assert.Contains("workload output pump", exception.Message);
+            }
+            else
+            {
+                await runCts.CancelAsync();
+                await Assert.ThrowsAsync<OperationCanceledException>(() => runTask.WaitAsync(timeout.Token));
+            }
+            Assert.IsNull(presentation.CompletedExitCode);
+        }
+        finally
+        {
+            presentation.WriteError = null;
+            presentation.ReleaseWrite.TrySetResult();
+            await runCts.CancelAsync();
+        }
+    }
+
+    [TestMethod]
+    [DataRow(0, false)]
+    [DataRow(7, false)]
+    [DataRow(0, true)]
+    [DataRow(7, true)]
+    public async Task WithProcess_QuickExit_PreservesOutputAndExitCode(int exitCode, bool silent)
+    {
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithProcess(CreateStartInfo(exitCode, silent))
+            .WithHeadless()
+            .WithDimensions(80, 10)
+            .Build();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        Assert.AreEqual(exitCode, await terminal.RunAsync(cts.Token));
+        if (!silent)
+        {
+            var snapshot = terminal.CreateSnapshot();
+            Assert.IsTrue(snapshot.ContainsText("FirstOutput"));
+            Assert.IsTrue(snapshot.ContainsText("FinalOutput"));
+            Assert.IsTrue(snapshot.ContainsText("ErrorOutput"));
+        }
+    }
+
+    [TestMethod]
+    public async Task WaitForExitAsync_BeforeReadingOutput_PreservesBothStreams()
+    {
+        await using var adapter = new StandardProcessWorkloadAdapter(CreateStartInfo(7));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var disconnected = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var disconnectCount = 0;
+        adapter.Disconnected += () =>
+        {
+            Interlocked.Increment(ref disconnectCount);
+            disconnected.TrySetResult();
+        };
+
+        await adapter.StartAsync(cts.Token);
+        Assert.AreEqual(7, await adapter.WaitForExitAsync(cts.Token));
+        await disconnected.Task.WaitAsync(cts.Token);
+
+        var output = new StringBuilder();
+        while (true)
+        {
+            var data = await adapter.ReadOutputAsync(cts.Token);
+            if (data.IsEmpty)
+                break;
+            output.Append(Encoding.UTF8.GetString(data.Span));
+        }
+
+        Assert.AreEqual(1, disconnectCount);
+        Assert.IsTrue(adapter.HasExited);
+        Assert.Contains("FirstOutput\n", output.ToString());
+        Assert.Contains("FinalOutput\n", output.ToString());
+        Assert.Contains("ErrorOutput\n", output.ToString());
+    }
+
+    private static ProcessStartInfo CreateStartInfo(int exitCode, bool silent = false)
+    {
+        var startInfo = new ProcessStartInfo(OperatingSystem.IsWindows() ? "cmd.exe" : "/bin/sh");
+        if (OperatingSystem.IsWindows())
+        {
+            startInfo.ArgumentList.Add("/d");
+            startInfo.ArgumentList.Add("/c");
+            startInfo.ArgumentList.Add(silent
+                ? $"exit /b {exitCode}"
+                : $"echo FirstOutput&echo FinalOutput&echo ErrorOutput>&2&exit /b {exitCode}");
+        }
+        else
+        {
+            startInfo.ArgumentList.Add("-c");
+            startInfo.ArgumentList.Add(silent
+                ? $"exit {exitCode}"
+                : $"printf 'FirstOutput\\nFinalOutput\\n'; printf 'ErrorOutput' >&2; exit {exitCode}");
+        }
+        return startInfo;
+    }
+
+    private sealed class GatedPresentationAdapter : IHex1bTerminalPresentationAdapter, ITerminalLifecycleAwarePresentationAdapter
+    {
+        private readonly HeadlessPresentationAdapter _headless = new(80, 10);
+        private Hex1bTerminal? _terminal;
+
+        public TaskCompletionSource WriteStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource ReleaseWrite { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public StringBuilder Output { get; } = new();
+        public int? CompletedExitCode { get; private set; }
+        public bool CompletedAfterOutput { get; private set; }
+        public Exception? WriteError { get; set; }
+        public int Width => _headless.Width;
+        public int Height => _headless.Height;
+        public TerminalCapabilities Capabilities => _headless.Capabilities;
+        public event Action<int, int>? Resized { add { } remove { } }
+        public event Action? Disconnected { add { } remove { } }
+
+        public async ValueTask WriteOutputAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default)
+        {
+            WriteStarted.TrySetResult();
+            await ReleaseWrite.Task.WaitAsync(ct);
+            if (WriteError is { } error)
+                throw error;
+            Output.Append(Encoding.UTF8.GetString(data.Span));
+        }
+
+        public void TerminalCreated(Hex1bTerminal terminal) => _terminal = terminal;
+        public void TerminalStarted() { }
+        public void TerminalCompleted(int exitCode)
+        {
+            CompletedExitCode = exitCode;
+            var snapshot = _terminal!.CreateSnapshot();
+            CompletedAfterOutput = snapshot.ContainsText("FirstOutput")
+                && snapshot.ContainsText("FinalOutput")
+                && snapshot.ContainsText("ErrorOutput");
+        }
+
+        public ValueTask<ReadOnlyMemory<byte>> ReadInputAsync(CancellationToken ct = default) => _headless.ReadInputAsync(ct);
+        public ValueTask FlushAsync(CancellationToken ct = default) => _headless.FlushAsync(ct);
+        public ValueTask EnterRawModeAsync(CancellationToken ct = default) => _headless.EnterRawModeAsync(ct);
+        public ValueTask ExitRawModeAsync(CancellationToken ct = default) => _headless.ExitRawModeAsync(ct);
+        public (int Row, int Column) GetCursorPosition() => (0, 0);
+        public ValueTask DisposeAsync() => _headless.DisposeAsync();
+    }
+
+    private sealed class PassthroughPresentationFilter : IHex1bTerminalPresentationFilter
+    {
+        public ValueTask<IReadOnlyList<AnsiToken>> OnOutputAsync(
+            IReadOnlyList<AppliedToken> appliedTokens, TimeSpan elapsed, CancellationToken ct = default)
+            => ValueTask.FromResult<IReadOnlyList<AnsiToken>>(appliedTokens.Select(t => t.Token).ToArray());
+
+        public ValueTask OnSessionStartAsync(int width, int height, DateTimeOffset timestamp, CancellationToken ct = default)
+            => ValueTask.CompletedTask;
+        public ValueTask OnInputAsync(IReadOnlyList<AnsiToken> tokens, TimeSpan elapsed, CancellationToken ct = default)
+            => ValueTask.CompletedTask;
+        public ValueTask OnResizeAsync(int width, int height, TimeSpan elapsed, CancellationToken ct = default)
+            => ValueTask.CompletedTask;
+        public ValueTask OnSessionEndAsync(TimeSpan elapsed, CancellationToken ct = default)
+            => ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #503. Related: #502, #463.

Remove on-demand SDK compilation from the two affected echo transport tests, and drain one-shot standard-process output before terminal shutdown.

**Current status: green and ready for review.** Rebased cleanly onto `main` at `6b207871b0125dbbb497262d33ae0bbd816c22b4`; current head is `835fedce56b599057e3fdc19d77335a8486af709`. `git range-diff` confirmed both focused commits are unchanged by the rebase. No merge or auto-merge is authorized.

## Diagnosis and changes
The original echo fixtures generated temporary C# programs and ran `dotnet run` inside a 30-second output deadline. Initial drain-only CI still failed #503 at 30.105s and #502 at 38.133s: in the latter, reading stopped at its cancellation deadline before the process eventually returned exit code 0. That direct-adapter path bypasses terminal shutdown, so draining alone was insufficient.

Both affected tests now use an already-available executable: `cmd.exe /d /c echo` on Windows, `/bin/echo` on Unix. Real subprocess execution, original output/argument expectations, exit-code assertions and the 30-second deadline are preserved. Other .NET process execution/environment/working-directory tests remain unchanged. The direct adapter uses `await using` to guarantee cleanup on failure.

The precise earlier Windows delay was not separately instrumented as startup versus observation. [SDK source](https://github.com/dotnet/sdk/blob/v10.0.100/src/Cli/dotnet/Commands/Run/RunCommand.cs#L119-L174) establishes compilation before target execution, but this PR does not claim a particular compiler-server timeout, artifact collision or SDK bug.

Independently, deterministic coverage proved that `RunAsync` cancelled its pump after process bytes were queued but before they necessarily reached the terminal/presentation. Standard-process EOF now ends the pump, and normal completion awaits it before lifecycle notification/shutdown. Cancellation interrupts draining and pump faults remain visible even when drain completion and fault notification become ready together. PTY/app/remote empty-read behavior and adapter line/encoding semantics are unchanged.

## Regression evidence
The controlled regression starts a real child, waits for exit, supplies an already-completed terminal callback, and gates presentation. Before the production fix, exit-code 0 and 7 cases failed immediately on premature completion; the direct-adapter case passed. No sleeps/retries control this ordering.

Eleven new cases cover raw/filtered output, stdout/stderr, lifecycle ordering, success/nonzero exit, cancellation/faults during drain, quick-exit builders, silent children and adapter reads after exit. Local macOS: 20 process cases repeated ten times, **200 passes / no skips**. Post-rebase neighboring coverage: **83 passed / 1 existing skip**.

Command: `dotnet test tests/Hex1b.Tests/Hex1b.Tests.csproj -v q --no-progress --filter 'FullyQualifiedName~StandardProcessOutputTests|FullyQualifiedName~Hex1bTerminalBuilderTests.WithProcess'`. Repetitions add `--no-build`; neighboring coverage additionally selects `Hex1bTerminalTests`, `TerminalFilterTests`, and `TerminalOutputByteCountTests`.

## Current CI: all required jobs passed
[Run 34298456408](https://github.com/mitchdenny/hex1b/actions/runs/34298456408), first attempt on rebased head `835fedce`:

| Suite | Windows | Linux |
|---|---:|---:|
| Main | 9,935 passed / 41 existing skips | 9,953 passed / 23 existing skips |
| Analyzers | 67 passed | 67 passed |
| MCP | 6 passed | 6 passed |
| Tool | 58 passed | 58 passed |

Zero failures. #503, #502, all eleven regressions and the three previously failing PTY/table/flow tests passed on both platforms. Native builds, web build/tests, PR package build/verification and PR package publishing all succeeded. Release/production jobs were correctly skipped for a PR; no required downstream job was skipped.

## Earlier CI history retained
Before rebase, [run 34227033332](https://github.com/mitchdenny/hex1b/actions/runs/34227033332) at `901318c4` had all 20 targeted cases passing on both platforms but failed Windows on the historical PTY diagnostic. The one parent-authorized Windows job retry also failed the table-focus intermediate assertion and the flow newline assertion. Windows analyzer/MCP/tool suites and PR packaging did not run in those failed attempts. Their TRX, logs and job metadata were preserved separately; this green rebase run does not rewrite that history.

Read-only triage showed the table test uses `Hex1bAppWorkloadAdapter` and `app.RunAsync`, never the changed standard-process drain path. Its failed intermediate sample saw Item 00060, while later states were correct and all 70 focus changes occurred, strongly suggesting premature sampling rather than a proven prior identical failure. The PTY diagnostic matches #463; the flow newline assertion matches #505. Neither was changed here. All three now pass, but their intermittent nature is not claimed fixed by this PR or by the rebase.

## Scope and review gate
The shared echo-fixture change also addresses #502's runtime-compilation dependency; its issue disposition remains parent/user-owned, so only #503 is auto-linked for closure. No broader #463 resolution or long-term flake-rate guarantee is claimed.

No timeout increases, assertion weakening, blanket serialization, sampling changes or unrelated flake fixes. Await explicit user approval; do not merge or enable auto-merge.