### PR TITLE
Support OSC 9;4 progress and OSC 133 shell integration

### DIFF
--- a/docs/muxer-protocol.md
+++ b/docs/muxer-protocol.md
@@ -9,6 +9,8 @@ The Hex1b Muxer Protocol is a binary framing protocol for multiplexing terminal 
 > `Hello` payload and a new client-emitted `ClientHello`. Old binaries cannot
 > speak the updated HMP1 — all builds upgrade together. Animation replay also
 > adds the one-time `KgpAnimationState` checkpoint described below.
+> Activity replay adds a mandatory `ActivityState` checkpoint after every
+> `StateSync`; producers and consumers must upgrade together.
 
 ## Frame Format
 
@@ -43,6 +45,7 @@ Maximum payload size: 16 MB.
 | PeerLeave | `0x0A` | Server → Client (broadcast) | An existing peer disconnected |
 | ClientHello | `0x0B` | Client → Server | Client identifies itself before the server's Hello (display name, default role) |
 | KgpAnimationState | `0x0C` | Server → Client | One-time playback-progress checkpoint following KGP animation replay |
+| ActivityState | `0x0D` | Server → Client | Mandatory activity baseline immediately following each StateSync |
 
 ## Peer IDs
 
@@ -166,15 +169,57 @@ including links spanning rows or wide characters. The active hyperlink is restor
 after painting so subsequent output retains its original link state. Sixel damage
 repaint also preserves cell links without changing that active state.
 
+Every `StateSync` is immediately followed by `ActivityState`, including an empty
+screen replay. The receiver buffers both as one state transaction before exposing
+the connected baseline. This also applies to later `StateSync` frames. A relay
+preserves this pair as control frames, not ordinary live output.
+
+The raw ANSI includes a canonical OSC 9;4 sequence for the current progress
+indicator, including explicit clear, so an ANSI-only/native presentation can
+restore progress. An authoritative replica suppresses intermediate replay
+notifications and uses the checkpoint for its final state. Shell phase is never
+reconstructed by emitting OSC 133 marker chains.
+
 If the snapshot contains graphics, the server queues KGP and Sixel replay after
-`StateSync` and before subsequent live output. The clear-screen sequence in
+`ActivityState` and before subsequent live output. The clear-screen sequence in
 `StateSync` would erase graphics sent before it. Graphics use separate `Output`
 frames because their encoded data may exceed the maximum size of one HMP frame.
+An unfinished ANSI parser prefix follows graphics replay and precedes live output,
+so a late-attaching replica can finish a fragmented OSC sequence without losing it.
 
 KGP animation replay sends the root and all fully composed frames, timing gaps,
 current-frame selection, placements, and playback controls. A subsequent
 `KgpAnimationState` frame restores the captured loop progress and frame age.
 There is no per-animation-tick retransmission of these pixels.
+
+### ActivityState (0x0D)
+
+This mandatory server-to-client UTF-8 JSON checkpoint is limited to **1,024 bytes**,
+with required fields (including explicit nulls):
+
+```json
+{
+  "progress": { "state": 1, "percentage": 42 },
+  "shellIntegration": { "phase": 3, "lastExitCode": -1 }
+}
+```
+
+Progress states are 0 (none), 1 (normal), 2 (error), 3 (indeterminate), and 4
+(warning). States 0 and 3 require a null percentage; the others require an
+integer from 0 through 100. Shell phases are 0 (unknown), 1 (prompt),
+2 (command line), 3 (executing), and 4 (finished). `lastExitCode` is null or a
+signed 32-bit integer; unknown phase requires null. Prompt, command-line, and
+executing phases may preserve the latest reported completion result.
+
+Defaults are none/null and unknown/null. Missing, malformed, oversized,
+incomplete, or unpaired checkpoints fail the connection, rather than making a
+partial screen baseline ready. Unknown or duplicate fields are rejected.
+
+The checkpoint restores **current state**, not command history or execution
+events. Identical resyncs do not publish changed-state notifications; later real
+OSC 9;4 and OSC 133 output is parsed normally. Browser presentations may coalesce
+transitions. Disconnect and workload exit retain the last reported state; they do
+not synthesize a command completion or progress clear.
 
 ### KgpAnimationState (0x0C)
 

--- a/docs/web-terminal-protocol.md
+++ b/docs/web-terminal-protocol.md
@@ -162,6 +162,8 @@ delta.
 | `mouseTracking` | integer | Effective mouse tracking mode: `0`, `9`, `1000`, `1002`, or `1003`; see §7. |
 | `peer` | object | Required complete HMP1 peer/primary state, or standalone defaults, defined below. |
 | `title` | string | Required complete current workload window title on every full/delta frame; `""` means unset or explicitly cleared. At most 4,096 UTF-16 code units, no C0/DEL/C1 controls or unpaired surrogates. |
+| `progress` | object | Required complete OSC 9;4 state: `state` and nullable `percentage`, defined below. |
+| `shellIntegration` | object | Required complete OSC 133 state: `phase` and nullable `lastExitCode`, defined below. |
 | `history` | object or null | Complete per-view text viewport, selection, and copy state, defined below. Null denotes a projection without history interaction metadata. |
 | `hyperlinks` | array of objects | Complete OSC 8 destination ranges for the presented viewport, including on cell-delta frames. |
 | `defaultBackground`, `defaultForeground` | integers | Resolved packed colors, using §3.3; producer emits opaque colors. |
@@ -212,6 +214,36 @@ Titles remain untrusted workload text, including literal markup and bidi text.
 The component never changes `document.title`, the accessible label, or host
 headers automatically. Hosts must use text rendering such as
 `header.textContent = title || fallback` and apply their own presentation policy.
+
+**Activity state:** `progress` is `{ "state": "none", "percentage": null }`
+initially. State is one of `none`, `normal`, `error`, `indeterminate`, `warning`.
+The percentage must be null for none/indeterminate and an integer 0-100 for
+the other states. `shellIntegration` initially contains
+`{ "phase": "unknown", "lastExitCode": null }`. Phase is one of `unknown`,
+`prompt`, `commandLine`, `executing`, `finished`. Last exit code is null or a
+signed 32-bit integer; Unknown requires null. Null does not imply success.
+All properties are required, including explicit nulls.
+
+Both objects are captured atomically with the screen, sent on every full and
+delta frame, and remain current when inspecting historical rows. Metadata-only
+output can emit a zero-cell delta. They use existing acknowledgement and
+synchronized-output coalescing; they do not retain semantic boundary positions
+or transport an event log. The browser validates fields before presenting,
+updates both getters, then invokes `onProgressChange` and
+`onShellIntegrationChange` for the initial state and distinct presented changes.
+Missing/malformed fields are fatal. Unchanged resyncs, discarded frames, and
+disposal do not notify.
+
+HMP1 restores these values from its structured activity checkpoint as part of
+the StateSync transaction, before the replica is available to browser capture.
+It does not reconstruct shell phase by sending synthetic OSC 133 markers.
+See [the muxer protocol](muxer-protocol.md) for ordering. Live OSC sequences
+still pass through the core parser. RIS clears activity; soft resets, screen
+clears, resize, and buffer switches preserve it. Disconnect/exit retain the
+last reported values, not an invented completion. Hosts should combine these
+values with connection status. The
+[public client contract](../src/web-terminal/README.md#application-progress-and-shell-activity)
+describes callback semantics and the supported OSC argument forms.
 
 `cursor` has exactly these currently emitted fields:
 
@@ -1195,6 +1227,8 @@ not a recorded multi-head benchmark.
   "mouseTracking": 0,
   "peer": { "id": null, "primaryId": null, "isPrimary": true },
   "title": "",
+  "progress": { "state": "none", "percentage": null },
+  "shellIntegration": { "phase": "unknown", "lastExitCode": null },
   "history": null,
   "hyperlinks": [],
   "defaultBackground": 4279769112,

--- a/samples/WebTerminalDemo/DemoWorkload.cs
+++ b/samples/WebTerminalDemo/DemoWorkload.cs
@@ -27,9 +27,10 @@ internal sealed class DemoWorkload : IHex1bTerminalWorkloadAdapter
 
     public DemoWorkload(string scene, int columns, int rows)
     {
-        if (scene is not ("mixed" or "text" or "sixel" or "kgp" or "animation"))
+        if (scene is not ("mixed" or "text" or "sixel" or "kgp" or "animation" or "activity"))
             throw new ArgumentException("Unknown demo scene.", nameof(scene));
         _scene = scene;
+        if (scene == "activity") _rate = 1;
         _columns = Math.Clamp(columns, 1, 300);
         _rows = Math.Clamp(rows, 2, 100);
         _sixels = scene is "mixed" or "sixel"
@@ -160,6 +161,8 @@ internal sealed class DemoWorkload : IHex1bTerminalWorkloadAdapter
                         Dashboard(output, columns, rows, tick);
                     else if (_scene == "kgp")
                         PlaceImage(output, columns, rows, tick);
+                    if (_scene == "activity")
+                        Activity(output, tick);
                     if (_scene == "text")
                     {
                         output.Append($"\x1b[3;{Math.Max(3, rows - 2)}r")
@@ -203,7 +206,7 @@ internal sealed class DemoWorkload : IHex1bTerminalWorkloadAdapter
         output.Append("\x1b[0m\x1b[2J").Append(Cup(1, 1))
             .Append("\x1b[1;38;2;100;210;255mHex1b WebTerminalDemo\x1b[0m");
         Status(output, 2, $"{_scene}: raw ANSI -> real Hex1bTerminal -> authoritative browser state");
-        if (_scene == "text") return;
+        if (_scene is "text" or "activity") return;
         output.Append(Cup(3, 1)).Append("Wide: \u4e16\u754c \u65e5\u672c\u8a9e | emoji: \U0001f680 \U0001f30d | combining: e\u0301 a\u0308 n\u0303")
             .Append(Cup(4, 1)).Append("\x1b[1mBold\x1b[0m  \x1b[3mItalic\x1b[0m  \x1b[4mUnderline\x1b[0m  \x1b[9mStrike\x1b[0m")
             .Append(Cup(5, 1)).Append("\x1b[2mDim\x1b[0m  \x1b[7mReverse\x1b[0m  \x1b[38;2;255;170;50mTruecolor\x1b[0m  \x1b[48;5;54m Indexed BG \x1b[0m");
@@ -222,6 +225,30 @@ internal sealed class DemoWorkload : IHex1bTerminalWorkloadAdapter
         }
         if (_scene == "mixed")
             output.Append(Cup(7, Math.Max(2, columns / 2))).Append("KGP: RGBA + alpha holes");
+    }
+
+    private static void Activity(StringBuilder output, long tick)
+    {
+        var (sequence, description) = (tick % 12) switch
+        {
+            0 => ("\x1b]9;4;0\a\x1b]133;A\a", "Prompt starts; progress hidden"),
+            1 => ("\x1b]133;B\a", "Command-line input; not executing"),
+            2 => ("\x1b]133;C\a\x1b]9;4;3\a", "Command executes; indeterminate progress"),
+            3 => ("\x1b]9;4;1;25\a", "Normal progress: 25%"),
+            4 => ("\x1b]9;4;1;75\a", "Normal progress: 75%"),
+            5 => ("\x1b]9;4;4;75\a", "Warning progress: 75%"),
+            6 => ("\x1b]9;4;2;75\a", "Error progress: 75%"),
+            7 => ("\x1b]133;D;1\a\x1b]9;4;0\a", "Command finishes with exit code 1; progress cleared"),
+            8 => ("\x1b]133;A\a", "Next prompt; previous result remains available"),
+            9 => ("\x1b]133;B\a", "Next command-line input"),
+            10 => ("\x1b]133;C\a\x1b]9;4;1;100\a", "Next command executes; progress 100%"),
+            _ => ("\x1b]133;D;0\a\x1b]9;4;0\a", "Command finishes successfully; progress cleared")
+        };
+        output.Append(sequence);
+        Status(output, 3, "Simulated shell markers and application progress (no commands are run)");
+        Status(output, 5, description);
+        Status(output, 7, "Watch the host-owned activity strip above the terminal.");
+        Status(output, 8, "Pause to attach a late Direct HWT1 or HMP1 relay view.");
     }
 
     private void PlaceImage(StringBuilder output, int columns, int rows, long tick)

--- a/samples/WebTerminalDemo/Program.cs
+++ b/samples/WebTerminalDemo/Program.cs
@@ -37,8 +37,8 @@ app.MapGet("/health", () => Results.Ok(new { status = "ready", renderer = "WebGP
 app.MapGet("/api/terminals", () => Results.Ok(terminals.List()));
 app.MapPost("/api/terminals", (CreateTerminalRequest request) =>
 {
-    if (request.Scene is not ("mixed" or "text" or "sixel" or "kgp" or "animation" or "shell"))
-        return Results.BadRequest(new { error = "scene must be mixed, text, sixel, kgp, animation, or shell." });
+    if (request.Scene is not ("mixed" or "text" or "sixel" or "kgp" or "animation" or "activity" or "shell"))
+        return Results.BadRequest(new { error = "scene must be mixed, text, sixel, kgp, animation, activity, or shell." });
     if (request.Columns is < 20 or > 300 || request.Rows is < 10 or > 100)
         return Results.BadRequest(new { error = "columns must be 20..300 and rows must be 10..100." });
     if (!IsValidName(request.Name))

--- a/samples/WebTerminalDemo/README.md
+++ b/samples/WebTerminalDemo/README.md
@@ -93,6 +93,7 @@ origin:
 | `graphics.browser.js` | Sixel and KGP in mixed WebGPU/WebGL2 views, renderer controls/diagnostics, cached-image movement, and late attachment to silent server-driven animation. |
 | `relay.browser.js` | Direct/relay transport selection, mixed peers, input and resize authority, primary closure, fresh reconnect/navigation-return replicas, retained KGP movement, and silent animation. |
 | `titles.browser.js` | Real POSIX shell title output through direct HWT1 and HMP1 relay, initial/late/reconnect notifications, safe header text and fallback, reset retention, duplicate/resync suppression, and disposal. |
+| `activity.browser.js` | Host-owned progress/severity and shell-phase chrome, direct and relayed current state, paused late attachment, resync, and fresh reconnect. No shell hooks required. |
 | `cloud-flicker.browser.js` | Real shell-launched Sixel/KGP cloud animations, sampling visible canvas pixels over at least 180 browser frames and ten received updates; twenty fresh KGP views (including thumbnails) must retain sprites and keep animating without pixel re-uploads or stray command text. Build `samples/SixelCloudDemo` and `samples/KgpCloudDemo` in Release first. |
 | `nested-flicker.browser.js` | WindowingDemo's Bash terminal running KittySearch: hover animation must keep painting through unrelated parent redraws, with at least 180 sampled browser frames and five distinct image states. Build `samples/WindowingDemo` and `samples/KittySearch` in Release first. Requires Bash. |
 | `nested-sixel.browser.js` | WindowingDemo's Bash terminal running both SixelCloudDemo modes: native Sixel presentation, overlapping motes, and synchronized frame persistence. Build `samples/WindowingDemo` and `samples/SixelCloudDemo` in Release first. Requires Bash. |
@@ -154,6 +155,28 @@ opened views. `?renderer=webgl2` selects WebGL2 on initial load; `auto` and
 The selected-view metrics show the active backend and any automatic fallback
 reason. WebGPU requires HTTPS or localhost; the package can use WebGL2 on
 ordinary HTTP, but this demo's loopback-only host policy remains unchanged.
+
+### Progress and shell activity
+
+Choose **Progress and shell activity**, or open `?scene=activity`, to run a
+controlled, repeating demonstration at one step per second. It emits OSC 133
+prompt/input/execution/completion markers and OSC 9;4 busy, determinate,
+warning, error, and clear states. These are simulated shell markers: the scene
+does not execute commands or install shell hooks.
+
+The activity strip is owned by this sample, outside the mounted terminal.
+It uses only `onProgressChange` and `onShellIntegrationChange`, with connection
+status to suppress stale active chrome. The terminal's title remains independent.
+Pause the producer while busy or showing a warning, select **HMP1 relay**,
+and **Attach view**: the new view should immediately show current activity.
+Close and reattach it, or press **Resync**, to exercise state restoration.
+Resume to watch progress and the latest command result change together.
+
+These are coalesced current-state notifications, not a history of every command.
+For .NET consumers, `Hex1bTerminal.Progress`, `ShellIntegration`, and their
+matching change events expose the same state, captured atomically by
+`CreateSnapshot()`. An unknown shell phase does not mean idle; a nullable
+exit status does not mean success.
 
 ### Optional HMP1 relay
 

--- a/samples/WebTerminalDemo/client/main.ts
+++ b/samples/WebTerminalDemo/client/main.ts
@@ -296,6 +296,11 @@ async function openView(instance: TerminalInstance, { primary = false, thumbnail
       <button class="resync" disabled>Resync</button>
       <span class="view-grid"></span>
     </div>
+    <div class="view-activity" aria-live="polite">
+      <span class="shell-status">Shell activity unknown</span>
+      <progress class="activity-progress" max="100" hidden aria-label="Application progress"></progress>
+      <span class="progress-status"></span>
+    </div>
     <div class="terminal-mount"></div>
     <footer class="view-footer">
       <span class="view-status">Initializing renderer...</span>
@@ -365,6 +370,24 @@ async function openView(instance: TerminalInstance, { primary = false, thumbnail
       onTitleChange(title) {
         header.textContent = title || fallbackTitle;
       },
+      onProgressChange(progress) {
+        const bar = elementAt(element, ".activity-progress", HTMLProgressElement);
+        bar.hidden = progress.state === "none";
+        if (progress.percentage === null) bar.removeAttribute("value");
+        else bar.value = progress.percentage;
+        element.dataset.progress = progress.state;
+        elementAt(element, ".progress-status", HTMLElement).textContent = progress.state === "none" ? ""
+          : `${progress.state}${progress.percentage === null ? "" : ` ${progress.percentage}%`}`;
+      },
+      onShellIntegrationChange(shell) {
+        const labels = {
+          unknown: "Shell activity unknown", prompt: "Prompt", commandLine: "Command input",
+          executing: "Command running", finished: "Command finished"
+        };
+        element.dataset.shellPhase = shell.phase;
+        elementAt(element, ".shell-status", HTMLElement).textContent = labels[shell.phase] +
+          (shell.lastExitCode === null ? "" : ` / last exit ${shell.lastExitCode}`);
+      },
       onStatus(message, level) {
         const status = elementAt(element, ".view-status", HTMLElement);
         status.textContent = message;
@@ -401,6 +424,7 @@ async function openView(instance: TerminalInstance, { primary = false, thumbnail
       },
       onStats(stats, text) {
         view.stats = stats;
+        element.dataset.connected = String(stats.connected ?? false);
         if (text !== undefined) view.text = text;
         metrics(view);
       }

--- a/samples/WebTerminalDemo/tests/activity.browser.js
+++ b/samples/WebTerminalDemo/tests/activity.browser.js
@@ -1,0 +1,92 @@
+async page => {
+  const origin = page.url().match(/^https?:\/\/[^/]+/)?.[0] || "http://localhost:5290";
+  const context = await page.context().browser().newContext({ viewport: { width: 1400, height: 1000 } });
+  const test = await context.newPage();
+  const errors = [];
+  let instanceId;
+  test.on("pageerror", error => errors.push(error.message));
+  const check = (condition, message) => { if (!condition) throw new Error(message); };
+  const waitState = async (progress, phase) => test.waitForFunction(({ progress, phase }) =>
+    [...webTerminalViews.values()].length > 0 && [...webTerminalViews.values()].every(view =>
+      view.terminal?.connected && view.terminal.progress.state === progress &&
+      view.terminal.shellIntegration.phase === phase &&
+      view.element.dataset.progress === progress && view.element.dataset.shellPhase === phase),
+  { progress, phase }, { timeout: 30000 });
+  try {
+    await test.goto(`${origin}/?scene=activity&renderer=webgl2`);
+    await test.waitForFunction(() => [...webTerminalViews.values()].some(view => view.terminal?.connected),
+      null, { timeout: 30000 });
+    instanceId = await test.evaluate(() => [...webTerminalViews.values()][0].instance.id);
+    await waitState("indeterminate", "executing");
+    check(await test.evaluate(() => [...webTerminalViews.values()].every(view => {
+      const bar = view.element.querySelector(".activity-progress");
+      return !bar.hidden && !bar.hasAttribute("value") &&
+        view.element.querySelector(".shell-status").textContent.includes("Command running");
+    })), "Busy state did not update host-owned chrome");
+
+    const paused = await test.request.post(`${origin}/api/terminals/${instanceId}/controls`, {
+      headers: { Origin: origin }, data: { paused: true }
+    });
+    check(paused.status() === 204, "Failed to pause controlled activity");
+    await test.selectOption("#transport", "hmp1");
+    await test.click("#attach");
+    await test.waitForFunction(() => [...webTerminalViews.values()].length === 2 &&
+      [...webTerminalViews.values()].every(view => view.terminal?.connected),
+    null, { timeout: 30000 });
+    await test.waitForFunction(() => {
+      const [first, second] = [...webTerminalViews.values()];
+      return JSON.stringify(first.terminal.progress) === JSON.stringify(second.terminal.progress) &&
+        JSON.stringify(first.terminal.shellIntegration) === JSON.stringify(second.terminal.shellIntegration);
+    }, null, { timeout: 30000 });
+    const retained = await test.evaluate(() => {
+      const view = [...webTerminalViews.values()].find(view => view.transport === "hmp1");
+      const state = { progress: view.terminal.progress, shell: view.terminal.shellIntegration,
+        revision: view.terminal.stats.revision };
+      view.terminal.resync();
+      return state;
+    });
+    await test.waitForFunction(retained => [...webTerminalViews.values()]
+      .filter(view => view.transport === "hmp1").every(view =>
+        view.terminal.stats.revision > retained.revision &&
+        JSON.stringify(view.terminal.progress) === JSON.stringify(retained.progress) &&
+        JSON.stringify(view.terminal.shellIntegration) === JSON.stringify(retained.shell)),
+    retained, { timeout: 30000 });
+
+    await test.locator('[data-transport="hmp1"] .close-view').click();
+    await test.waitForFunction(() => webTerminalViews.size === 1);
+    await test.click("#attach");
+    await test.waitForFunction(retained => webTerminalViews.size === 2 &&
+      [...webTerminalViews.values()].filter(view => view.transport === "hmp1").every(view =>
+        view.terminal?.connected &&
+        JSON.stringify(view.terminal.progress) === JSON.stringify(retained.progress) &&
+        JSON.stringify(view.terminal.shellIntegration) === JSON.stringify(retained.shell)),
+    retained, { timeout: 30000 });
+
+    const resumed = await test.request.post(`${origin}/api/terminals/${instanceId}/controls`, {
+      headers: { Origin: origin }, data: { paused: false }
+    });
+    check(resumed.status() === 204, "Failed to resume activity");
+    await waitState("normal", "executing");
+    check(await test.evaluate(() => [...webTerminalViews.values()].every(view => {
+      const bar = view.element.querySelector(".activity-progress");
+      return !bar.hidden && bar.value === view.terminal.progress.percentage;
+    })), "Determinate progress getter and host bar disagree");
+    await waitState("warning", "executing");
+    await waitState("error", "executing");
+    await waitState("none", "finished");
+    check(await test.evaluate(() => [...webTerminalViews.values()].every(view =>
+      view.terminal.shellIntegration.lastExitCode === 1 &&
+      view.element.querySelector(".activity-progress").hidden &&
+      view.element.querySelector(".shell-status").textContent.includes("last exit 1"))),
+    "Completion or progress clearing was lost");
+    check(errors.length === 0, `Browser errors: ${errors.join("; ")}`);
+    return { passed: true, directAndRelayed: true, lateAttachAndReconnect: true,
+      states: ["indeterminate", "normal", "warning", "error", "none"] };
+  } finally {
+    try {
+      if (instanceId) await test.request.delete(`${origin}/api/terminals/${instanceId}`, { headers: { Origin: origin } });
+    } finally {
+      await context.close();
+    }
+  }
+}

--- a/samples/WebTerminalDemo/tests/bindings.browser.js
+++ b/samples/WebTerminalDemo/tests/bindings.browser.js
@@ -145,6 +145,7 @@ async page => {
           validateHistory(history, 40, 12);
           const message = {
             type: "geometry", columns: 40, rows: 12, cellWidth: 10, cellHeight: 20, hyperlinks: [], title: "",
+            progress: { state: "none", percentage: null }, shellIntegration: { phase: "unknown", lastExitCode: null },
             mouseTracking: this.tracking, peer: { id: this.name, primaryId: "native", isPrimary: false },
             revision: ++this.revision, history, text: history.rowIds.map(rowId => this.line(rowId)).join("\n")
           };

--- a/samples/WebTerminalDemo/tests/mount.browser.js
+++ b/samples/WebTerminalDemo/tests/mount.browser.js
@@ -18,6 +18,7 @@ async page => {
           if (worker.stopped) continue;
           worker.dispatchEvent(new MessageEvent("message", { data: {
             type: "geometry", ...grid, cellWidth: 10, cellHeight: 20, mouseTracking: 1003, hyperlinks: [], title: "",
+            progress: { state: "none", percentage: null }, shellIntegration: { phase: "unknown", lastExitCode: null },
             peer: { id: worker.id, primaryId, isPrimary: worker.id === primaryId }
           } }));
           worker.dispatchEvent(new MessageEvent("message", { data: {
@@ -35,6 +36,7 @@ async page => {
                 this.dispatchEvent(new MessageEvent("message", { data: { type: "connected" } }));
                 this.dispatchEvent(new MessageEvent("message", { data: {
                   type: "geometry", ...grid, cellWidth: 10, cellHeight: 20, mouseTracking: 0, hyperlinks: [], title: "",
+                  progress: { state: "none", percentage: null }, shellIntegration: { phase: "unknown", lastExitCode: null },
                   peer: { id: null, primaryId: null, isPrimary: false }
                 } }));
                 this.dispatchEvent(new MessageEvent("message", { data: { type: "stats", stats: { revision: 1 } } }));

--- a/samples/WebTerminalDemo/tests/renderers.browser.js
+++ b/samples/WebTerminalDemo/tests/renderers.browser.js
@@ -185,6 +185,7 @@ async page => {
         peer: { id: null, primaryId: null, isPrimary: true },
         cursor: { x: 0, y: 0, visible: false, shape: 0 }, history: null,
         images: [], retainedImages: [], placements: [], warnings: [], hyperlinks: [], title: "",
+        progress: { state: "none", percentage: null }, shellIntegration: { phase: "unknown", lastExitCode: null },
         stats: { workloadBytes: 0, outputBatches: 0, captureMs: 0, elapsedMs: 0 }
       };
       const json = Uint8Array.from(JSON.stringify(metadata), character => character.charCodeAt(0));

--- a/samples/WebTerminalDemo/tests/selection-ui.browser.js
+++ b/samples/WebTerminalDemo/tests/selection-ui.browser.js
@@ -49,6 +49,7 @@ async page => {
           const revision = ++uiFixture.revision;
           this.dispatchEvent(new MessageEvent("message", { data: {
             type: "geometry", columns: 40, rows: 10, cellWidth: 10, cellHeight: 20, mouseTracking: 1003, hyperlinks: [], title: "",
+            progress: { state: "none", percentage: null }, shellIntegration: { phase: "unknown", lastExitCode: null },
             peer: { id: this.id, primaryId: "native", isPrimary: false }, revision, text: "HELLO",
             history: { generation: "1", buffer: "main", totalRows: 30, top: this.top, liveTop: 20,
               following: this.top === 20, requestId: this.viewportRequest,

--- a/samples/WebTerminalDemo/wwwroot/index.html
+++ b/samples/WebTerminalDemo/wwwroot/index.html
@@ -98,6 +98,12 @@
     .view-tools { display: flex; flex: 0 0 36px; min-width: 0; align-items: center; gap: 4px; overflow: hidden; padding: 4px 6px; border-bottom: 1px solid var(--cp-border); }
     .terminal-window button { font-size: 11px; min-height: 26px; padding: 3px 6px; border-radius: 6px; flex: none; }
     .view-grid { font: 11px Consolas, "Courier New", Courier, monospace; white-space: nowrap; margin-left: auto; color: var(--cp-text-muted); }
+    .view-activity { display: flex; flex: 0 0 24px; align-items: center; gap: 8px; padding: 0 8px; font-size: 11px; color: var(--cp-text-muted); overflow: hidden; white-space: nowrap; }
+    .activity-progress { width: 80px; height: 8px; flex: none; accent-color: var(--cp-accent); }
+    [data-progress=warning] .activity-progress { accent-color: var(--cp-warning); }
+    [data-progress=error] .activity-progress { accent-color: var(--cp-danger); }
+    [data-shell-phase=executing] .shell-status { color: var(--cp-accent); }
+    [data-connected=false] .view-activity { visibility: hidden; }
     .terminal-mount { flex: 1 1 0; min-width: 0; min-height: 0; contain: size; overflow: hidden; }
     .view-footer { display: flex; flex: 0 0 24px; min-width: 0; align-items: center; gap: 4px; padding: 0 24px 0 8px; border-top: 1px solid var(--cp-border); }
     .view-status { flex: 1; min-width: 0; font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--cp-text-muted); }
@@ -134,6 +140,7 @@
           <option value="sixel">Sixel graphics</option>
           <option value="kgp">Kitty graphics</option>
           <option value="animation">Graphics animation</option>
+          <option value="activity">Progress and shell activity</option>
           <option value="shell">Interactive shell</option>
         </select>
       </label>

--- a/src/Hex1b/Automation/Hex1bTerminalSnapshot.cs
+++ b/src/Hex1b/Automation/Hex1bTerminalSnapshot.cs
@@ -61,6 +61,8 @@ public sealed class Hex1bTerminalSnapshot : IHex1bTerminalRegion, IDisposable
         WindowTitle = state.WindowTitle;
         IconName = state.IconName;
         SavedTitles = state.SavedTitles;
+        Progress = state.Progress;
+        ShellIntegration = state.ShellIntegration;
 
         var scrollbackRows = state.ScrollbackRows;
         ScrollbackLineCount = scrollbackRows.Length;
@@ -161,6 +163,13 @@ public sealed class Hex1bTerminalSnapshot : IHex1bTerminalRegion, IDisposable
     /// <remarks>Empty means no title. The value uses the same normalization and reset
     /// behavior as <see cref="Hex1bTerminal.WindowTitle"/> and remains untrusted text.</remarks>
     public string WindowTitle { get; }
+
+    /// <summary>Gets the immutable progress state captured atomically with this snapshot.</summary>
+    public TerminalProgress Progress { get; }
+
+    /// <summary>Gets the immutable shell phase and latest result captured atomically with this snapshot.</summary>
+    /// <remarks>This is current terminal activity even when the snapshot displays historical text.</remarks>
+    public TerminalShellIntegration ShellIntegration { get; }
 
     internal string IconName { get; }
 

--- a/src/Hex1b/Automation/Hex1bTerminalSnapshotState.cs
+++ b/src/Hex1b/Automation/Hex1bTerminalSnapshotState.cs
@@ -33,4 +33,6 @@ internal sealed record Hex1bTerminalSnapshotState(
     HyperlinkData? ActiveHyperlink,
     string WindowTitle,
     string IconName,
-    IReadOnlyList<(string Title, string IconName)> SavedTitles);
+    IReadOnlyList<(string Title, string IconName)> SavedTitles,
+    TerminalProgress Progress,
+    TerminalShellIntegration ShellIntegration);

--- a/src/Hex1b/Hex1bTerminal.Activity.cs
+++ b/src/Hex1b/Hex1bTerminal.Activity.cs
@@ -1,0 +1,109 @@
+namespace Hex1b;
+
+public sealed partial class Hex1bTerminal
+{
+    private TerminalActivityState _activityState = TerminalActivityState.Default;
+    private TerminalActivityState? _activityRestoreBaseline;
+    private int _activityRestoreDepth;
+    private event Action<TerminalActivityState>? ActivityStateChanged;
+
+    /// <summary>Gets the current progress reported by OSC 9;4.</summary>
+    /// <remarks>
+    /// Defaults to hidden progress. RIS clears it; soft reset, screen changes, and process
+    /// exit preserve it. Read a snapshot to capture progress and shell integration together.
+    /// </remarks>
+    public TerminalProgress Progress
+    {
+        get { lock (_bufferLock) return _activityState.Progress; }
+    }
+
+    /// <summary>Gets the current shell phase and latest reported command result.</summary>
+    /// <remarks>
+    /// Defaults to unknown, not idle. Only OSC 133 markers update this state, except RIS,
+    /// which resets it. Disconnect and process exit do not imply command completion.
+    /// </remarks>
+    public TerminalShellIntegration ShellIntegration
+    {
+        get { lock (_bufferLock) return _activityState.ShellIntegration; }
+    }
+
+    /// <summary>Occurs when the reported progress changes to a distinct value.</summary>
+    /// <remarks>
+    /// Subscribing does not emit the baseline; read <see cref="Progress"/> for current state.
+    /// This is a current-state notification, not a history of workload operations.
+    /// </remarks>
+    public event Action<TerminalProgress>? ProgressChanged;
+
+    /// <summary>Occurs when the reported shell phase or latest exit code changes.</summary>
+    /// <remarks>
+    /// Subscribing does not emit the baseline; read <see cref="ShellIntegration"/>.
+    /// Equal values are suppressed. This is not a command-started or command-completed event.
+    /// </remarks>
+    public event Action<TerminalShellIntegration>? ShellIntegrationChanged;
+
+    internal void SubscribeActivityStateChanged(Action<TerminalActivityState> handler)
+    {
+        lock (_bufferLock)
+        {
+            ActivityStateChanged += handler;
+            handler(_activityState);
+        }
+    }
+
+    internal void UnsubscribeActivityStateChanged(Action<TerminalActivityState> handler)
+        => ActivityStateChanged -= handler;
+
+    internal void BeginActivityStateRestore()
+    {
+        lock (_bufferLock)
+        {
+            if (_activityRestoreDepth++ == 0)
+                _activityRestoreBaseline = _activityState;
+        }
+    }
+
+    internal void RestoreActivityState(TerminalProgress progress, TerminalShellIntegration shellIntegration)
+    {
+        lock (_bufferLock)
+        {
+            SetActivityState(new TerminalActivityState(progress, shellIntegration));
+        }
+        PresentationInvalidated?.Invoke();
+    }
+
+    internal void EndActivityStateRestore()
+    {
+        lock (_bufferLock)
+        {
+            if (_activityRestoreDepth == 0)
+                throw new InvalidOperationException("No activity state restore is in progress.");
+            if (--_activityRestoreDepth == 0)
+            {
+                var baseline = _activityRestoreBaseline!;
+                _activityRestoreBaseline = null;
+                NotifyActivityStateChanged(baseline, _activityState);
+            }
+        }
+    }
+
+    private void SetActivityState(TerminalActivityState state)
+    {
+        var previous = _activityState;
+        if (previous == state)
+            return;
+        _activityState = state;
+        if (_activityRestoreDepth == 0)
+            NotifyActivityStateChanged(previous, state);
+    }
+
+    private void NotifyActivityStateChanged(TerminalActivityState previous, TerminalActivityState state)
+    {
+        if (previous == state)
+            return;
+        ActivityStateChanged?.Invoke(state);
+        if (previous.Progress != state.Progress)
+            ProgressChanged?.Invoke(state.Progress);
+        if (previous.ShellIntegration != state.ShellIntegration)
+            ShellIntegrationChanged?.Invoke(state.ShellIntegration);
+    }
+}

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -1242,16 +1242,20 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 IReadOnlyList<AnsiToken>? preTokenizedTokens = null;
                 Hmp1TerminalState? remoteState = null;
                 Hmp1KgpAnimationState? animationState = null;
+                Hmp1ActivityState? activityState = null;
+                Hmp1WorkloadAdapter? remoteSource = null;
                 var isStateSync = false;
                 byte[]? pooledItemBuffer = null;
                 List<AnsiToken>? pooledItemTokens = null;
                 Action<List<AnsiToken>>? pooledItemTokensReturn = null;
 
-                if (_workload is Hmp1WorkloadAdapter remoteWorkload)
+                if (_workload is IHmp1TerminalOutputSource remoteWorkload)
                 {
                     var item = await remoteWorkload.ReadTerminalOutputAsync(ct);
                     remoteState = item.State;
                     animationState = item.AnimationState;
+                    activityState = item.ActivityState;
+                    remoteSource = item.Source;
                     isStateSync = item.IsStateSync;
                     data = item.Bytes;
                 }
@@ -1286,7 +1290,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
 
                 Interlocked.Add(ref _outputBytesRead, data.Length);
 
-                var outputStateLock = _workload is Hmp1WorkloadAdapter ? Hmp1OutputStateLock : _hmp1OutputStateLock;
+                var outputStateLock = _workload is IHmp1TerminalOutputSource ? Hmp1OutputStateLock : _hmp1OutputStateLock;
                 var outputStateLockTaken = false;
                 try
                 {
@@ -1297,15 +1301,16 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 }
                 // Publish connection geometry and its replay as one output-state
                 // transaction. A browser must not become ready on the empty replica.
+                if (isStateSync)
+                {
+                    await ApplyHmp1ReplayAsync(data, remoteState, activityState, ct);
+                    remoteSource?.CompleteInitialReplay(null);
+                    continue;
+                }
                 if (remoteState is not null)
                     await ApplyHmp1StateAsync(remoteState);
                 if (animationState is not null)
                     ApplyHmp1KgpAnimationState(animationState);
-                if (isStateSync)
-                {
-                    lock (_bufferLock)
-                        _titleStack.Clear();
-                }
                 if (data.IsEmpty)
                     continue;
                 var rawPresentationPassthrough =
@@ -1389,8 +1394,14 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                     }
                 }
                 }
+                catch (Exception error)
+                {
+                    remoteSource?.CompleteInitialReplay(error);
+                    throw;
+                }
                 finally
                 {
+                    Hmp1ReplayActivityState = null;
                     if (outputStateLockTaken)
                         outputStateLock!.Release();
                     if (pooledItemBuffer is not null)
@@ -1400,12 +1411,14 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 }
             }
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException error)
         {
             // Normal shutdown
+            (_workload as IHmp1TerminalOutputSource)?.Hmp1Workload?.CompleteInitialReplay(error);
         }
         catch (Exception ex)
         {
+            (_workload as IHmp1TerminalOutputSource)?.Hmp1Workload?.CompleteInitialReplay(ex);
             ReportPumpFault("workload output pump", ex);
         }
         finally
@@ -2115,7 +2128,9 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 _currentHyperlink?.Data,
                 _windowTitle,
                 _iconName,
-                includeSavedTitles ? Array.AsReadOnly(_titleStack.ToArray()) : []);
+                includeSavedTitles ? Array.AsReadOnly(_titleStack.ToArray()) : [],
+                _activityState.Progress,
+                _activityState.ShellIntegration);
         }
     }
 
@@ -2425,6 +2440,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
     /// </summary>
     public void Resize(int newWidth, int newHeight)
     {
+        bool deferNotification;
         lock (_bufferLock)
         {
             if (_width != newWidth || _height != newHeight)
@@ -2451,8 +2467,10 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             _scrollBottom = newHeight - 1;
             
             _pendingWrap = false;
+            deferNotification = _deferHmp1ReplayCallbacks;
         }
-        NotifyPresentationInvalidated();
+        if (!deferNotification)
+            NotifyPresentationInvalidated();
     }
 
     private void ResizeWithReflow(int newWidth, int newHeight, ITerminalReflowProvider reflowProvider)
@@ -3389,6 +3407,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 break;
 
             case RisToken:
+                SetActivityState(TerminalActivityState.Default);
                 SetSynchronizedOutputMode(false);
                 InvalidateTextCoordinates();
                 // RIS (ESC c): Full terminal reset — clear screen, reset all state
@@ -6740,6 +6759,11 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 // OSC 8: Hyperlinks
                 ProcessOsc8Hyperlink(parameters, payload);
                 break;
+
+            case "9":
+            case "133":
+                SetActivityState(_activityState.ApplyOsc(command, parameters, payload));
+                break;
                 
             case "22":
                 // OSC 22: Push title onto stack
@@ -6796,7 +6820,8 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         if (_windowTitle != title)
         {
             _windowTitle = title;
-            WindowTitleChanged?.Invoke(title);
+            if (!_deferHmp1ReplayCallbacks)
+                WindowTitleChanged?.Invoke(title);
         }
     }
     
@@ -6809,7 +6834,8 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         if (_iconName != name)
         {
             _iconName = name;
-            IconNameChanged?.Invoke(name);
+            if (!_deferHmp1ReplayCallbacks)
+                IconNameChanged?.Invoke(name);
         }
     }
     

--- a/src/Hex1b/Hmp1/Hex1bTerminal.Hmp1Replay.cs
+++ b/src/Hex1b/Hmp1/Hex1bTerminal.Hmp1Replay.cs
@@ -1,0 +1,152 @@
+using System.Runtime.ExceptionServices;
+using System.Diagnostics;
+using Hex1b.Tokens;
+
+namespace Hex1b;
+
+public sealed partial class Hex1bTerminal
+{
+    // Scoped to one output-state transaction. HMP presentations, including ones
+    // inside a composite, must forward replay as control frames rather than live OSC.
+    internal Hmp1ActivityState? Hmp1ReplayActivityState { get; private set; }
+
+    private bool _deferHmp1ReplayCallbacks;
+
+    internal async Task WaitForHmp1InitialReplayAsync(CancellationToken cancellationToken)
+    {
+        if (_workload is not IHmp1TerminalOutputSource source)
+            return;
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _disposeCts.Token);
+        while (source.Hmp1Workload is { ConnectionStarted: true } workload)
+        {
+            var error = await workload.InitialHandshake.WaitAsync(linked.Token).ConfigureAwait(false)
+                ?? await workload.InitialReplay.WaitAsync(linked.Token).ConfigureAwait(false);
+            if (!ReferenceEquals(source.Hmp1Workload, workload))
+                continue;
+            if (error is not null)
+                ExceptionDispatchInfo.Capture(error).Throw();
+            return;
+        }
+    }
+
+    private async Task ApplyHmp1ReplayAsync(
+        ReadOnlyMemory<byte> bytes, Hmp1TerminalState? state, Hmp1ActivityState? activity, CancellationToken ct)
+    {
+        if (activity is null)
+            throw new InvalidDataException("StateSync requires an activity checkpoint.");
+        Hmp1ReplayActivityState = activity;
+        var rawPassthrough = _presentationFilters.Count == 0 &&
+            _presentation is not ICellImpactAwarePresentationAdapter;
+        var fastPath = _workloadFilters.Count == 0 && rawPassthrough;
+
+        if (rawPassthrough && !_disposed && _presentation is not null)
+        {
+            var started = Stopwatch.GetTimestamp();
+            await _presentation.WriteOutputAsync(bytes, ct).ConfigureAwait(false);
+            _metrics.TerminalRawPassthroughDuration.Record(Stopwatch.GetElapsedTime(started).TotalMilliseconds);
+            _metrics.TerminalOutputBytes.Record(bytes.Length);
+        }
+
+        // The new baseline supersedes any unfinished prefix from the previous stream.
+        _incompleteSequenceBuffer = "";
+        _utf8Decoder.Reset();
+        _pendingUtf8OutputLength = 0;
+        _dcsByteStreamParser.Complete();
+        var tokenization = TokenizeRawWorkloadOutput(bytes.Span);
+        var tokens = tokenization.Tokens;
+        _metrics.TerminalOutputTokens.Record(tokens.Count);
+        if (!fastPath && !bytes.IsEmpty)
+            await NotifyWorkloadFiltersOutputAsync(tokens).ConfigureAwait(false);
+        ct.ThrowIfCancellationRequested();
+
+        IReadOnlyList<AppliedToken> applied;
+        bool resized;
+        lock (_bufferLock)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            var previous = _activityState;
+            var previousTitle = _windowTitle;
+            var previousIcon = _iconName;
+            _deferHmp1ReplayCallbacks = true;
+            BeginActivityStateRestore();
+            try
+            {
+                _titleStack.Clear();
+                resized = state is not null && state.Width > 0 && state.Height > 0 &&
+                    (_width != state.Width || _height != state.Height);
+                if (state is not null)
+                {
+                    _hmp1State = state;
+                    if (resized)
+                        Resize(state.Width, state.Height);
+                }
+                if (fastPath)
+                {
+                    ApplyTokens(tokens, tokenization.FramedDcs);
+                    applied = [];
+                }
+                else
+                {
+                    applied = ApplyTokensWithImpacts(tokens, tokenization.FramedDcs);
+                }
+                ObjectDisposedException.ThrowIf(_disposed, this);
+                RestoreActivityState(
+                    new TerminalProgress((TerminalProgressState)activity.Progress.State, activity.Progress.Percentage),
+                    new TerminalShellIntegration((TerminalShellIntegrationPhase)activity.ShellIntegration.Phase,
+                        activity.ShellIntegration.LastExitCode));
+            }
+            catch
+            {
+                // Failed application must not install an unrendered checkpoint or emit
+                // intermediate activity from a partially applied replay.
+                SetActivityState(previous);
+                throw;
+            }
+            finally
+            {
+                try
+                {
+                    EndActivityStateRestore();
+                }
+                finally
+                {
+                    _deferHmp1ReplayCallbacks = false;
+                }
+            }
+
+            // The monitor is reentrant: observers must run after painting and the
+            // checkpoint commit, not while replay switches screens or restores titles.
+            if (previousTitle != _windowTitle)
+                WindowTitleChanged?.Invoke(_windowTitle);
+            if (previousIcon != _iconName)
+                IconNameChanged?.Invoke(_iconName);
+            if (resized)
+                NotifyPresentationInvalidated();
+        }
+
+        // Screen and activity are already committed together. Never hold the buffer
+        // monitor across an asynchronous presentation or filter callback.
+        if (resized)
+        {
+            await NotifyPresentationFiltersResizeAsync(state!.Width, state.Height).ConfigureAwait(false);
+            await NotifyWorkloadFiltersResizeAsync(state.Width, state.Height).ConfigureAwait(false);
+        }
+        if (_presentation is ICellImpactAwarePresentationAdapter impactAware)
+        {
+            if (_presentationFilters.Count > 0)
+                await NotifyPresentationFiltersOutputAsync(applied).ConfigureAwait(false);
+            ct.ThrowIfCancellationRequested();
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            await impactAware.WriteOutputWithImpactsAsync(applied, ct).ConfigureAwait(false);
+        }
+        else if (!rawPassthrough && _presentation is not null)
+        {
+            var filtered = await NotifyPresentationFiltersOutputAsync(applied).ConfigureAwait(false);
+            ct.ThrowIfCancellationRequested();
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            var filteredBytes = AnsiTokenUtf8Serializer.Serialize(filtered);
+            await _presentation.WriteOutputAsync(filteredBytes, ct).ConfigureAwait(false);
+            _metrics.TerminalOutputBytes.Record(filteredBytes.Length);
+        }
+    }
+}

--- a/src/Hex1b/Hmp1/Hmp1ActivityState.cs
+++ b/src/Hex1b/Hmp1/Hmp1ActivityState.cs
@@ -1,0 +1,86 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Hex1b.Automation;
+
+namespace Hex1b;
+
+// A baseline, not a history of shell events. Kept separate from the ANSI screen replay.
+[JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
+internal sealed record Hmp1ActivityState
+{
+    internal const int MaxPayloadSize = 1024;
+
+    public required Hmp1ProgressState Progress { get; init; }
+    public required Hmp1ShellIntegrationState ShellIntegration { get; init; }
+
+    internal static Hmp1ActivityState Default { get; } = new()
+    {
+        Progress = new() { State = 0, Percentage = null },
+        ShellIntegration = new() { Phase = 0, LastExitCode = null }
+    };
+
+    internal static Hmp1ActivityState Capture(Hex1bTerminalSnapshot snapshot) => new()
+    {
+        Progress = new() { State = (int)snapshot.Progress.State, Percentage = snapshot.Progress.Percentage },
+        ShellIntegration = new()
+        {
+            Phase = (int)snapshot.ShellIntegration.Phase,
+            LastExitCode = snapshot.ShellIntegration.LastExitCode
+        }
+    };
+
+    internal static Hmp1ActivityState Parse(ReadOnlyMemory<byte> payload)
+    {
+        if (payload.IsEmpty || payload.Length > MaxPayloadSize)
+            throw new InvalidDataException("Invalid HMP activity checkpoint size.");
+        try
+        {
+            using var document = JsonDocument.Parse(payload);
+            RejectDuplicateProperties(document.RootElement);
+            var state = JsonSerializer.Deserialize(payload.Span, Hmp1JsonContext.Default.Hmp1ActivityState)
+                ?? throw new InvalidDataException("Missing HMP activity checkpoint.");
+            if (state.Progress is not { State: >= 0 and <= 4 } progress ||
+                state.ShellIntegration is not { Phase: >= 0 and <= 4 } shell ||
+                (progress.State is 0 or 3 ? progress.Percentage is not null : progress.Percentage is not (>= 0 and <= 100)) ||
+                (shell.Phase == 0 && shell.LastExitCode is not null))
+                throw new InvalidDataException("Invalid HMP activity checkpoint state.");
+            return state;
+        }
+        catch (JsonException exception)
+        {
+            throw new InvalidDataException("Malformed HMP activity checkpoint.", exception);
+        }
+    }
+
+    internal string BuildProgressReplay() => Progress.Percentage is { } percentage
+        ? string.Create(CultureInfo.InvariantCulture, $"\x1b]9;4;{Progress.State};{percentage}\x1b\\")
+        : string.Create(CultureInfo.InvariantCulture, $"\x1b]9;4;{Progress.State}\x1b\\");
+
+    private static void RejectDuplicateProperties(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+            return;
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var property in element.EnumerateObject())
+        {
+            if (!names.Add(property.Name))
+                throw new InvalidDataException("Duplicate HMP activity checkpoint property.");
+            RejectDuplicateProperties(property.Value);
+        }
+    }
+}
+
+[JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
+internal sealed record Hmp1ProgressState
+{
+    public required int State { get; init; }
+    public required int? Percentage { get; init; }
+}
+
+[JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
+internal sealed record Hmp1ShellIntegrationState
+{
+    public required int Phase { get; init; }
+    public required int? LastExitCode { get; init; }
+}

--- a/src/Hex1b/Hmp1/Hmp1BuilderExtensions.cs
+++ b/src/Hex1b/Hmp1/Hmp1BuilderExtensions.cs
@@ -122,10 +122,9 @@ public static class Hmp1BuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(options);
 
-        var adapter = new Hmp1WorkloadAdapter(options);
-
         builder.SetWorkloadFactory(_ =>
         {
+            var adapter = new Hmp1WorkloadAdapter(options);
             Func<CancellationToken, Task<int>> runCallback = async ct =>
             {
                 await adapter.ConnectAsync(ct);

--- a/src/Hex1b/Hmp1/Hmp1FrameType.cs
+++ b/src/Hex1b/Hmp1/Hmp1FrameType.cs
@@ -88,5 +88,8 @@ internal enum Hmp1FrameType : byte
     // Server → Client. One-time playback checkpoint following a KGP state replay.
     // Standard KGP commands carry the pixels/gaps; this restores loop progress and
     // elapsed frame time that cannot be represented by those commands.
-    KgpAnimationState = 0x0C
+    KgpAnimationState = 0x0C,
+
+    // Server → Client. Mandatory authoritative activity baseline immediately after StateSync.
+    ActivityState = 0x0D
 }

--- a/src/Hex1b/Hmp1/Hmp1JsonContext.cs
+++ b/src/Hex1b/Hmp1/Hmp1JsonContext.cs
@@ -13,6 +13,7 @@ namespace Hex1b;
 [JsonSerializable(typeof(PeerJoinPayload))]
 [JsonSerializable(typeof(PeerLeavePayload))]
 [JsonSerializable(typeof(Hmp1KgpAnimationState))]
+[JsonSerializable(typeof(Hmp1ActivityState))]
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 internal sealed partial class Hmp1JsonContext : JsonSerializerContext
 {

--- a/src/Hex1b/Hmp1/Hmp1PresentationAdapter.cs
+++ b/src/Hex1b/Hmp1/Hmp1PresentationAdapter.cs
@@ -23,7 +23,8 @@ namespace Hex1b;
 /// Each client first sends a <see cref="Hmp1FrameType.ClientHello"/> frame; the
 /// server then assigns a peer ID and replies with <see cref="Hmp1FrameType.Hello"/>
 /// (carrying the assigned peer ID, current primary, and roster) followed by a
-/// <see cref="Hmp1FrameType.StateSync"/> frame with a full screen snapshot.
+/// <see cref="Hmp1FrameType.StateSync"/> frame with a full screen snapshot and
+/// its mandatory <see cref="Hmp1FrameType.ActivityState"/> checkpoint.
 /// </para>
 /// <para>
 /// One peer may be the <em>primary</em> at any time. The primary's
@@ -153,7 +154,7 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
 
     /// <summary>
     /// Invoked after a new client completes its ClientHello → Hello →
-    /// StateSync handshake. Argument carries the assigned peer ID, the
+    /// StateSync → ActivityState handshake. Argument carries the assigned peer ID, the
     /// display name and (parsed) role hint the client supplied.
     /// </summary>
     /// <remarks>
@@ -224,7 +225,7 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
     /// <see cref="Hmp1FrameType.ClientHello"/> frame; the server then writes
     /// the assigned peer ID, current primary, and roster in
     /// <see cref="Hmp1FrameType.Hello"/>, followed by a
-    /// <see cref="Hmp1FrameType.StateSync"/> frame.
+    /// <see cref="Hmp1FrameType.StateSync"/> frame and its activity checkpoint.
     /// </summary>
     /// <param name="stream">A bidirectional stream connected to the client.</param>
     /// <param name="ct">Cancellation token.</param>
@@ -296,6 +297,7 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
         session.BrowserView = view;
         try
         {
+            await terminal.WaitForHmp1InitialReplayAsync(cancellationToken).ConfigureAwait(false);
             await terminal.Hmp1OutputStateLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
@@ -364,6 +366,7 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
         var displayName = session.DisplayName;
         Hmp1ClientSession[] existingPeers;
         byte[] syncBytes;
+        Hmp1ActivityState activityState;
         IReadOnlyList<KgpPlacement> kgpPlacements;
         IReadOnlyDictionary<uint, KgpImageData> kgpImages;
         DateTimeOffset? kgpAnimationTimestamp;
@@ -375,6 +378,8 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
         string? primarySnapshot;
         int widthSnapshot;
         int heightSnapshot;
+        if (_terminal is not null)
+            await _terminal.WaitForHmp1InitialReplayAsync(ct).ConfigureAwait(false);
         var outputStateLock = _terminal?.Hmp1OutputStateLock;
         if (outputStateLock is not null)
             await outputStateLock.WaitAsync(ct).ConfigureAwait(false);
@@ -408,10 +413,13 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
                     IncludeTrailingNewline = false,
                 }, includeHyperlinks: true);
                 var suffix = BuildStateReplaySuffix(snap);
+                activityState = Hmp1ActivityState.Capture(snap);
+                var progress = activityState.BuildProgressReplay();
                 var titles = Hmp1TitleStateReplay.Build(snap,
                     Hmp1Protocol.MaxPayloadSize - Encoding.UTF8.GetByteCount(prefix) -
-                    Encoding.UTF8.GetByteCount(ansi) - Encoding.UTF8.GetByteCount(suffix));
-                syncBytes = Encoding.UTF8.GetBytes(prefix + titles + ansi + suffix);
+                    Encoding.UTF8.GetByteCount(ansi) - Encoding.UTF8.GetByteCount(suffix) -
+                    Encoding.UTF8.GetByteCount(progress));
+                syncBytes = Encoding.UTF8.GetBytes(prefix + titles + progress + ansi + suffix);
                 kgpPlacements = snap.KgpPlacements;
                 kgpImages = snap.KgpImages;
                 kgpAnimationTimestamp = snap.KgpAnimationTimestamp;
@@ -423,6 +431,7 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
             }
             else
             {
+                activityState = Hmp1ActivityState.Default;
                 syncBytes = [];
                 kgpPlacements = [];
                 kgpImages = new Dictionary<uint, KgpImageData>();
@@ -532,13 +541,14 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
             roster.Add(new HelloPeerInfo { PeerId = p.PeerId, DisplayName = p.DisplayName });
         }
 
-        // Send Hello + StateSync to the new peer over the raw stream (the per-client
+        // Send Hello + StateSync + ActivityState over the raw stream (the per-client
         // pump hasn't started yet). Failures here are propagated because the caller
         // hasn't yet received a handle.
         await Hmp1Protocol.WriteHelloAsync(
             stream, widthSnapshot, heightSnapshot, peerId, primarySnapshot, roster, ct).ConfigureAwait(false);
 
         await Hmp1Protocol.WriteFrameAsync(stream, Hmp1FrameType.StateSync, syncBytes, ct).ConfigureAwait(false);
+        await Hmp1Protocol.WriteActivityStateAsync(stream, activityState, ct).ConfigureAwait(false);
 
         ct.ThrowIfCancellationRequested();
         // Always enter the pumps so their finally blocks clean up even if the
@@ -685,7 +695,8 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
     /// <inheritdoc />
     public ValueTask WriteOutputAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default)
     {
-        if (_disposed || data.IsEmpty) return ValueTask.CompletedTask;
+        var replayActivity = _terminal?.Hmp1ReplayActivityState;
+        if (_disposed || (data.IsEmpty && replayActivity is null)) return ValueTask.CompletedTask;
 
         // Copy once; each session's pump consumes the same buffer view.
         var copy = data.ToArray();
@@ -702,7 +713,16 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
                     browserView.RecordOutputBatch();
                     continue;
                 }
-                if (!session.OutputChannel.Writer.TryWrite(new Hmp1OutboundWork(copy, null)))
+                var work = replayActivity is null
+                    ? new Hmp1OutboundWork(copy, null)
+                    : new Hmp1OutboundWork(default, async stream =>
+                    {
+                        await Hmp1Protocol.WriteFrameAsync(stream, Hmp1FrameType.StateSync, copy, session.Cts.Token)
+                            .ConfigureAwait(false);
+                        await Hmp1Protocol.WriteActivityStateAsync(stream, replayActivity, session.Cts.Token)
+                            .ConfigureAwait(false);
+                    });
+                if (!session.OutputChannel.Writer.TryWrite(work))
                 {
                     // Client can't keep up — disconnect it
                     _sessions.RemoveAt(i);

--- a/src/Hex1b/Hmp1/Hmp1Protocol.cs
+++ b/src/Hex1b/Hmp1/Hmp1Protocol.cs
@@ -85,7 +85,8 @@ internal static class Hmp1Protocol
         var type = (Hmp1FrameType)header[0];
         var length = BinaryPrimitives.ReadInt32LittleEndian(header.AsSpan(1));
 
-        if (length < 0 || length > MaxPayloadSize)
+        if (length < 0 || length > MaxPayloadSize ||
+            (type == Hmp1FrameType.ActivityState && length > Hmp1ActivityState.MaxPayloadSize))
             throw new InvalidOperationException($"Invalid frame payload length: {length}");
 
         ReadOnlyMemory<byte> payload;
@@ -103,6 +104,21 @@ internal static class Hmp1Protocol
         }
 
         return new Hmp1Frame(type, payload);
+    }
+
+    internal static ValueTask WriteActivityStateAsync(
+        Stream stream, Hmp1ActivityState state, CancellationToken ct = default)
+        => WriteFrameAsync(stream, Hmp1FrameType.ActivityState,
+            JsonSerializer.SerializeToUtf8Bytes(state, Hmp1JsonContext.Default.Hmp1ActivityState), ct);
+
+    internal static async ValueTask<Hmp1ActivityState> ReadActivityStateAsync(
+        Stream stream, CancellationToken ct)
+    {
+        var frame = await ReadFrameAsync(stream, ct).ConfigureAwait(false)
+            ?? throw new InvalidDataException("Server closed connection before ActivityState checkpoint.");
+        if (frame.Type != Hmp1FrameType.ActivityState)
+            throw new InvalidDataException($"Expected ActivityState checkpoint, got {frame.Type}.");
+        return Hmp1ActivityState.Parse(frame.Payload);
     }
 
     /// <summary>

--- a/src/Hex1b/Hmp1/Hmp1WorkloadAdapter.cs
+++ b/src/Hex1b/Hmp1/Hmp1WorkloadAdapter.cs
@@ -13,7 +13,8 @@ namespace Hex1b;
 /// input and resize events to it. On connection, the client sends a
 /// <see cref="Hmp1FrameType.ClientHello"/> frame; the server responds with a
 /// <see cref="Hmp1FrameType.Hello"/> (with the assigned peer ID, current primary, and
-/// roster) and a <see cref="Hmp1FrameType.StateSync"/>.
+/// roster), a <see cref="Hmp1FrameType.StateSync"/>, and its mandatory
+/// <see cref="Hmp1FrameType.ActivityState"/> checkpoint.
 /// </para>
 /// <para>
 /// The adapter is transport-agnostic: provide any bidirectional <see cref="Stream"/>
@@ -29,7 +30,8 @@ namespace Hex1b;
 /// <see cref="IHmp1ConnectionHandle.OnPeerLeft"/> to drive UX state.
 /// </para>
 /// </remarks>
-public sealed class Hmp1WorkloadAdapter : IHex1bTerminalWorkloadAdapter, IHmp1ConnectionHandle, IConnectableWorkloadAdapter
+public sealed class Hmp1WorkloadAdapter : IHex1bTerminalWorkloadAdapter, IHmp1ConnectionHandle, IConnectableWorkloadAdapter,
+    IHmp1TerminalOutputSource
 {
     private readonly Hmp1ClientOptions _options;
     private readonly string _localDisplayName;
@@ -51,13 +53,26 @@ public sealed class Hmp1WorkloadAdapter : IHex1bTerminalWorkloadAdapter, IHmp1Co
     // user-handler duration. See WaitForDisconnectAsync.
     private readonly TaskCompletionSource _disconnectedTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-    // Completed once the handshake (ClientHello → Hello → StateSync) has
+    // Completed once the handshake (ClientHello → Hello → StateSync → ActivityState) has
     // succeeded. Surfaced via IConnectableWorkloadAdapter so multiplexing
     // wrappers (PlaceholderWorkloadAdapter) can react without HMP1-specific
     // coupling. Never faults — connect failures during ConnectAsync are
     // surfaced through the usual exception channel and leave this task
     // pending; callers then rely on DisconnectedTask for the disconnect path.
     private readonly TaskCompletionSource _connectedTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource<Exception?> _initialHandshake =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource<Exception?> _initialReplay =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private int _connectionStarted;
+
+    internal bool ConnectionStarted => Volatile.Read(ref _connectionStarted) != 0;
+    internal Task<Exception?> InitialHandshake => _initialHandshake.Task;
+    internal Task<Exception?> InitialReplay => _initialReplay.Task;
+    internal void CompleteInitialReplay(Exception? error) => _initialReplay.TrySetResult(error);
+    Hmp1WorkloadAdapter IHmp1TerminalOutputSource.Hmp1Workload => this;
+    ValueTask<Hmp1WorkloadOutput> IHmp1TerminalOutputSource.ReadTerminalOutputAsync(CancellationToken cancellationToken)
+        => ReadTerminalOutputAsync(cancellationToken);
 
     /// <summary>
     /// Creates a muxer workload adapter from the supplied options bag.
@@ -228,7 +243,7 @@ public sealed class Hmp1WorkloadAdapter : IHex1bTerminalWorkloadAdapter, IHmp1Co
     public Task DisconnectedTask => _disconnectedTcs.Task;
 
     /// <summary>
-    /// Completes when the HMP1 handshake (ClientHello → Hello → StateSync)
+    /// Completes when the HMP1 handshake (ClientHello → Hello → StateSync → ActivityState)
     /// has succeeded and the read pump has been started. Implements
     /// <see cref="IConnectableWorkloadAdapter.ConnectedTask"/>.
     /// </summary>
@@ -241,7 +256,7 @@ public sealed class Hmp1WorkloadAdapter : IHex1bTerminalWorkloadAdapter, IHmp1Co
     public bool IsConnected => _connectedTcs.Task.IsCompletedSuccessfully && !_disconnectedTcs.Task.IsCompleted;
 
     /// <summary>
-    /// Connects to the server, sends ClientHello, reads Hello and StateSync,
+    /// Connects to the server, sends ClientHello, reads Hello, StateSync, and ActivityState,
     /// and starts the background read pump.
     /// </summary>
     /// <remarks>
@@ -252,6 +267,22 @@ public sealed class Hmp1WorkloadAdapter : IHex1bTerminalWorkloadAdapter, IHmp1Co
     /// down the read pump after the handshake had already succeeded.
     /// </remarks>
     public async Task ConnectAsync(CancellationToken ct)
+    {
+        Interlocked.Exchange(ref _connectionStarted, 1);
+        try
+        {
+            await ConnectCoreAsync(ct).ConfigureAwait(false);
+        }
+        catch (Exception error)
+        {
+            _initialHandshake.TrySetResult(error);
+            _outputChannel.Writer.TryComplete();
+            _disconnectedTcs.TrySetResult();
+            throw;
+        }
+    }
+
+    private async Task ConnectCoreAsync(CancellationToken ct)
     {
         var rawStream = await _options.StreamFactory(ct).ConfigureAwait(false);
 
@@ -303,7 +334,9 @@ public sealed class Hmp1WorkloadAdapter : IHex1bTerminalWorkloadAdapter, IHmp1Co
 
         // Hello geometry must be applied before StateSync, even when the adapter
         // was connected before its consuming terminal was constructed.
-        _outputChannel.Writer.TryWrite(new(syncFrame.Payload, CaptureTerminalState(connected: true), IsStateSync: true));
+        var activityState = await Hmp1Protocol.ReadActivityStateAsync(_stream, ct).ConfigureAwait(false);
+        _outputChannel.Writer.TryWrite(new(syncFrame.Payload, CaptureTerminalState(connected: true),
+            IsStateSync: true, ActivityState: activityState));
 
         // Start the background read pump. Important: do NOT capture the caller-supplied
         // CancellationToken here. A "handshake timeout" CT must NOT keep cancelling
@@ -318,6 +351,7 @@ public sealed class Hmp1WorkloadAdapter : IHex1bTerminalWorkloadAdapter, IHmp1Co
         // also fires before the user's OnDisconnected callback so framework
         // wrappers don't get coupled to user-handler duration.
         _connectedTcs.TrySetResult();
+        _initialHandshake.TrySetResult(null);
 
         // Snapshot connected-state under the lock, raise the event without
         // holding it. Handlers run on the connecting thread and are
@@ -372,9 +406,9 @@ public sealed class Hmp1WorkloadAdapter : IHex1bTerminalWorkloadAdapter, IHmp1Co
             _outputChannel.Reader.Completion.IsCompleted && !_terminalDisconnectDelivered)
         {
             _terminalDisconnectDelivered = true;
-            return new(default, CaptureTerminalState(connected: false));
+            return new(default, CaptureTerminalState(connected: false), Source: this);
         }
-        return item;
+        return item with { Source = this };
     }
 
     private Hmp1TerminalState CaptureTerminalState(bool connected)
@@ -398,13 +432,13 @@ public sealed class Hmp1WorkloadAdapter : IHex1bTerminalWorkloadAdapter, IHmp1Co
 
             // Never coalesce across a terminal-state or animation checkpoint. Public callbacks
             // still run at receipt time; terminal state follows this ordered queue.
-            if (first.State is not null || first.AnimationState is not null ||
-                !_outputChannel.Reader.TryPeek(out var next) || next.State is not null || next.AnimationState is not null)
+            if (first.State is not null || first.AnimationState is not null || first.IsStateSync ||
+                !_outputChannel.Reader.TryPeek(out var next) || next.State is not null || next.AnimationState is not null || next.IsStateSync)
                 return first;
 
             var pending = new List<ReadOnlyMemory<byte>> { first.Bytes };
             var total = first.Bytes.Length;
-            while (_outputChannel.Reader.TryPeek(out next) && next.State is null && next.AnimationState is null &&
+            while (_outputChannel.Reader.TryPeek(out next) && next.State is null && next.AnimationState is null && !next.IsStateSync &&
                 _outputChannel.Reader.TryRead(out var more))
             {
                 pending.Add(more.Bytes);
@@ -558,9 +592,14 @@ public sealed class Hmp1WorkloadAdapter : IHex1bTerminalWorkloadAdapter, IHmp1Co
                 switch (frame.Type)
                 {
                     case Hmp1FrameType.StateSync:
+                        var activityState = await Hmp1Protocol.ReadActivityStateAsync(_stream, ct).ConfigureAwait(false);
                         await _outputChannel.Writer.WriteAsync(
-                            new(frame.Payload, CaptureTerminalState(connected: true), IsStateSync: true), ct).ConfigureAwait(false);
+                            new(frame.Payload, CaptureTerminalState(connected: true),
+                                IsStateSync: true, ActivityState: activityState), ct).ConfigureAwait(false);
                         break;
+
+                    case Hmp1FrameType.ActivityState:
+                        throw new InvalidDataException("ActivityState checkpoint without StateSync.");
 
                     case Hmp1FrameType.Output:
                         // WriteAsync (not TryWrite) so the bounded channel back-pressures
@@ -618,7 +657,7 @@ public sealed class Hmp1WorkloadAdapter : IHex1bTerminalWorkloadAdapter, IHmp1Co
             }
         }
         catch (OperationCanceledException) { }
-        catch (Exception ex) when (ex is IOException or ObjectDisposedException or InvalidOperationException)
+        catch (Exception ex) when (ex is IOException or ObjectDisposedException or InvalidOperationException or InvalidDataException)
         {
             // Stream error
         }
@@ -711,6 +750,8 @@ public sealed class Hmp1WorkloadAdapter : IHex1bTerminalWorkloadAdapter, IHmp1Co
     {
         if (_disposed) return;
         _disposed = true;
+        _initialHandshake.TrySetResult(new ObjectDisposedException(nameof(Hmp1WorkloadAdapter)));
+        _initialReplay.TrySetResult(new ObjectDisposedException(nameof(Hmp1WorkloadAdapter)));
 
         // Detect dispose-from-callback: a user handler running on the
         // read pump that calls back into us (e.g.

--- a/src/Hex1b/Hmp1/Hmp1WorkloadOutput.cs
+++ b/src/Hex1b/Hmp1/Hmp1WorkloadOutput.cs
@@ -3,4 +3,5 @@ namespace Hex1b;
 // A state transition is applied before this item's bytes, after all earlier items.
 internal readonly record struct Hmp1WorkloadOutput(
     ReadOnlyMemory<byte> Bytes, Hmp1TerminalState? State = null,
-    Hmp1KgpAnimationState? AnimationState = null, bool IsStateSync = false);
+    Hmp1KgpAnimationState? AnimationState = null, bool IsStateSync = false,
+    Hmp1ActivityState? ActivityState = null, Hmp1WorkloadAdapter? Source = null);

--- a/src/Hex1b/Hmp1/IHmp1TerminalOutputSource.cs
+++ b/src/Hex1b/Hmp1/IHmp1TerminalOutputSource.cs
@@ -1,0 +1,8 @@
+namespace Hex1b;
+
+// Keeps ordered HMP control information intact through internal workload wrappers.
+internal interface IHmp1TerminalOutputSource
+{
+    Hmp1WorkloadAdapter? Hmp1Workload { get; }
+    ValueTask<Hmp1WorkloadOutput> ReadTerminalOutputAsync(CancellationToken cancellationToken);
+}

--- a/src/Hex1b/Hwt1/Hwt1FrameMetadata.cs
+++ b/src/Hex1b/Hwt1/Hwt1FrameMetadata.cs
@@ -6,4 +6,5 @@ internal sealed record Hwt1FrameMetadata(
     uint DefaultBackground, uint DefaultForeground, Hwt1Cursor Cursor,
     List<Hwt1RenderImage> Images, string[] RetainedImages, List<Hwt1RenderPlacement> Placements,
     Hwt1FrameStatistics Stats, List<string> Warnings, Hwt1Peer Peer, Hwt1History? History,
-    List<Hwt1Hyperlink> Hyperlinks, string Title);
+    List<Hwt1Hyperlink> Hyperlinks, string Title,
+    Hwt1Progress Progress, Hwt1ShellIntegration ShellIntegration);

--- a/src/Hex1b/Hwt1/Hwt1PresentationAdapter.cs
+++ b/src/Hex1b/Hwt1/Hwt1PresentationAdapter.cs
@@ -46,6 +46,8 @@ namespace Hex1b;
 /// title. Title-only output can produce a frame with no changed cells. Titles follow
 /// the same coalescing and synchronized-output rules as other state; frames are not
 /// a lossless stream of individual title-setting sequences.
+/// Progress and shell-integration state use the same snapshot and coalescing rules.
+/// These fields are current even when the view is displaying historical text.
 /// </remarks>
 public sealed class Hwt1PresentationAdapter :
     ICellImpactAwarePresentationAdapter, ITerminalLifecycleAwarePresentationAdapter
@@ -58,7 +60,8 @@ public sealed class Hwt1PresentationAdapter :
     private readonly TimeProvider _timeProvider;
     private readonly long _started = Stopwatch.GetTimestamp();
     private Hex1bTerminal? _terminal;
-    private Hmp1WorkloadAdapter? _hmp1Workload;
+    private IHmp1TerminalOutputSource? _hmp1OutputSource;
+    private Hmp1WorkloadAdapter? Hmp1Workload => _hmp1OutputSource?.Hmp1Workload;
     private Hmp1PresentationAdapter? _muxer;
     private Hmp1PresentationAdapter.Hmp1ClientSession? _session;
     private readonly Hwt1ViewState _view = new();
@@ -167,6 +170,7 @@ public sealed class Hwt1PresentationAdapter :
         try
         {
             using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _disposedCancellation.Token);
+            await terminal.WaitForHmp1InitialReplayAsync(linked.Token).ConfigureAwait(false);
             Task? acknowledgement;
             lock (_ackLock)
                 acknowledgement = _ack?.Task;
@@ -180,7 +184,7 @@ public sealed class Hwt1PresentationAdapter :
             Hex1bTerminalSnapshot? snapshot;
             Hwt1History? history;
             Hwt1Peer peer;
-            var outputLock = _muxer is not null || _hmp1Workload is not null ? terminal.Hmp1OutputStateLock : null;
+            var outputLock = _muxer is not null || _hmp1OutputSource is not null ? terminal.Hmp1OutputStateLock : null;
             while (true)
             {
                 linked.Token.ThrowIfCancellationRequested();
@@ -195,7 +199,7 @@ public sealed class Hwt1PresentationAdapter :
                     if (terminal.TryCaptureBrowserSnapshot(_view, out snapshot, out history,
                         out var remoteState, out pendingUpdate))
                     {
-                        if (_hmp1Workload is not null)
+                        if (_muxer is null && (Hmp1Workload is not null || remoteState is not null))
                             peer = remoteState is null ? Hwt1Peer.Unconnected :
                                 new Hwt1Peer(remoteState.PeerId, remoteState.PrimaryPeerId, remoteState.IsPrimary);
                         break;
@@ -281,7 +285,7 @@ public sealed class Hwt1PresentationAdapter :
                 var rows = ReadBounded(command, "rows", 10, 100);
                 if (_muxer is not null)
                     await _muxer.ResizeBrowserAsync(_session!, columns, rows, primary: false, linked.Token);
-                else if (_hmp1Workload is { } remote)
+                else if (Hmp1Workload is { } remote)
                     await remote.ResizeAsync(columns, rows, linked.Token);
                 else
                     Resize(columns, rows);
@@ -291,9 +295,9 @@ public sealed class Hwt1PresentationAdapter :
                 var primaryRows = ReadBounded(command, "rows", 10, 100);
                 if (_muxer is not null)
                     await _muxer.ResizeBrowserAsync(_session!, primaryColumns, primaryRows, primary: true, linked.Token);
-                else if (_hmp1Workload is { IsConnected: true } candidate)
+                else if (Hmp1Workload is { IsConnected: true } candidate)
                     await candidate.RequestPrimaryAsync(primaryColumns, primaryRows, linked.Token);
-                else if (_hmp1Workload is null)
+                else if (Hmp1Workload is null)
                     Resize(primaryColumns, primaryRows);
                 break;
             case "input":
@@ -350,7 +354,7 @@ public sealed class Hwt1PresentationAdapter :
         ArgumentNullException.ThrowIfNull(terminal);
         if (Interlocked.CompareExchange(ref _terminal, terminal, null) is not null)
             throw new InvalidOperationException("An HWT1 adapter can only be attached to one terminal.");
-        _hmp1Workload = terminal.Workload as Hmp1WorkloadAdapter;
+        _hmp1OutputSource = terminal.Workload as IHmp1TerminalOutputSource;
         terminal.PresentationInvalidated += InvalidatePresentation;
         InvalidatePresentation();
     }

--- a/src/Hex1b/Hwt1/Hwt1Progress.cs
+++ b/src/Hex1b/Hwt1/Hwt1Progress.cs
@@ -1,0 +1,14 @@
+namespace Hex1b;
+
+internal sealed record Hwt1Progress(string State, int? Percentage)
+{
+    internal static Hwt1Progress From(TerminalProgress progress) => new(progress.State switch
+    {
+        TerminalProgressState.None => "none",
+        TerminalProgressState.Normal => "normal",
+        TerminalProgressState.Error => "error",
+        TerminalProgressState.Indeterminate => "indeterminate",
+        TerminalProgressState.Warning => "warning",
+        _ => throw new ArgumentOutOfRangeException(nameof(progress))
+    }, progress.Percentage);
+}

--- a/src/Hex1b/Hwt1/Hwt1RenderProjection.cs
+++ b/src/Hex1b/Hwt1/Hwt1RenderProjection.cs
@@ -171,7 +171,8 @@ internal sealed class Hwt1RenderProjection
             newImages, _images.Keys.ToArray(), placements,
             new(workloadBytes, outputBatches, elapsedMs,
                 snapshotMs + Stopwatch.GetElapsedTime(started).TotalMilliseconds),
-            warnings, peer ?? Hwt1Peer.Standalone, history, hyperlinks, snapshot.WindowTitle),
+            warnings, peer ?? Hwt1Peer.Standalone, history, hyperlinks, snapshot.WindowTitle,
+            Hwt1Progress.From(snapshot.Progress), Hwt1ShellIntegration.From(snapshot.ShellIntegration)),
             Hwt1JsonSerializerContext.Default.Hwt1FrameMetadata);
         if (metadata.Length > 8 * 1024 * 1024)
             throw new InvalidDataException("Frame metadata exceeds the HWT1 8 MiB limit.");

--- a/src/Hex1b/Hwt1/Hwt1ShellIntegration.cs
+++ b/src/Hex1b/Hwt1/Hwt1ShellIntegration.cs
@@ -1,0 +1,14 @@
+namespace Hex1b;
+
+internal sealed record Hwt1ShellIntegration(string Phase, int? LastExitCode)
+{
+    internal static Hwt1ShellIntegration From(TerminalShellIntegration shell) => new(shell.Phase switch
+    {
+        TerminalShellIntegrationPhase.Unknown => "unknown",
+        TerminalShellIntegrationPhase.Prompt => "prompt",
+        TerminalShellIntegrationPhase.CommandLine => "commandLine",
+        TerminalShellIntegrationPhase.Executing => "executing",
+        TerminalShellIntegrationPhase.Finished => "finished",
+        _ => throw new ArgumentOutOfRangeException(nameof(shell))
+    }, shell.LastExitCode);
+}

--- a/src/Hex1b/PlaceholderWorkloadAdapter.cs
+++ b/src/Hex1b/PlaceholderWorkloadAdapter.cs
@@ -30,7 +30,7 @@ namespace Hex1b;
 /// is also invoked so it discards diff state.
 /// </para>
 /// </remarks>
-internal sealed class PlaceholderWorkloadAdapter : IHex1bTerminalWorkloadAdapter
+internal sealed class PlaceholderWorkloadAdapter : IHex1bTerminalWorkloadAdapter, IHmp1TerminalOutputSource
 {
     // Hard-reset sequence prepended to each swapped-in child's first frame.
     //   ESC c            - RIS, full reset (modes, attrs, scroll regions, alt-screen)
@@ -104,6 +104,10 @@ internal sealed class PlaceholderWorkloadAdapter : IHex1bTerminalWorkloadAdapter
 
     /// <summary>The currently-active child (test hook).</summary>
     internal IHex1bTerminalWorkloadAdapter ActiveChild => Volatile.Read(ref _active);
+    Hmp1WorkloadAdapter? IHmp1TerminalOutputSource.Hmp1Workload =>
+        (ActiveChild as IHmp1TerminalOutputSource)?.Hmp1Workload;
+    ValueTask<Hmp1WorkloadOutput> IHmp1TerminalOutputSource.ReadTerminalOutputAsync(CancellationToken cancellationToken)
+        => ReadOutputItemAsync(preserveState: true, cancellationToken);
 
     /// <summary>
     /// Replace the primary workload with a freshly-built instance. Used by
@@ -170,6 +174,9 @@ internal sealed class PlaceholderWorkloadAdapter : IHex1bTerminalWorkloadAdapter
     public event Action? Disconnected;
 
     public async ValueTask<ReadOnlyMemory<byte>> ReadOutputAsync(CancellationToken ct = default)
+        => (await ReadOutputItemAsync(preserveState: false, ct).ConfigureAwait(false)).Bytes;
+
+    private async ValueTask<Hmp1WorkloadOutput> ReadOutputItemAsync(bool preserveState, CancellationToken ct)
     {
         while (true)
         {
@@ -196,13 +203,24 @@ internal sealed class PlaceholderWorkloadAdapter : IHex1bTerminalWorkloadAdapter
                 {
                     repaintable.RequestFullRepaint();
                 }
-                return ResetSequence;
+                // A remote child's reset belongs to its first compound replay. A
+                // standalone RIS would publish fictitious default activity before
+                // the authoritative checkpoint and lose replay control at a relay.
+                if (!preserveState || active is not IHmp1TerminalOutputSource)
+                {
+                    var state = preserveState && _primary is IHmp1TerminalOutputSource
+                        ? new Hmp1TerminalState(null, null, _lastWidth, _lastHeight, false)
+                        : null;
+                    return new(ResetSequence, State: state);
+                }
             }
 
             using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, swapToken);
             try
             {
-                var data = await active.ReadOutputAsync(linked.Token).ConfigureAwait(false);
+                var output = preserveState && active is IHmp1TerminalOutputSource source
+                    ? await source.ReadTerminalOutputAsync(linked.Token).ConfigureAwait(false)
+                    : new Hmp1WorkloadOutput(await active.ReadOutputAsync(linked.Token).ConfigureAwait(false));
 
                 // If a swap happened while we were awaiting, drop these bytes
                 // — they belong to the now-inactive child and would mix into
@@ -212,7 +230,7 @@ internal sealed class PlaceholderWorkloadAdapter : IHex1bTerminalWorkloadAdapter
                     continue;
                 }
 
-                if (data.IsEmpty)
+                if (output.Bytes.IsEmpty && output.State is null && output.AnimationState is null && !output.IsStateSync)
                 {
                     // EOF on the active child. If that's the primary and the
                     // resume policy allows it, fall back to the placeholder
@@ -225,10 +243,17 @@ internal sealed class PlaceholderWorkloadAdapter : IHex1bTerminalWorkloadAdapter
                     }
 
                     Disconnected?.Invoke();
-                    return ReadOnlyMemory<byte>.Empty;
+                    return default;
                 }
 
-                return data;
+                if (emitReset)
+                {
+                    var combined = new byte[ResetSequence.Length + output.Bytes.Length];
+                    ResetSequence.Span.CopyTo(combined);
+                    output.Bytes.Span.CopyTo(combined.AsSpan(ResetSequence.Length));
+                    output = output with { Bytes = combined };
+                }
+                return output;
             }
             catch (OperationCanceledException) when (!ct.IsCancellationRequested)
             {

--- a/src/Hex1b/TerminalActivityState.cs
+++ b/src/Hex1b/TerminalActivityState.cs
@@ -1,0 +1,97 @@
+using System.Globalization;
+using Hex1b.Tokens;
+
+namespace Hex1b;
+
+/// <summary>Immutable activity pair and shared reducer for authoritative and standalone terminals.</summary>
+internal sealed record TerminalActivityState(
+    TerminalProgress Progress,
+    TerminalShellIntegration ShellIntegration)
+{
+    internal static TerminalActivityState Default { get; } =
+        new(TerminalProgress.Default, TerminalShellIntegration.Default);
+
+    internal TerminalActivityState Apply(AnsiToken token) => token switch
+    {
+        OscToken osc => ApplyOsc(osc.Command, osc.Parameters, osc.Payload),
+        RisToken => Default,
+        _ => this
+    };
+
+    internal TerminalActivityState ApplyOsc(string command, string parameters, string payload)
+    {
+        if (command == "9" && parameters == "4")
+        {
+            var separator = payload.IndexOf(';');
+            var stateText = separator < 0 ? payload.AsSpan() : payload.AsSpan(0, separator);
+            var percentageText = separator < 0 ? default : payload.AsSpan(separator + 1);
+            if (stateText.Length != 1 || stateText[0] is < '0' or > '4' ||
+                percentageText.Contains(';'))
+                return this;
+
+            var state = (TerminalProgressState)(stateText[0] - '0');
+            int? percentage = null;
+            if (state is TerminalProgressState.Normal or TerminalProgressState.Error or TerminalProgressState.Warning)
+            {
+                if (!IsAsciiDecimal(percentageText, allowSign: false) ||
+                    !int.TryParse(percentageText, NumberStyles.None, CultureInfo.InvariantCulture, out var value) ||
+                    value > 100)
+                    return this;
+                percentage = value;
+            }
+
+            return this with { Progress = new TerminalProgress(state, percentage) };
+        }
+
+        if (command == "133")
+        {
+            // The tokenizer places a bare marker in Payload, but a marker with an
+            // argument in Parameters (including D with an explicitly empty argument).
+            var marker = parameters.Length == 0 ? payload : parameters;
+            if (marker == "D")
+            {
+                int? exitCode = null;
+                if (parameters.Length != 0 && payload.Length != 0)
+                {
+                    if (!IsAsciiDecimal(payload, allowSign: true) ||
+                        !int.TryParse(payload, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var value))
+                        return this;
+                    exitCode = value;
+                }
+                return this with
+                {
+                    ShellIntegration = new TerminalShellIntegration(TerminalShellIntegrationPhase.Finished, exitCode)
+                };
+            }
+
+            if (parameters.Length != 0)
+                return this;
+            var phase = marker switch
+            {
+                "A" => TerminalShellIntegrationPhase.Prompt,
+                "B" => TerminalShellIntegrationPhase.CommandLine,
+                "C" => TerminalShellIntegrationPhase.Executing,
+                _ => TerminalShellIntegrationPhase.Unknown
+            };
+            if (phase != TerminalShellIntegrationPhase.Unknown)
+                return this with
+                {
+                    ShellIntegration = new TerminalShellIntegration(phase, ShellIntegration.LastExitCode)
+                };
+        }
+
+        return this;
+    }
+
+    private static bool IsAsciiDecimal(ReadOnlySpan<char> text, bool allowSign)
+    {
+        if (allowSign && !text.IsEmpty && text[0] is '+' or '-')
+            text = text[1..];
+        if (text.IsEmpty)
+            return false;
+        foreach (var character in text)
+            if (character is < '0' or > '9')
+                return false;
+        return true;
+    }
+}

--- a/src/Hex1b/TerminalProgress.cs
+++ b/src/Hex1b/TerminalProgress.cs
@@ -1,0 +1,27 @@
+namespace Hex1b;
+
+/// <summary>
+/// Contains the current progress indicator reported by a terminal workload.
+/// </summary>
+/// <remarks>
+/// Progress is independent of shell integration and terminal-process lifetime.
+/// No progress is inferred from output, and process exit does not clear it.
+/// </remarks>
+public sealed record TerminalProgress
+{
+    internal static TerminalProgress Default { get; } = new(TerminalProgressState.None, null);
+
+    internal TerminalProgress(TerminalProgressState state, int? percentage)
+    {
+        State = state;
+        Percentage = percentage;
+    }
+
+    /// <summary>Gets the reported progress indicator state.</summary>
+    public TerminalProgressState State { get; }
+
+    /// <summary>
+    /// Gets the reported percentage from 0 to 100, or null for hidden or indeterminate progress.
+    /// </summary>
+    public int? Percentage { get; }
+}

--- a/src/Hex1b/TerminalProgressState.cs
+++ b/src/Hex1b/TerminalProgressState.cs
@@ -1,0 +1,18 @@
+namespace Hex1b;
+
+/// <summary>
+/// Describes the progress indicator reported by a terminal workload using OSC 9;4.
+/// </summary>
+public enum TerminalProgressState
+{
+    /// <summary>No progress indicator is displayed.</summary>
+    None = 0,
+    /// <summary>Normal determinate progress is displayed.</summary>
+    Normal = 1,
+    /// <summary>Determinate progress indicates an error.</summary>
+    Error = 2,
+    /// <summary>Activity is reported without a percentage.</summary>
+    Indeterminate = 3,
+    /// <summary>Determinate progress indicates a warning.</summary>
+    Warning = 4
+}

--- a/src/Hex1b/TerminalShellIntegration.cs
+++ b/src/Hex1b/TerminalShellIntegration.cs
@@ -1,0 +1,32 @@
+namespace Hex1b;
+
+/// <summary>
+/// Contains the current shell phase and latest reported command result.
+/// </summary>
+/// <remarks>
+/// This is current state, not command history or the terminal process's lifecycle.
+/// Markers can arrive out of order; missing markers are not synthesized.
+/// </remarks>
+public sealed record TerminalShellIntegration
+{
+    internal static TerminalShellIntegration Default { get; } =
+        new(TerminalShellIntegrationPhase.Unknown, null);
+
+    internal TerminalShellIntegration(TerminalShellIntegrationPhase phase, int? lastExitCode)
+    {
+        Phase = phase;
+        LastExitCode = lastExitCode;
+    }
+
+    /// <summary>Gets the latest phase reported by the shell.</summary>
+    public TerminalShellIntegrationPhase Phase { get; }
+
+    /// <summary>
+    /// Gets the latest exit code reported by marker D, or null when no result was reported.
+    /// </summary>
+    /// <remarks>
+    /// Prompt, command-line, and execution markers retain this value. A completion marker
+    /// with no exit code replaces the previous result with null, not success.
+    /// </remarks>
+    public int? LastExitCode { get; }
+}

--- a/src/Hex1b/TerminalShellIntegrationPhase.cs
+++ b/src/Hex1b/TerminalShellIntegrationPhase.cs
@@ -1,0 +1,18 @@
+namespace Hex1b;
+
+/// <summary>
+/// Describes the current phase reported by a shell using OSC 133 markers.
+/// </summary>
+public enum TerminalShellIntegrationPhase
+{
+    /// <summary>No shell phase has been reported; this does not imply an idle shell.</summary>
+    Unknown = 0,
+    /// <summary>The shell has started displaying its prompt (marker A).</summary>
+    Prompt = 1,
+    /// <summary>The shell is accepting command-line input (marker B).</summary>
+    CommandLine = 2,
+    /// <summary>The shell has reported command execution (marker C).</summary>
+    Executing = 3,
+    /// <summary>The shell has reported command completion (marker D).</summary>
+    Finished = 4
+}

--- a/src/Hex1b/TerminalWidgetHandle.cs
+++ b/src/Hex1b/TerminalWidgetHandle.cs
@@ -94,6 +94,11 @@ public sealed class TerminalWidgetHandle :
     
     // Reference to the owning terminal for forwarding input
     private Hex1bTerminal? _terminal;
+    private Hex1bTerminal? _activityTerminal;
+    private Action<TerminalActivityState>? _activityChangedHandler;
+    private TerminalActivityState _activityState = TerminalActivityState.Default;
+    private int _activitySubscriptionVersion;
+    private bool _ignoreDetachedActivityOutput;
     
     // Terminal lifecycle state
     private TerminalState _state = TerminalState.NotStarted;
@@ -255,6 +260,37 @@ public sealed class TerminalWidgetHandle :
     /// </summary>
     /// <remarks>Uses the same text normalization and length bound as <see cref="WindowTitle"/>.</remarks>
     public string IconName => _iconName;
+
+    /// <summary>Gets the current progress reported by the child workload.</summary>
+    /// <remarks>
+    /// Remains live while copy mode freezes displayed cells. Process exit and disconnect
+    /// retain the last report; <see cref="Reset"/> returns it to hidden progress.
+    /// </remarks>
+    public TerminalProgress Progress
+    {
+        get { lock (_bufferLock) return _activityState.Progress; }
+    }
+
+    /// <summary>Gets the current shell phase and latest reported command result.</summary>
+    /// <remarks>
+    /// Remains live in copy mode and is independent of <see cref="State"/> and
+    /// <see cref="ExitCode"/>, which describe the terminal process, not shell commands.
+    /// </remarks>
+    public TerminalShellIntegration ShellIntegration
+    {
+        get { lock (_bufferLock) return _activityState.ShellIntegration; }
+    }
+
+    /// <summary>Occurs when reported progress changes to a distinct value.</summary>
+    /// <remarks>Subscribing does not emit a baseline; read <see cref="Progress"/>.</remarks>
+    public event Action<TerminalProgress>? ProgressChanged;
+
+    /// <summary>Occurs when the reported shell phase or latest result changes.</summary>
+    /// <remarks>
+    /// Subscribing does not emit a baseline; read <see cref="ShellIntegration"/>.
+    /// This describes current state, not a history of command executions.
+    /// </remarks>
+    public event Action<TerminalShellIntegration>? ShellIntegrationChanged;
     
     /// <summary>
     /// Event raised when the terminal state changes.
@@ -280,7 +316,40 @@ public sealed class TerminalWidgetHandle :
     /// <inheritdoc />
     void ITerminalLifecycleAwarePresentationAdapter.TerminalCreated(Hex1bTerminal terminal)
     {
-        _terminal = terminal;
+        Hex1bTerminal? previousTerminal;
+        Action<TerminalActivityState>? previousHandler;
+        Action<TerminalActivityState> handler;
+        lock (_bufferLock)
+        {
+            if (_disposed)
+                return;
+            previousTerminal = _activityTerminal;
+            previousHandler = _activityChangedHandler;
+            _terminal = terminal;
+            _activityTerminal = terminal;
+            _ignoreDetachedActivityOutput = false;
+            var version = ++_activitySubscriptionVersion;
+            handler = activity =>
+            {
+                lock (_bufferLock)
+                {
+                    if (!_disposed && version == _activitySubscriptionVersion)
+                        SetActivityState(activity);
+                }
+            };
+            _activityChangedHandler = handler;
+        }
+
+        if (previousHandler is not null)
+            previousTerminal?.UnsubscribeActivityStateChanged(previousHandler);
+        // Subscribe and capture the baseline under the terminal's lock, without
+        // taking that lock while holding the handle's buffer lock.
+        terminal.SubscribeActivityStateChanged(handler);
+        bool detached;
+        lock (_bufferLock)
+            detached = _disposed || _activityChangedHandler != handler;
+        if (detached)
+            terminal.UnsubscribeActivityStateChanged(handler);
     }
 
     void IHex1bTerminalPresentationAdapter.InvalidatePresentation()
@@ -315,16 +384,70 @@ public sealed class TerminalWidgetHandle :
     /// <summary>
     /// Resets the terminal state to NotStarted. Used when restarting a terminal.
     /// </summary>
+    /// <remarks>
+    /// Clears activity and queued copy-mode output, and disconnects the previous terminal.
+    /// A newly attached terminal supplies the next session's activity.
+    /// </remarks>
     public void Reset()
     {
+        Hex1bTerminal? previousTerminal;
+        Action<TerminalActivityState>? previousHandler;
+        TerminalActivityState previousActivity;
+        bool wasInCopyMode;
+        StopDragScrollTimer();
         lock (_bufferLock)
         {
+            if (_disposed)
+                return;
+            previousTerminal = _activityTerminal;
+            previousHandler = _activityChangedHandler;
+            previousActivity = _activityState;
+            wasInCopyMode = _inCopyMode;
+            _ignoreDetachedActivityOutput |= previousTerminal is not null;
+            _activityTerminal = null;
+            _activityChangedHandler = null;
+            _terminal = null;
+            _activitySubscriptionVersion++;
             _state = TerminalState.NotStarted;
             _exitCode = null;
+            _inCopyMode = false;
+            _selection = null;
+            _outputQueue = null;
+            _scrollbackOffset = 0;
+            UpdateCopyModeState();
+            _activityState = TerminalActivityState.Default;
             ClearBuffer();
         }
+        if (previousHandler is not null)
+            previousTerminal?.UnsubscribeActivityStateChanged(previousHandler);
+        NotifyActivityStateChanged(previousActivity, TerminalActivityState.Default);
+        if (wasInCopyMode)
+            CopyModeChanged?.Invoke(false);
         StateChanged?.Invoke(_state);
         OutputReceived?.Invoke();
+    }
+
+    private void SetActivityState(TerminalActivityState activity)
+    {
+        var previous = _activityState;
+        if (previous == activity)
+            return;
+        _activityState = activity;
+        NotifyActivityStateChanged(previous, activity);
+    }
+
+    private void NotifyActivityStateChanged(TerminalActivityState previous, TerminalActivityState activity)
+    {
+        if (_disposed || previous == activity)
+            return;
+        if (previous.Progress != activity.Progress)
+            ProgressChanged?.Invoke(activity.Progress);
+        if (_disposed)
+            return;
+        if (previous.ShellIntegration != activity.ShellIntegration)
+            ShellIntegrationChanged?.Invoke(activity.ShellIntegration);
+        if (!_disposed)
+            OutputReceived?.Invoke();
     }
     
     /// <summary>
@@ -657,6 +780,16 @@ public sealed class TerminalWidgetHandle :
         
         lock (_bufferLock)
         {
+            if (_disposed)
+                return ValueTask.CompletedTask;
+            // Attached terminals publish the authoritative pair directly, including
+            // replay checkpoints. Standalone handles reduce activity once on arrival,
+            // never again when queued cells are drained after copy mode.
+            if (_activityTerminal is null && !_ignoreDetachedActivityOutput)
+            {
+                foreach (var applied in appliedTokens)
+                    SetActivityState(_activityState.Apply(applied.Token));
+            }
             if (_inCopyMode && _outputQueue != null)
             {
                 // Queue output for later application — buffer is frozen during copy mode.
@@ -833,6 +966,9 @@ public sealed class TerminalWidgetHandle :
     /// </summary>
     public void EnterCopyMode()
     {
+        // Activity observers run under the terminal lock, so never acquire that
+        // lock while holding the handle's buffer lock.
+        int scrollbackCount = ScrollbackCount;
         lock (_bufferLock)
         {
             if (_inCopyMode) return;
@@ -841,7 +977,6 @@ public sealed class TerminalWidgetHandle :
             _outputQueue = new List<IReadOnlyList<AppliedToken>>();
             
             // Position cursor at the terminal's current cursor position in virtual coordinates
-            int scrollbackCount = ScrollbackCount;
             var initialPosition = new BufferPosition(scrollbackCount + _cursorY, _cursorX);
             _selection = new TerminalSelection(initialPosition);
         }
@@ -893,6 +1028,7 @@ public sealed class TerminalWidgetHandle :
     public string? CopySelection()
     {
         string? text;
+        var scrollbackRows = _terminal?.GetScrollbackRows(int.MaxValue) ?? [];
         
         lock (_bufferLock)
         {
@@ -902,7 +1038,9 @@ public sealed class TerminalWidgetHandle :
             }
             else
             {
-                text = _selection.ExtractText(GetVirtualCellUnlocked, _width);
+                text = _selection.ExtractText(
+                    (row, column) => GetVirtualCellUnlocked(row, column, scrollbackRows.Length, scrollbackRows),
+                    _width);
             }
         }
         
@@ -1219,24 +1357,27 @@ public sealed class TerminalWidgetHandle :
     /// <returns>The cell at that position, or null if out of bounds.</returns>
     public TerminalCell? GetVirtualCell(int virtualRow, int column)
     {
+        var terminal = _terminal;
+        var scrollbackCount = terminal?.ScrollbackCount ?? 0;
+        var rows = virtualRow >= 0 && virtualRow < scrollbackCount
+            ? terminal?.GetScrollbackRows(scrollbackCount) ?? []
+            : [];
         lock (_bufferLock)
         {
-            return GetVirtualCellUnlocked(virtualRow, column);
+            return GetVirtualCellUnlocked(virtualRow, column, scrollbackCount, rows);
         }
     }
     
-    private TerminalCell? GetVirtualCellUnlocked(int virtualRow, int column)
+    private TerminalCell? GetVirtualCellUnlocked(
+        int virtualRow, int column, int scrollbackCount, ScrollbackRow[] rows)
     {
-        int scrollbackCount = ScrollbackCount;
-        
         if (virtualRow < 0) return null;
         if (column < 0 || column >= _width) return null;
         
         if (virtualRow < scrollbackCount)
         {
             // Scrollback region
-            var rows = _terminal?.GetScrollbackRows(scrollbackCount);
-            if (rows == null || virtualRow >= rows.Length) return null;
+            if (virtualRow >= rows.Length) return null;
             var cells = rows[virtualRow].Cells;
             if (column >= cells.Length) return TerminalCell.Empty;
             return cells[column];
@@ -1258,8 +1399,21 @@ public sealed class TerminalWidgetHandle :
     /// <inheritdoc />
     public ValueTask DisposeAsync()
     {
-        if (_disposed) return ValueTask.CompletedTask;
-        _disposed = true;
+        Hex1bTerminal? previousTerminal;
+        Action<TerminalActivityState>? previousHandler;
+        lock (_bufferLock)
+        {
+            if (_disposed) return ValueTask.CompletedTask;
+            _disposed = true;
+            previousTerminal = _activityTerminal;
+            previousHandler = _activityChangedHandler;
+            _activityTerminal = null;
+            _activityChangedHandler = null;
+            _activitySubscriptionVersion++;
+            _outputQueue = null;
+        }
+        if (previousHandler is not null)
+            previousTerminal?.UnsubscribeActivityStateChanged(previousHandler);
         
         StopDragScrollTimer();
         Disconnected?.Invoke();

--- a/src/Hex1b/Tokens/AnsiTokenizer.cs
+++ b/src/Hex1b/Tokens/AnsiTokenizer.cs
@@ -1033,6 +1033,13 @@ public static class AnsiTokenizer
         }
 
         var secondSemicolon = oscData.IndexOf(';', firstSemicolon + 1);
+        if (command == "133" && secondSemicolon == firstSemicolon + 1)
+        {
+            // Keep an empty marker invalid, including after filtered-output serialization.
+            // Otherwise 133;;A and 133;A collapse to the same token.
+            payload = oscData[(firstSemicolon + 1)..];
+            return true;
+        }
         if (secondSemicolon < 0)
         {
             // Only one semicolon - rest is payload

--- a/src/web-terminal/README.md
+++ b/src/web-terminal/README.md
@@ -138,6 +138,7 @@ workers, fonts, and the intended WebSocket endpoint.
 | `readOnly` | Disable application input while retaining history inspection and selection. |
 | `label` | Accessible label for the terminal's hidden keyboard input. |
 | `onTitleChange` | Initial authoritative workload title, then distinct presented changes; see below. |
+| `onProgressChange`, `onShellIntegrationChange` | Initial authoritative activity, then distinct presented changes for host-owned chrome. |
 | `inputBindings`, `onInput`, `actions` | Per-view input policy and custom actions. |
 | `onSelectionUI` | Synchronous, cancelable UI notification hook. |
 
@@ -148,7 +149,7 @@ Font size is an integer from 8–32, defaulting to 16. Import `MIN_FONT_SIZE` an
 ownership. `requestPrimary()` explicitly requests ownership; inspect `peer` or
 `onRoleChange` to observe the result.
 
-The handle exposes `geometry`, `peer`, `connected`, `title`, `stats`, `screenText`,
+The handle exposes `geometry`, `peer`, `connected`, `title`, `progress`, `shellIntegration`, `stats`, `screenText`,
 `sizing`, `viewport`, `selection`, `inputBindings`, and `inputContext`.
 Metrics start empty; check optional fields before using them. History may be
 unavailable, and selection can be unavailable, none, pending, valid, or
@@ -157,7 +158,7 @@ their state-specific values. `screenText` reflects the presented viewport, not
 an independently reconstructed ANSI buffer.
 
 Callbacks include `onGeometry`, `onRoleChange`, `onTitleChange`, `onSizingChange`, `onStats`,
-`onViewportChange`, `onSelectionChange`, `onStatus`, and `onInputError`.
+`onProgressChange`, `onShellIntegrationChange`, `onViewportChange`, `onSelectionChange`, `onStatus`, and `onInputError`.
 
 ### Workload titles
 
@@ -219,6 +220,96 @@ an empty title.
 The per-title bound is not a limit on all parser buffering or saved-stack depth.
 An HMP1 snapshot with too much saved title state fails its 16 MiB replay limit
 rather than silently discarding saved titles.
+
+### Application progress and shell activity
+
+`terminal.progress` exposes OSC 9;4 state as `{ state, percentage }`.
+The states are `"none"`, `"normal"`, `"error"`, `"indeterminate"`, and `"warning"`.
+Normal/error/warning percentages are integers from 0 through 100. None and
+indeterminate have `percentage: null`; none means the host should hide its indicator.
+This is application-reported progress, not inferred from output or CPU activity.
+It is independent of `ProgressWidget`, which draws inside terminal cells.
+
+`terminal.shellIntegration` exposes OSC 133 as `{ phase, lastExitCode }`.
+The phases are `"unknown"`, `"prompt"` (A), `"commandLine"` (B),
+`"executing"` (C), and `"finished"` (D). B means input after the prompt, **not**
+command execution. Unknown does not mean idle. `lastExitCode` is a signed
+32-bit integer, or null when no status was reported; null is not success.
+A/B/C preserve the last reported result, and D replaces it, including clearing
+it to null when the shell omits its status. No command text, history, or output
+locations are retained by these APIs.
+
+Both getters return defensive copies. Their callbacks receive the first
+authoritative presented state before mount resolves, then distinct presented
+changes. Both getters are updated before either activity callback. Callbacks
+use the same direct, synchronous host-callback convention as title changes;
+host exceptions are not swallowed or retried.
+
+Frames coalesce: the browser might see only Finished for a fast command, or
+miss an entire command whose final state is unchanged. These callbacks are
+**current-state notifications, not a lossless start/finish event stream**.
+Resync/replay never invent commands, unchanged state does not notify again,
+and a new mount receives its own baseline.
+
+This example creates optional chrome outside the terminal:
+
+```ts
+import { WebTerminal } from "@hex1b/web-terminal";
+
+const status = document.createElement("span");
+const progress = document.createElement("progress");
+progress.max = 100;
+progress.hidden = true;
+const container = document.createElement("div");
+container.style.cssText = "width:800px;height:480px";
+document.body.append(status, progress, container);
+
+const terminal = await WebTerminal.mount(container, {
+  url: "/ws/terminal",
+  onProgressChange(value) {
+    progress.hidden = value.state === "none";
+    progress.dataset.state = value.state; // Host CSS can distinguish error/warning.
+    if (value.percentage === null) progress.removeAttribute("value");
+    else progress.value = value.percentage;
+  },
+  onShellIntegrationChange(value) {
+    status.textContent = value.phase +
+      (value.lastExitCode === null ? "" : ` (last exit ${value.lastExitCode})`);
+  },
+  onStats(stats) {
+    if (!stats.connected) {
+      progress.hidden = true;
+      status.textContent = "Disconnected";
+    }
+  }
+});
+console.log(terminal.progress, terminal.shellIntegration);
+```
+
+No title, document chrome, or progress UI is changed automatically by the
+component. The sample endpoint must be supplied by your application.
+Callbacks can run before the `terminal` variable is assigned; use their
+arguments during initial mounting.
+
+RIS resets progress to None and shell integration to Unknown. Soft reset,
+screen clearing, resize, and buffer switches preserve them. OSC 9;4 state 0
+clears only progress; a shell completion does not implicitly clear it.
+Disconnect, process exit, and disposal retain the last reported values
+without inventing a completion or progress clear. Check `connected` before
+showing active chrome, and remount to reconnect. Disposal stops callbacks.
+Snapshots and historical viewports carry current activity, not activity at
+the time a particular row was printed.
+
+The core accepts BEL, ESC-backslash ST, and decoded Unicode C1 terminators
+through its UTF-8 input path. Determinate progress requires unsigned decimal
+0-100; clear/indeterminate allow an omitted percentage and ignore its optional
+value. OSC 133 supports the basic A/B/C forms and D with an optional signed
+decimal exit status (an empty field also means no status). Missing required,
+malformed, overflowed, excess, or unsupported arguments do not change state.
+The raw-output presentation path still forwards the original sequences to
+supporting outer terminals. Required activity metadata needs the matching
+server build; invalid/missing wire fields fail the connection, not silently
+fall back to default state.
 
 ## Input and clipboard
 

--- a/src/web-terminal/src/protocol.ts
+++ b/src/web-terminal/src/protocol.ts
@@ -102,6 +102,25 @@ function validateMetadata(metadata: unknown): asserts metadata is FrameMetadata 
       /[\u0000-\u001f\u007f-\u009f\ud800-\udfff]/u.test(metadata.title)) {
     throw new Error("Invalid terminal title");
   }
+  const progress = metadata.progress;
+  if (!isRecord(progress) || typeof progress.state !== "string" ||
+      !["none", "normal", "error", "indeterminate", "warning"].includes(progress.state)) {
+    throw new Error("Invalid terminal progress");
+  }
+  if (progress.state === "none" || progress.state === "indeterminate") {
+    if (progress.percentage !== null) throw new Error("Unexpected terminal progress percentage");
+  } else {
+    integer(progress.percentage, "terminal progress percentage", 0, 100);
+  }
+  const shell = metadata.shellIntegration;
+  if (!isRecord(shell) || typeof shell.phase !== "string" ||
+      !["unknown", "prompt", "commandLine", "executing", "finished"].includes(shell.phase)) {
+    throw new Error("Invalid terminal shell integration");
+  }
+  if (shell.lastExitCode !== null)
+    integer(shell.lastExitCode, "terminal shell exit code", -2147483648, 2147483647);
+  if (shell.phase === "unknown" && shell.lastExitCode !== null)
+    throw new Error("Unknown terminal shell phase has an exit code");
   const columns = integer(metadata.columns, "columns", 1, 1024);
   const rows = integer(metadata.rows, "rows", 1, 512);
   if (typeof metadata.mouseTracking !== "number" || ![0, 9, 1000, 1002, 1003].includes(metadata.mouseTracking)) {

--- a/src/web-terminal/src/terminal-worker.ts
+++ b/src/web-terminal/src/terminal-worker.ts
@@ -137,6 +137,7 @@ async function drawFrame() {
         cellWidth: metadata.cellWidth, cellHeight: metadata.cellHeight,
         mouseTracking: metadata.mouseTracking, peer: metadata.peer,
         history: metadata.history, revision: frame.revision, title: metadata.title,
+        progress: metadata.progress, shellIntegration: metadata.shellIntegration,
         text, hyperlinks: metadata.hyperlinks
       });
       send({ type: "ack", revision: frame.revision });

--- a/src/web-terminal/src/types.ts
+++ b/src/web-terminal/src/types.ts
@@ -142,6 +142,21 @@ export interface SelectionUIDetail extends SelectionUIState {
   readonly rects: readonly Readonly<SelectionRectangle>[];
 }
 export type SelectionUIEvent = CustomEvent<SelectionUIDetail>;
+/** Application-reported OSC 9;4 indicator, independent of shell execution. */
+export type TerminalProgressState = "none" | "normal" | "error" | "indeterminate" | "warning";
+/** Immutable current progress; a hidden or indeterminate indicator has no percentage. */
+export interface TerminalProgress {
+  readonly state: TerminalProgressState;
+  readonly percentage: number | null;
+}
+/** Last reported OSC 133 phase. Unknown does not mean idle; commandLine is not execution. */
+export type TerminalShellIntegrationPhase = "unknown" | "prompt" | "commandLine" | "executing" | "finished";
+/** Current shell phase and latest reported completion status, not command history. */
+export interface TerminalShellIntegration {
+  readonly phase: TerminalShellIntegrationPhase;
+  /** Null means no reported status, not success. Preserved across the next prompt/command. */
+  readonly lastExitCode: number | null;
+}
 export interface WebTerminalOptions extends InputPolicyOptions {
   url: string | URL;
   /** Optional module-worker entry, resolved against the page URL. Defaults to the bundled worker. */
@@ -164,6 +179,19 @@ export interface WebTerminalOptions extends InputPolicyOptions {
    * text; render with textContent, not HTML. No notifications after disposal.
    */
   onTitleChange?: (title: string) => void;
+  /**
+   * Receives the first authoritative presented progress before mount resolves, then distinct
+   * presented changes. Both activity getters update before either callback. Intermediate
+   * states may coalesce; this is not a callback for every OSC sequence. None hides the indicator.
+   * No notifications after disposal; connection loss does not manufacture a progress clear.
+   */
+  onProgressChange?: (progress: TerminalProgress) => void;
+  /**
+   * Receives the first authoritative presented shell state before mount resolves, then distinct
+   * presented changes. This is not a lossless command-start/finish stream: entire commands may
+   * occur between frames. Replays provide current state, never synthetic command executions.
+   */
+  onShellIntegrationChange?: (shellIntegration: TerminalShellIntegration) => void;
   onStats?: (stats: TerminalStats, text: string | undefined) => void;
   onViewportChange?: (viewport: TerminalViewport) => void;
   onSelectionChange?: (selection: TerminalSelection) => void;
@@ -179,6 +207,10 @@ export interface WebTerminalHandle {
   readonly connected: boolean;
   /** Current presented workload title, or "" when unset/cleared. Retained on disconnect/dispose. */
   readonly title: string;
+  /** Current presented progress, initially none. Retained on disconnect/dispose; check connected. */
+  readonly progress: TerminalProgress;
+  /** Current presented shell state, initially unknown. Retained on disconnect/dispose. */
+  readonly shellIntegration: TerminalShellIntegration;
   readonly stats: TerminalStats;
   readonly screenText: string;
   readonly sizing: TerminalSizingState;

--- a/src/web-terminal/src/web-terminal.ts
+++ b/src/web-terminal/src/web-terminal.ts
@@ -12,7 +12,7 @@ import type { MouseCapture } from "./mouse-input.js";
 import type { CopySelectionOptions, InputActionHandler, InputDecision, InputBinding,
   TerminalActionName, TerminalGeometry, TerminalInput, TerminalInputContext, TerminalPeer,
   TerminalRendererPreference, TerminalSelection, TerminalSizing, TerminalSizingState, TerminalStats, TerminalViewport,
-  WebTerminalHandle, WebTerminalOptions } from "./types.js";
+  TerminalProgress, TerminalShellIntegration, WebTerminalHandle, WebTerminalOptions } from "./types.js";
 import type { InputCommand, TerminalCommand, WorkerInputMessage, WorkerOutputMessage } from "./wire-types.js";
 import { errorMessage, isRecord } from "./validation.js";
 export { InputRoute, TerminalAction, defaultInputBindings } from "./input-policy.js";
@@ -55,6 +55,9 @@ export class WebTerminal implements WebTerminalHandle {
   #screenText = "";
   #title = "";
   #hasTitle = false;
+  #progress: TerminalProgress = { state: "none", percentage: null };
+  #shellIntegration: TerminalShellIntegration = { phase: "unknown", lastExitCode: null };
+  #hasActivity = false;
   #history: HistoryState;
   #highlights!: HTMLDivElement;
   #inspection!: HTMLDivElement;
@@ -116,6 +119,8 @@ export class WebTerminal implements WebTerminalHandle {
   get connected() { return this.#connected; }
   /** Current presented workload title; retained on disconnect/dispose. Treat as untrusted text. */
   get title(): string { return this.#title; }
+  get progress(): TerminalProgress { return { ...this.#progress }; }
+  get shellIntegration(): TerminalShellIntegration { return { ...this.#shellIntegration }; }
   get stats(): TerminalStats { return { ...this.#stats }; }
   get screenText() { return this.#screenText; }
   get sizing(): TerminalSizingState { return { ...this.#sizing }; }
@@ -306,11 +311,20 @@ export class WebTerminal implements WebTerminalHandle {
       if (oldPeer.id !== this.#peer.id || oldPeer.primaryId !== this.#peer.primaryId || oldPeer.isPrimary !== this.#peer.isPrimary) {
         this.#options.onRoleChange?.(this.peer);
       }
-      if (!this.#disposed && this.#connected && (this.#peer.id !== null || this.#peer.isPrimary) &&
-          (!this.#hasTitle || this.#title !== message.title)) {
+      if (!this.#disposed && this.#connected && (this.#peer.id !== null || this.#peer.isPrimary)) {
+        const titleChanged = !this.#hasTitle || this.#title !== message.title;
+        const progressChanged = !this.#hasActivity || this.#progress.state !== message.progress.state ||
+          this.#progress.percentage !== message.progress.percentage;
+        const shellChanged = !this.#hasActivity || this.#shellIntegration.phase !== message.shellIntegration.phase ||
+          this.#shellIntegration.lastExitCode !== message.shellIntegration.lastExitCode;
         this.#title = message.title;
         this.#hasTitle = true;
-        this.#options.onTitleChange?.(this.#title);
+        this.#progress = { ...message.progress };
+        this.#shellIntegration = { ...message.shellIntegration };
+        this.#hasActivity = true;
+        if (titleChanged) this.#options.onTitleChange?.(this.#title);
+        if (!this.#disposed && progressChanged) this.#options.onProgressChange?.(this.progress);
+        if (!this.#disposed && shellChanged) this.#options.onShellIntegrationChange?.(this.shellIntegration);
       }
     } else if (message.type === "history") {
       this.#screenText = message.text;
@@ -318,7 +332,8 @@ export class WebTerminal implements WebTerminalHandle {
     } else if (message.type === "stats") {
       this.#stats = message.stats;
       if (message.text !== undefined) this.#screenText = message.text;
-      if (message.stats.revision > 0 && this.#hasTitle && this.#connected && (this.#peer.id !== null || this.#peer.isPrimary)) {
+      if (message.stats.revision > 0 && this.#hasTitle && this.#hasActivity && this.#connected &&
+          (this.#peer.id !== null || this.#peer.isPrimary)) {
         clearTimeout(this.#readyTimer);
         this.#ready.resolve(this);
       }

--- a/src/web-terminal/src/wire-types.ts
+++ b/src/web-terminal/src/wire-types.ts
@@ -1,6 +1,6 @@
 import type { InputModifiers, PointerButton, SelectionMode, SelectionRange,
   TerminalBuffer, TerminalFont, TerminalGeometry, TerminalPeer, TerminalSize, TerminalStats,
-  TerminalRendererPreference, TerminalStatusLevel } from "./types.js";
+  TerminalRendererPreference, TerminalStatusLevel, TerminalProgress, TerminalShellIntegration } from "./types.js";
 
 export type SelectionText =
   | { status: "valid"; text: string }
@@ -35,6 +35,8 @@ export interface FrameMetadata extends TerminalGeometry {
   version: 1; full: boolean; revision: number; baseRevision: number;
   peer: TerminalPeer; history: HistoryMetadata | null;
   title: string;
+  progress: TerminalProgress;
+  shellIntegration: TerminalShellIntegration;
   defaultBackground?: number; defaultForeground?: number;
   cursor: { visible: boolean; x: number; y: number; shape: number };
   images: ImageMetadata[]; retainedImages: string[]; placements: ImagePlacement[]; warnings: string[];
@@ -82,6 +84,7 @@ export type WorkerOutputMessage =
   | { type: "connected" | "disconnected" }
   | { type: "status"; message: string; level: TerminalStatusLevel }
   | ({ type: "geometry"; peer: TerminalPeer; history: HistoryMetadata | null;
-       revision: number; title: string; text: string; hyperlinks: HyperlinkRange[] } & TerminalGeometry)
+       revision: number; title: string; progress: TerminalProgress; shellIntegration: TerminalShellIntegration;
+       text: string; hyperlinks: HyperlinkRange[] } & TerminalGeometry)
   | { type: "history"; history: HistoryMetadata | null; revision: number; text: string }
   | { type: "stats"; stats: WorkerStats; text?: string };

--- a/src/web-terminal/tests/protocol-validation.test.mjs
+++ b/src/web-terminal/tests/protocol-validation.test.mjs
@@ -6,6 +6,8 @@ function metadata() {
   return {
     version: 1, revision: 1, baseRevision: 0, full: true,
     title: "",
+    progress: { state: "none", percentage: null },
+    shellIntegration: { phase: "unknown", lastExitCode: null },
     columns: 1, rows: 1, cellWidth: 10, cellHeight: 20, mouseTracking: 0,
     peer: { id: null, primaryId: null, isPrimary: true },
     cursor: { x: 0, y: 0, visible: false, shape: "SteadyBlock" }, history: null,
@@ -65,6 +67,35 @@ test("Typed protocol boundary still rejects malformed metadata before use", () =
     const state = metadata();
     state[field] = invalid;
     assert.throws(() => decodeFrame(frame(state)), field);
+  }
+});
+
+test("Activity metadata preserves all progress states and signed shell exit codes", () => {
+  for (const state of ["none", "normal", "error", "indeterminate", "warning"]) {
+    for (const percentage of state === "none" || state === "indeterminate" ? [null] : [0, 50, 100]) {
+      const progress = { state, percentage };
+      assert.deepEqual(decodeFrame(frame({ ...metadata(), progress })).metadata.progress, progress);
+    }
+  }
+  for (const phase of ["unknown", "prompt", "commandLine", "executing", "finished"]) {
+    for (const lastExitCode of phase === "unknown" ? [null] : [null, -2147483648, -1, 0, 1, 2147483647]) {
+      const shellIntegration = { phase, lastExitCode };
+      assert.deepEqual(decodeFrame(frame({ ...metadata(), shellIntegration })).metadata.shellIntegration, shellIntegration);
+    }
+  }
+});
+
+test("Activity metadata rejects missing, inconsistent, and out-of-range state", () => {
+  for (const progress of [undefined, null, {}, [], { state: 1, percentage: 50 },
+    { state: "busy", percentage: null }, { state: "none", percentage: 0 },
+    { state: "indeterminate" }, { state: "indeterminate", percentage: 50 },
+    ...[undefined, null, -1, 101, 1.5, "50"].map(percentage => ({ state: "normal", percentage }))]) {
+    assert.throws(() => decodeFrame(frame({ ...metadata(), progress })), /progress/u);
+  }
+  for (const shellIntegration of [undefined, null, {}, [], { phase: "idle", lastExitCode: null },
+    { phase: 3, lastExitCode: 0 }, { phase: "unknown", lastExitCode: 0 },
+    ...[undefined, -2147483649, 2147483648, .5, "0"].map(lastExitCode => ({ phase: "finished", lastExitCode }))]) {
+    assert.throws(() => decodeFrame(frame({ ...metadata(), shellIntegration })), /shell/u);
   }
 });
 

--- a/src/web-terminal/tests/title.test.mjs
+++ b/src/web-terminal/tests/title.test.mjs
@@ -126,6 +126,8 @@ function frame({ title = "", revision = 1, full = revision === 1, baseRevision =
   peer = { id: null, primaryId: null, isPrimary: true }, ...overrides } = {}) {
   const metadata = {
     version: 1, title, revision, full, baseRevision, peer,
+    progress: { state: "none", percentage: null },
+    shellIntegration: { phase: "unknown", lastExitCode: null },
     columns: 1, rows: 1, cellWidth: 10, cellHeight: 20, mouseTracking: 0,
     cursor: { visible: true, x: 0, y: 0, shape: 1 },
     history: null, images: [], retainedImages: [], placements: [], warnings: [], hyperlinks: [],
@@ -176,6 +178,131 @@ async function present(view, state) {
   await view.worker.request("frame", { buffer: frame(state) });
   await view.worker.request("draw");
 }
+
+test("Activity arrives after presentation, before mount, with both getters set and isolated from callbacks", async t => {
+  const workers = browser(t);
+  const progressNotices = [];
+  const shellNotices = [];
+  const initialProgress = { state: "indeterminate", percentage: null };
+  const initialShell = { phase: "executing", lastExitCode: -1 };
+  const view = await mounting(t, workers, {
+    onProgressChange(progress) {
+      assert.deepEqual(view.handle.progress, progress);
+      assert.deepEqual(view.handle.shellIntegration, initialShell);
+      progressNotices.push({ ...progress });
+      progress.percentage = 99;
+    },
+    onShellIntegrationChange(shell) {
+      assert.deepEqual(view.handle.progress, initialProgress);
+      assert.deepEqual(view.handle.shellIntegration, shell);
+      shellNotices.push({ ...shell });
+      shell.phase = "finished";
+    }
+  });
+  await view.worker.request("open");
+  await view.worker.request("hold");
+  await view.worker.request("frame", { buffer: frame({ progress: initialProgress, shellIntegration: initialShell }) });
+  await view.worker.request("draw");
+  assert.deepEqual(progressNotices, []);
+  assert.deepEqual(shellNotices, []);
+  assert.equal(view.settled, false);
+  await view.worker.request("release");
+  const terminal = await view.promise;
+  assert.deepEqual(progressNotices, [initialProgress]);
+  assert.deepEqual(shellNotices, [initialShell]);
+  assert.deepEqual(terminal.progress, initialProgress);
+  assert.deepEqual(terminal.shellIntegration, initialShell);
+  terminal.progress.state = "error";
+  terminal.shellIntegration.lastExitCode = 123;
+  assert.deepEqual(terminal.progress, initialProgress);
+  assert.deepEqual(terminal.shellIntegration, initialShell);
+  assert.deepEqual(view.worker.errors, []);
+});
+
+test("Activity callbacks deliver defaults then distinct states, never infer missing intermediate markers", async t => {
+  const workers = browser(t);
+  const progressNotices = [];
+  const shellNotices = [];
+  const view = await mounting(t, workers, {
+    onProgressChange(value) { progressNotices.push(value); },
+    onShellIntegrationChange(value) { shellNotices.push(value); }
+  });
+  await view.worker.request("open");
+  await present(view, {});
+  const terminal = await view.promise;
+  assert.deepEqual(progressNotices, [{ state: "none", percentage: null }]);
+  assert.deepEqual(shellNotices, [{ phase: "unknown", lastExitCode: null }]);
+  let revision = 1;
+  for (const [state, percentage] of [["normal", 0], ["normal", 100], ["warning", 50], ["error", 25],
+    ["indeterminate", null], ["none", null]]) {
+    await present(view, { revision: ++revision, progress: { state, percentage },
+      shellIntegration: { phase: "finished", lastExitCode: 1 } });
+  }
+  assert.equal(progressNotices.length, 7);
+  assert.deepEqual(shellNotices, [{ phase: "unknown", lastExitCode: null }, { phase: "finished", lastExitCode: 1 }]);
+  await present(view, { revision: ++revision, shellIntegration: { phase: "commandLine", lastExitCode: 1 } });
+  terminal.resync();
+  await present(view, { revision: ++revision, full: true, shellIntegration: { phase: "commandLine", lastExitCode: 1 } });
+  assert.equal(shellNotices.length, 3);
+  assert.equal(progressNotices.length, 7);
+  assert.deepEqual(terminal.shellIntegration, { phase: "commandLine", lastExitCode: 1 });
+  assert.equal(terminal.title, "");
+  assert.deepEqual(view.worker.errors, []);
+});
+
+test("Activity ignores connecting replicas, dropped and malformed frames, and retains last state on disconnect", async t => {
+  const workers = browser(t);
+  const notices = [];
+  const view = await mounting(t, workers, { onProgressChange(value) { notices.push(value); } });
+  await view.worker.request("open");
+  await present(view, { peer: { id: null, primaryId: null, isPrimary: false } });
+  assert.deepEqual(notices, []);
+  assert.equal(view.settled, false);
+  const peer = { id: "replica", primaryId: "producer", isPrimary: false };
+  const progress = { state: "warning", percentage: 40 };
+  await present(view, { revision: 2, peer, progress });
+  const terminal = await view.promise;
+  await present(view, { revision: 3, baseRevision: 99, peer });
+  assert.deepEqual(terminal.progress, progress);
+  await present(view, { revision: 4, full: true, peer, progress });
+  await present(view, { revision: 5, peer, progress: { state: "normal", percentage: 101 } });
+  assert.equal(terminal.connected, false);
+  assert.deepEqual(terminal.progress, progress);
+  assert.deepEqual(notices, [progress]);
+  terminal.dispose();
+  assert.deepEqual(terminal.progress, progress);
+  const remount = await mounting(t, workers, { onProgressChange(value) { notices.push(value); } });
+  await remount.worker.request("open");
+  await present(remount, { peer, progress });
+  await remount.promise;
+  assert.deepEqual(notices, [progress, progress]);
+});
+
+test("Disposing in a progress callback suppresses the paired shell callback and queued messages", async t => {
+  const workers = browser(t);
+  const notices = [];
+  const view = await mounting(t, workers, {
+    onProgressChange(value) {
+      notices.push(value);
+      if (value.state === "error") view.handle.dispose();
+    },
+    onShellIntegrationChange(value) { notices.push(value); }
+  });
+  await view.worker.request("open");
+  await present(view, {});
+  const terminal = await view.promise;
+  const progress = { state: "error", percentage: 25 };
+  const shellIntegration = { phase: "finished", lastExitCode: 1 };
+  await present(view, { revision: 2, progress, shellIntegration });
+  const geometry = view.worker.outputs.find(message => message.type === "geometry");
+  view.worker.deliver({ ...geometry, revision: 3 });
+  assert.deepEqual(notices, [
+    { state: "none", percentage: null }, { phase: "unknown", lastExitCode: null }, progress
+  ]);
+  assert.deepEqual(terminal.progress, progress);
+  assert.deepEqual(terminal.shellIntegration, shellIntegration);
+  assert.deepEqual(view.worker.errors, []);
+});
 
 for (const initial of ["", "shell; 世界 😀"]) {
   test(`Mount publishes initial title ${JSON.stringify(initial)} only after presentation, then distinct changes`, async t => {

--- a/src/web-terminal/tests/types/consumer.ts
+++ b/src/web-terminal/tests/types/consumer.ts
@@ -2,7 +2,8 @@ import {
   WebTerminal, InputRoute, TerminalAction, defaultInputBindings, MIN_FONT_SIZE, MAX_FONT_SIZE,
   type WebTerminalOptions, type WebTerminalHandle, type TerminalInput, type InputBinding,
   type TerminalSelection, type TerminalViewport, type SelectionUIEvent, type TerminalStats,
-  type TerminalRendererKind, type TerminalRendererPreference
+  type TerminalRendererKind, type TerminalRendererPreference, type TerminalProgress,
+  type TerminalShellIntegration
 } from "@hex1b/web-terminal";
 
 const container = document.createElement("div");
@@ -54,6 +55,18 @@ const options: WebTerminalOptions = {
     const currentTitle: string = title;
     console.log(currentTitle);
   },
+  onProgressChange(progress) {
+    const current: TerminalProgress = progress;
+    if (current.state === "normal") console.log(current.percentage);
+    // @ts-expect-error Progress callback values are readonly.
+    current.percentage = 100;
+  },
+  onShellIntegrationChange(shell) {
+    const current: TerminalShellIntegration = shell;
+    if (current.phase === "finished") console.log(current.lastExitCode);
+    // @ts-expect-error Shell callback values are readonly.
+    current.phase = "executing";
+  },
   onSelectionUI(event) {
     const notification: SelectionUIEvent = event;
     notification.preventDefault();
@@ -82,6 +95,9 @@ const terminal: WebTerminalHandle = mountedTerminal;
 const title: string = terminal.title;
 const mountedTitle: string = mountedTerminal.title;
 console.log(title, mountedTitle);
+const progress: TerminalProgress = terminal.progress;
+const shell: TerminalShellIntegration = mountedTerminal.shellIntegration;
+console.log(progress, shell);
 const forcedRenderer: TerminalRendererPreference = "webgl2";
 const forcedOptions: WebTerminalOptions = { ...options, renderer: forcedRenderer };
 console.log(forcedOptions);
@@ -102,6 +118,10 @@ new WebTerminal(options);
 terminal.title = "host title";
 // @ts-expect-error The WebTerminal class exposes only a getter.
 mountedTerminal.title = "host title";
+// @ts-expect-error Terminal activity is read-only on the public handle.
+terminal.progress = { state: "none", percentage: null };
+// @ts-expect-error Shell phase is read-only, not a way to execute commands.
+terminal.shellIntegration.phase = "executing";
 // @ts-expect-error Fixed sizing requires both grid dimensions.
 terminal.setSizing({ mode: "fixed", columns: 80 });
 // @ts-expect-error Paste is text, not bytes.

--- a/src/web-terminal/tests/web-terminal.test.mjs
+++ b/src/web-terminal/tests/web-terminal.test.mjs
@@ -117,6 +117,8 @@ function frame(peer) {
   const metadata = {
     version: 1, revision: 1, baseRevision: 0, full: true,
     title: "",
+    progress: { state: "none", percentage: null },
+    shellIntegration: { phase: "unknown", lastExitCode: null },
     columns: 1, rows: 1, cellWidth: 10, cellHeight: 20, mouseTracking: 0, peer,
     cursor: { x: 0, y: 0, visible: false, shape: 0 }, history: null,
     images: [], retainedImages: [], placements: [], warnings: [], hyperlinks: [],

--- a/tests/Hex1b.Tests/Hmp1/Hmp1ActivityStateTests.cs
+++ b/tests/Hex1b.Tests/Hmp1/Hmp1ActivityStateTests.cs
@@ -1,0 +1,912 @@
+using System.Buffers.Binary;
+using System.Collections.Concurrent;
+using System.IO.Pipelines;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Channels;
+using Hex1b.Automation;
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests.Hmp1;
+
+[TestClass]
+public class Hmp1ActivityStateTests
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(5);
+
+    [TestMethod]
+    [DataRow("", 0, null, 0, null)]
+    [DataRow("\x1b]9;4;0\a", 0, null, 0, null)]
+    [DataRow("\x1b]9;4;1;0\a\x1b]133;A\a", 1, 0, 1, null)]
+    [DataRow("\x1b]9;4;2;100\a\x1b]133;B\a", 2, 100, 2, null)]
+    [DataRow("\x1b]9;4;3\a\x1b]133;C\a", 3, null, 3, null)]
+    [DataRow("\x1b]9;4;4;37\a\x1b]133;D;0\a", 4, 37, 4, 0)]
+    [DataRow("\x1b]133;D;7\a", 0, null, 4, 7)]
+    [DataRow("\x1b]133;D;-2147483648\a", 0, null, 4, int.MinValue)]
+    [DataRow("\x1b]133;D;2147483647\a", 0, null, 4, int.MaxValue)]
+    [DataRow("\x1b]133;D\a", 0, null, 4, null)]
+    [DataRow("\x1b]133;D;\a", 0, null, 4, null)]
+    [DataRow("\x1b]133;D;-1\a\x1b]133;A\a", 0, null, 1, -1)]
+    [DataRow("\x1b]133;D;-1\a\x1b]133;B\a", 0, null, 2, -1)]
+    [DataRow("\x1b]133;D;-1\a\x1b]133;C\a", 0, null, 3, -1)]
+    public async Task StateSync_LateAttachAndReconnect_RestoresAuthoritativeActivity(
+        string sequence, int state, int? percentage, int phase, int? exitCode)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var server = new Hmp1PresentationAdapter(20, 5);
+        await using var producer = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithPresentation(server).WithDimensions(20, 5).Build();
+        producer.ApplyTokens(AnsiTokenizer.Tokenize(sequence + "ready"));
+
+        for (var attempt = 0; attempt < 2; attempt++)
+        {
+            var connection = await ConnectAsync(server);
+            await using var handle = connection.Handle;
+            await using var client = connection.Client;
+            await using var mirror = Hex1bTerminal.CreateBuilder()
+                .WithWorkload(client).WithHeadless().Build();
+            await WaitAsync(mirror, snapshot => snapshot.ContainsText("ready") &&
+                (int)snapshot.Progress.State == state && snapshot.Progress.Percentage == percentage &&
+                (int)snapshot.ShellIntegration.Phase == phase && snapshot.ShellIntegration.LastExitCode == exitCode);
+            using var snapshot = mirror.CreateSnapshot();
+            Assert.AreEqual(producer.Progress, snapshot.Progress);
+            Assert.AreEqual(producer.ShellIntegration, snapshot.ShellIntegration);
+        }
+    }
+
+    [TestMethod]
+    public async Task StateSync_TwoHops_LiveChangesAndClearPreserveActivity()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var server = new Hmp1PresentationAdapter(20, 5);
+        await using var producer = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithPresentation(server).WithDimensions(20, 5).Build();
+        producer.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]133;D;-1\a\x1b]133;C\a\x1b]9;4;3\ainitial"));
+        var upstream = await ConnectAsync(server);
+        await using var upstreamHandle = upstream.Handle;
+        await using var upstreamClient = upstream.Client;
+        await using var relay = new Hmp1PresentationAdapter(20, 5);
+        await using var replica = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(upstreamClient).WithPresentation(relay).Build();
+        var downstream = await ConnectAsync(relay);
+        await using var downstreamHandle = downstream.Handle;
+        await using var downstreamClient = downstream.Client;
+        await using var mirror = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(downstreamClient).WithHeadless().Build();
+        await WaitAsync(mirror, snapshot => snapshot.ContainsText("initial") &&
+            snapshot.ShellIntegration.Phase == TerminalShellIntegrationPhase.Executing &&
+            snapshot.ShellIntegration.LastExitCode == -1 &&
+            snapshot.Progress.State == TerminalProgressState.Indeterminate);
+
+        foreach (var sequence in new[]
+        {
+            "\x1b]9;4;1;15\a", "\x1b]9;4;2;80\a", "\x1b]9;4;4;100\a",
+            "\x1b]133;D;0\a", "\x1b]133;A\a", "\x1b]133;B\a", "\x1b]9;4;0\a"
+        })
+        {
+            var previousProgress = producer.Progress;
+            var previousShell = producer.ShellIntegration;
+            workload.Write(sequence);
+            await WaitAsync(producer, snapshot =>
+                snapshot.Progress != previousProgress || snapshot.ShellIntegration != previousShell);
+            await WaitAsync(mirror, snapshot =>
+                snapshot.Progress == producer.Progress && snapshot.ShellIntegration == producer.ShellIntegration);
+            Assert.AreEqual(producer.Progress, replica.Progress);
+            Assert.AreEqual(producer.ShellIntegration, replica.ShellIntegration);
+        }
+    }
+
+    [TestMethod]
+    [DataRow("\x1b]9;4;2;63\x1b\\", 1)]
+    [DataRow("\x1b]9;4;2;63\x1b\\", 8)]
+    [DataRow("\x1b]9;4;2;63\x1b\\", 11)]
+    [DataRow("\x1b]133;D;-7\x1b\\", 1)]
+    [DataRow("\x1b]133;D;-7\x1b\\", 8)]
+    [DataRow("\x1b]133;D;-7\x1b\\", 11)]
+    public async Task StateSync_FragmentedOscAcrossTwoHops_ContinuesOnlyRealOutput(string sequence, int split)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var server = new Hmp1PresentationAdapter(20, 5);
+        await using var producer = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithPresentation(server).WithDimensions(20, 5).Build();
+        var upstream = await ConnectAsync(server);
+        await using var upstreamHandle = upstream.Handle;
+        await using var upstreamClient = upstream.Client;
+        await using var relay = new Hmp1PresentationAdapter(20, 5);
+        await using var replica = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(upstreamClient).WithPresentation(relay).Build();
+        workload.Write("\x1b]133;C\a\x1b]9;4;1;20\aready" + sequence[..split]);
+        await WaitAsync(replica, snapshot => snapshot.ContainsText("ready"));
+        var late = await ConnectAsync(relay);
+        await using var lateHandle = late.Handle;
+        await using var lateClient = late.Client;
+        await using var mirror = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(lateClient).WithHeadless().Build();
+        await WaitAsync(mirror, snapshot => snapshot.ContainsText("ready") &&
+            snapshot.Progress.Percentage == 20 &&
+            snapshot.ShellIntegration.Phase == TerminalShellIntegrationPhase.Executing);
+
+        var progressChanges = new ConcurrentQueue<TerminalProgress>();
+        var shellChanges = new ConcurrentQueue<TerminalShellIntegration>();
+        mirror.ProgressChanged += progressChanges.Enqueue;
+        mirror.ShellIntegrationChanged += shellChanges.Enqueue;
+        workload.Write(sequence[split..] + "done");
+        await WaitAsync(producer, snapshot => snapshot.ContainsText("done"));
+        await WaitAsync(mirror, snapshot => snapshot.ContainsText("done") &&
+            snapshot.Progress == producer.Progress && snapshot.ShellIntegration == producer.ShellIntegration);
+        Assert.AreEqual(sequence.Contains("133") ? 1 : 0, shellChanges.Count);
+        Assert.AreEqual(sequence.Contains("9;4") ? 1 : 0, progressChanges.Count);
+        using var expected = producer.CreateSnapshot();
+        using var actual = mirror.CreateSnapshot();
+        for (var row = 0; row < expected.Height; row++)
+            Assert.AreEqual(expected.GetLine(row), actual.GetLine(row));
+    }
+
+    [TestMethod]
+    public async Task StateSync_RepeatedReplayAtRelay_DeduplicatesAndNeverSynthesizesShellMarkers()
+    {
+        var streams = CreateStreams();
+        await using var wire = streams.Server;
+        await using var upstream = Hmp1TestHelpers.NewClient(streams.Client);
+        var baseline = Activity(2, 42, 4, -7);
+        await HandshakeAsync(wire, upstream, "\x1b]9;4;2;42\ainitial", baseline);
+        await using var relay = new Hmp1PresentationAdapter(20, 5);
+        await using var replica = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(upstream).WithPresentation(relay).Build();
+        var connection = await ConnectAsync(relay);
+        await using var handle = connection.Handle;
+        await using var client = connection.Client;
+        await using var mirror = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(client).WithHeadless().Build();
+        await WaitAsync(mirror, snapshot => snapshot.ContainsText("initial") &&
+            snapshot.ShellIntegration.LastExitCode == -7);
+        var progress = new ConcurrentQueue<TerminalProgress>();
+        var shell = new ConcurrentQueue<TerminalShellIntegration>();
+        mirror.ProgressChanged += progress.Enqueue;
+        mirror.ShellIntegrationChanged += shell.Enqueue;
+
+        await Hmp1Protocol.WriteFrameAsync(wire, Hmp1FrameType.Output,
+            "partial\x1b]133;D;99\x1b"u8.ToArray(), TestContext.Current.CancellationToken);
+        await WaitAsync(mirror, snapshot => snapshot.ContainsText("partial"));
+        // RIS resets activity during replay; only the final restored value is observable.
+        await WriteSyncAsync(wire, "\x1b" + "c\x1b]9;4;2;42\arepeat", baseline);
+        await WaitAsync(mirror, snapshot => snapshot.ContainsText("repeat") &&
+            snapshot.ShellIntegration.LastExitCode == -7);
+        Assert.IsTrue(progress.IsEmpty);
+        Assert.IsTrue(shell.IsEmpty);
+
+        await WriteSyncAsync(wire, "\x1b[2J\x1b[Hchanged", Activity(4, 81, 1, -7));
+        await WaitAsync(mirror, snapshot => snapshot.ContainsText("changed") &&
+            snapshot.Progress.Percentage == 81 && snapshot.ShellIntegration.Phase == TerminalShellIntegrationPhase.Prompt);
+        Assert.AreEqual(TerminalProgressState.Warning, TestSeq.Single(progress).State);
+        Assert.AreEqual(TerminalShellIntegrationPhase.Prompt, TestSeq.Single(shell).Phase);
+
+        await Hmp1Protocol.WriteFrameAsync(wire, Hmp1FrameType.Output,
+            "\x1b]133;C\a\x1b]9;4;0\alive"u8.ToArray(), TestContext.Current.CancellationToken);
+        await WaitAsync(mirror, snapshot => snapshot.ContainsText("live") &&
+            snapshot.Progress.State == TerminalProgressState.None &&
+            snapshot.ShellIntegration.Phase == TerminalShellIntegrationPhase.Executing);
+        TestSeq.AreEqual(new[] { TerminalShellIntegrationPhase.Prompt, TerminalShellIntegrationPhase.Executing },
+            shell.Select(value => value.Phase));
+    }
+
+    [TestMethod]
+    public async Task ReadPumpAsync_CheckpointPaused_HoldsSubsequentScreenReplayAndFollowingOutput()
+    {
+        var streams = CreateStreams();
+        await using var wire = streams.Server;
+        await using var client = Hmp1TestHelpers.NewClient(streams.Client);
+        await HandshakeAsync(wire, client, "initial", Activity(1, 25, 3, -7));
+        await using var mirror = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(client).WithHeadless().Build();
+        await WaitAsync(mirror, snapshot => snapshot.ContainsText("initial") && snapshot.Progress.Percentage == 25);
+        await Hmp1Protocol.WriteFrameAsync(wire, Hmp1FrameType.StateSync,
+            "\x1b[2J\x1b[Hreplacement"u8.ToArray(), TestContext.Current.CancellationToken);
+        using (var snapshot = mirror.CreateSnapshot())
+        {
+            Assert.IsTrue(snapshot.ContainsText("initial"));
+            Assert.AreEqual(25, snapshot.Progress.Percentage);
+        }
+        await Hmp1Protocol.WriteActivityStateAsync(wire, Activity(0, null, 4, null), TestContext.Current.CancellationToken);
+        await Hmp1Protocol.WriteFrameAsync(wire, Hmp1FrameType.Output,
+            "\r\nlive"u8.ToArray(), TestContext.Current.CancellationToken);
+        await WaitAsync(mirror, snapshot => snapshot.ContainsText("replacement") && snapshot.ContainsText("live") &&
+            snapshot.Progress.State == TerminalProgressState.None &&
+            snapshot.ShellIntegration.Phase == TerminalShellIntegrationPhase.Finished &&
+            snapshot.ShellIntegration.LastExitCode == null);
+    }
+
+    [TestMethod]
+    public async Task ConnectAsync_CheckpointPaused_DoesNotPublishPartialBrowserBaseline()
+    {
+        var streams = CreateStreams();
+        await using var wire = streams.Server;
+        await using var client = Hmp1TestHelpers.NewClient(streams.Client);
+        using var timeout = new CancellationTokenSource(Timeout);
+        var connecting = client.ConnectAsync(timeout.Token);
+        await Hmp1Protocol.ReadFrameAsync(wire, timeout.Token);
+        await Hmp1Protocol.WriteHelloAsync(wire, 20, 5, "peer", null, [], timeout.Token);
+        await Hmp1Protocol.WriteFrameAsync(wire, Hmp1FrameType.StateSync, "screen"u8.ToArray(), timeout.Token);
+        Assert.IsFalse(connecting.IsCompleted);
+        Assert.IsFalse(client.IsConnected);
+        await using var view = new Hwt1PresentationAdapter();
+        await using var mirror = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(client).WithPresentation(view).Build();
+        var pending = view.ReadFrameAsync(timeout.Token).AsTask();
+        Assert.IsFalse(pending.IsCompleted);
+        await Hmp1Protocol.WriteActivityStateAsync(wire, Activity(2, 67, 4, -1), timeout.Token);
+        await connecting.WaitAsync(timeout.Token);
+        var bytes = await pending.WaitAsync(timeout.Token);
+        var length = BinaryPrimitives.ReadInt32LittleEndian(bytes.Span[4..]);
+        using var metadata = JsonDocument.Parse(bytes.Slice(8, length));
+        Assert.AreEqual("error", metadata.RootElement.GetProperty("progress").GetProperty("state").GetString());
+        Assert.AreEqual(67, metadata.RootElement.GetProperty("progress").GetProperty("percentage").GetInt32());
+        Assert.AreEqual("finished", metadata.RootElement.GetProperty("shellIntegration").GetProperty("phase").GetString());
+        Assert.AreEqual(-1, mirror.ShellIntegration.LastExitCode);
+    }
+
+    [TestMethod]
+    public async Task StateSync_BlockedImpactPresentation_PublicSnapshotHasCompleteActivity()
+    {
+        var streams = CreateStreams();
+        await using var wire = streams.Server;
+        await using var client = Hmp1TestHelpers.NewClient(streams.Client);
+        await HandshakeAsync(wire, client, "\x1b" + "c\x1b]9;4;1;9\ascreen", Activity(2, 67, 4, -7));
+        await using var presentation = new ReplayImpactGate();
+        await using var mirror = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(client).WithPresentation(presentation).Build();
+        using var timeout = new CancellationTokenSource(Timeout);
+        try
+        {
+            await presentation.Entered.Task.WaitAsync(timeout.Token);
+            using var snapshot = mirror.CreateSnapshot();
+            Assert.IsTrue(snapshot.ContainsText("screen"));
+            Assert.AreEqual(TerminalProgressState.Error, snapshot.Progress.State);
+            Assert.AreEqual(67, snapshot.Progress.Percentage);
+            Assert.AreEqual(TerminalShellIntegrationPhase.Finished, snapshot.ShellIntegration.Phase);
+            Assert.AreEqual(-7, snapshot.ShellIntegration.LastExitCode);
+            var ready = mirror.WaitForHmp1InitialReplayAsync(timeout.Token);
+            Assert.IsFalse(ready.IsCompleted);
+            presentation.Release.TrySetResult();
+            await ready.WaitAsync(timeout.Token);
+        }
+        finally
+        {
+            presentation.Release.TrySetResult();
+        }
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public async Task StateSync_PresentationFailure_FailsReadinessWithoutPublishingUnappliedCheckpoint(bool afterApplication)
+    {
+        var streams = CreateStreams();
+        await using var wire = streams.Server;
+        await using var client = Hmp1TestHelpers.NewClient(streams.Client);
+        await HandshakeAsync(wire, client, "\x1b]9;4;1;9\ascreen", Activity(2, 67, 4, -7));
+        await using ReplayPresentationGate presentation = afterApplication
+            ? new ReplayImpactGate() : new ReplayPresentationGate();
+        presentation.Fail = true;
+        await using var mirror = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(client).WithPresentation(presentation).Build();
+        using var timeout = new CancellationTokenSource(Timeout);
+        try
+        {
+            await presentation.Entered.Task.WaitAsync(timeout.Token);
+            var progressChanges = new ConcurrentQueue<TerminalProgress>();
+            mirror.ProgressChanged += progressChanges.Enqueue;
+            var ready = mirror.WaitForHmp1InitialReplayAsync(timeout.Token);
+            presentation.Release.TrySetResult();
+            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => ready.WaitAsync(timeout.Token));
+            Assert.IsTrue(progressChanges.IsEmpty,
+                "A failed presentation must not cause a new checkpoint assignment in cleanup.");
+            using var snapshot = mirror.CreateSnapshot();
+            Assert.AreEqual(afterApplication, snapshot.ContainsText("screen"));
+            Assert.AreEqual(afterApplication ? TerminalProgressState.Error : TerminalProgressState.None, snapshot.Progress.State);
+            Assert.AreEqual(afterApplication ? 67 : (int?)null, snapshot.Progress.Percentage);
+            Assert.AreEqual(afterApplication ? TerminalShellIntegrationPhase.Finished : TerminalShellIntegrationPhase.Unknown,
+                snapshot.ShellIntegration.Phase);
+        }
+        finally
+        {
+            presentation.Release.TrySetResult();
+        }
+    }
+
+    [TestMethod]
+    public async Task StateSync_WorkloadFilterFailure_DoesNotRestoreCheckpointAndFailsReadiness()
+    {
+        var streams = CreateStreams();
+        await using var wire = streams.Server;
+        await using var client = Hmp1TestHelpers.NewClient(streams.Client);
+        await HandshakeAsync(wire, client, "\x1b]9;4;1;9\ascreen", Activity(2, 67, 4, -7));
+        await using var mirror = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(client).WithHeadless().AddWorkloadFilter(new FailingReplayFilter()).Build();
+        using var timeout = new CancellationTokenSource(Timeout);
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => mirror.WaitForHmp1InitialReplayAsync(timeout.Token));
+        using var snapshot = mirror.CreateSnapshot();
+        Assert.IsFalse(snapshot.ContainsText("screen"));
+        Assert.AreEqual(TerminalProgressState.None, snapshot.Progress.State);
+        Assert.AreEqual(TerminalShellIntegrationPhase.Unknown, snapshot.ShellIntegration.Phase);
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public async Task StateSync_GeneratedAlternateScreen_ReentrantObserversSeeCommittedSnapshot(bool unchangedTitles)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var server = new Hmp1PresentationAdapter(20, 5);
+        await using var producer = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithPresentation(server).WithDimensions(20, 5).Build();
+        producer.ApplyTokens(AnsiTokenizer.Tokenize(
+            "\x1b]2;saved title\a\x1b]1;saved icon\a\x1b]22;0\a" +
+            "\x1b]2;current title\a\x1b]1;current icon\a" +
+            "\x1b]133;D;-7\a\x1b]133;C\a\x1b]9;4;2;63\a\x1b[?1049hcomplete screen"));
+        using var expected = producer.CreateSnapshot(includeAllKgpImages: false, includeSavedTitles: true);
+        Assert.AreEqual(1, expected.SavedTitles.Count);
+        var connection = await ConnectAsync(server);
+        await using var handle = connection.Handle;
+        await using var client = connection.Client;
+        await using var presentation = new ReplayPresentationGate();
+        await using var mirror = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(client).WithPresentation(presentation).Build();
+        using var timeout = new CancellationTokenSource(Timeout);
+        var observations = new ConcurrentQueue<string>();
+        Action<string> titleChanged = _ => Observe("title");
+        Action<string> iconChanged = _ => Observe("icon");
+        try
+        {
+            await presentation.Entered.Task.WaitAsync(timeout.Token);
+            mirror.Resize(10, 3);
+            mirror.ApplyTokens(AnsiTokenizer.Tokenize(
+                (unchangedTitles
+                    ? "\x1b]2;current title\a\x1b]1;current icon\a"
+                    : "\x1b]2;old title\a\x1b]1;old icon\a") +
+                "\x1b]133;A\a\x1b]9;4;1;9\aold"));
+            mirror.WindowTitleChanged += titleChanged;
+            mirror.IconNameChanged += iconChanged;
+            presentation.Invalidated = () => Observe("resize");
+            presentation.Release.TrySetResult();
+            await mirror.WaitForHmp1InitialReplayAsync(timeout.Token);
+            Assert.AreEqual(unchangedTitles ? 0 : 1, observations.Count(value => value == "title"));
+            Assert.AreEqual(unchangedTitles ? 0 : 1, observations.Count(value => value == "icon"));
+            Assert.AreEqual(1, observations.Count(value => value == "resize"));
+        }
+        finally
+        {
+            presentation.Release.TrySetResult();
+            presentation.Invalidated = null;
+            mirror.WindowTitleChanged -= titleChanged;
+            mirror.IconNameChanged -= iconChanged;
+        }
+
+        void Observe(string observer)
+        {
+            using var snapshot = mirror.CreateSnapshot(includeAllKgpImages: false, includeSavedTitles: true);
+            Assert.AreEqual(expected.Width, snapshot.Width, observer);
+            Assert.AreEqual(expected.Height, snapshot.Height, observer);
+            Assert.IsTrue(snapshot.InAlternateScreen, observer);
+            for (var row = 0; row < expected.Height; row++)
+                Assert.AreEqual(expected.GetLine(row), snapshot.GetLine(row), observer);
+            Assert.AreEqual(expected.WindowTitle, snapshot.WindowTitle, observer);
+            Assert.AreEqual(expected.IconName, snapshot.IconName, observer);
+            TestSeq.AreEqual(expected.SavedTitles, snapshot.SavedTitles);
+            Assert.AreEqual(expected.Progress, snapshot.Progress, observer);
+            Assert.AreEqual(expected.ShellIntegration, snapshot.ShellIntegration, observer);
+            observations.Enqueue(observer);
+        }
+    }
+
+    [TestMethod]
+    public async Task StateSync_TokenApplicationFailure_DoesNotInstallCheckpointOrEmitIntermediateActivity()
+    {
+        var streams = CreateStreams();
+        await using var wire = streams.Server;
+        await using var client = Hmp1TestHelpers.NewClient(streams.Client);
+        await HandshakeAsync(wire, client,
+            "\x1b]9;4;1;9\a\x1b]2;new title\a\x1b]1;new icon\a1\r\n2\r\n3\r\n4\r\n5\r\n6",
+            Activity(2, 67, 4, -7));
+        await using var presentation = new ReplayPresentationGate();
+        await using var mirror = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(client).WithPresentation(presentation)
+            .WithScrollback(10, _ => throw new InvalidOperationException("Token application failed.")).Build();
+        using var timeout = new CancellationTokenSource(Timeout);
+        try
+        {
+            await presentation.Entered.Task.WaitAsync(timeout.Token);
+            mirror.Resize(10, 3);
+            var changes = new ConcurrentQueue<TerminalProgress>();
+            var titles = new ConcurrentQueue<string>();
+            var icons = new ConcurrentQueue<string>();
+            var invalidations = 0;
+            mirror.ProgressChanged += changes.Enqueue;
+            mirror.WindowTitleChanged += titles.Enqueue;
+            mirror.IconNameChanged += icons.Enqueue;
+            presentation.Invalidated = () => Interlocked.Increment(ref invalidations);
+            var ready = mirror.WaitForHmp1InitialReplayAsync(timeout.Token);
+            presentation.Release.TrySetResult();
+            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => ready.WaitAsync(timeout.Token));
+            Assert.IsTrue(changes.IsEmpty);
+            Assert.IsTrue(titles.IsEmpty);
+            Assert.IsTrue(icons.IsEmpty);
+            Assert.AreEqual(0, invalidations);
+            Assert.AreEqual(TerminalProgressState.None, mirror.Progress.State);
+            Assert.AreEqual(TerminalShellIntegrationPhase.Unknown, mirror.ShellIntegration.Phase);
+        }
+        finally
+        {
+            presentation.Release.TrySetResult();
+            presentation.Invalidated = null;
+        }
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public async Task ConnectAsync_FailedOrCancelledHandshake_UnblocksInitialReplayWait(bool cancelled)
+    {
+        var streams = CreateStreams();
+        await using var wire = streams.Server;
+        await using var client = Hmp1TestHelpers.NewClient(streams.Client);
+        await using var mirror = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(client).WithHeadless().Build();
+        using var timeout = new CancellationTokenSource(Timeout);
+        await mirror.WaitForHmp1InitialReplayAsync(timeout.Token);
+        using var handshakeCancellation = new CancellationTokenSource();
+        var connecting = client.ConnectAsync(handshakeCancellation.Token);
+        await Hmp1Protocol.ReadFrameAsync(wire, timeout.Token);
+        var ready = mirror.WaitForHmp1InitialReplayAsync(timeout.Token);
+        Assert.IsFalse(ready.IsCompleted);
+        if (cancelled)
+        {
+            handshakeCancellation.Cancel();
+            await Assert.ThrowsAsync<OperationCanceledException>(() => connecting.WaitAsync(timeout.Token));
+            await Assert.ThrowsAsync<OperationCanceledException>(() => ready.WaitAsync(timeout.Token));
+        }
+        else
+        {
+            await Hmp1Protocol.WriteHelloAsync(wire, 20, 5, timeout.Token);
+            await Hmp1Protocol.WriteFrameAsync(wire, Hmp1FrameType.StateSync, "screen"u8.ToArray(), timeout.Token);
+            await Hmp1Protocol.WriteFrameAsync(wire, Hmp1FrameType.ActivityState, "{}"u8.ToArray(), timeout.Token);
+            await Assert.ThrowsExactlyAsync<InvalidDataException>(() => connecting.WaitAsync(timeout.Token));
+            await Assert.ThrowsExactlyAsync<InvalidDataException>(() => ready.WaitAsync(timeout.Token));
+        }
+        Assert.IsFalse(client.IsConnected);
+        using var snapshot = mirror.CreateSnapshot();
+        Assert.IsFalse(snapshot.ContainsText("screen"));
+    }
+
+    [TestMethod]
+    public async Task ConnectAsync_ConnectedCallbackAwaitsInitialReplay_DoesNotDeadlockHandshake()
+    {
+        var streams = CreateStreams();
+        await using var wire = streams.Server;
+        await using var client = Hmp1TestHelpers.NewClient(streams.Client);
+        await using var mirror = Hex1bTerminal.CreateBuilder().WithWorkload(client).WithHeadless().Build();
+        client.OnConnected = async (_, ct) => await mirror.WaitForHmp1InitialReplayAsync(ct);
+        await HandshakeAsync(wire, client, "screen", Activity(2, 67, 4, -7));
+        Assert.AreEqual(67, mirror.Progress.Percentage);
+        Assert.AreEqual(-7, mirror.ShellIntegration.LastExitCode);
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public async Task WithPlaceholderWorkload_LateBaselineAndReconnect_PreservesActivityAndRelay(bool throughRelay)
+    {
+#pragma warning disable HEX1B002
+        using var firstWorkload = new Hex1bAppWorkloadAdapter();
+        using var secondWorkload = new Hex1bAppWorkloadAdapter();
+        using var placeholder = new Hex1bAppWorkloadAdapter();
+        await using var firstServer = new Hmp1PresentationAdapter(20, 10);
+        await using var secondServer = new Hmp1PresentationAdapter(20, 10);
+        await using var firstProducer = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(firstWorkload).WithPresentation(firstServer).WithDimensions(20, 10).Build();
+        await using var secondProducer = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(secondWorkload).WithPresentation(secondServer).WithDimensions(20, 10).Build();
+        firstProducer.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]133;D;-7\a\x1b]133;C\a\x1b]9;4;2;63\afirst"));
+        secondProducer.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]133;D;3\a\x1b]9;4;4;90\asecond"));
+        var streams = Channel.CreateUnbounded<Stream>();
+        await using var relay = new Hmp1PresentationAdapter(20, 10);
+        await using var view = new Hwt1PresentationAdapter(20, 10);
+        await using var mirror = Hex1bTerminal.CreateBuilder()
+            .WithHmp1Client(async ct => await streams.Reader.ReadAsync(ct))
+            .WithPlaceholderWorkload(builder => builder.WithWorkload(placeholder))
+            .WithPresentation(throughRelay ? relay : view).WithDimensions(20, 10).Build();
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var running = mirror.RunAsync(cancellation.Token);
+        Hmp1ClientHandle? firstHandle = null;
+        Hmp1ClientHandle? secondHandle = null;
+        Hmp1ClientHandle? downstreamHandle = null;
+        Hmp1WorkloadAdapter? downstreamClient = null;
+        Hex1bTerminal? downstream = null;
+        Hwt1PresentationAdapter? localBrowser = null;
+        string? localPeerId = null;
+        try
+        {
+            placeholder.Write("\x1b]133;A\a\x1b]9;4;1;12\aWaiting");
+            await WaitAsync(mirror, snapshot => snapshot.ContainsText("Waiting") &&
+                snapshot.ShellIntegration.Phase == TerminalShellIntegrationPhase.Prompt &&
+                snapshot.Progress.Percentage == 12);
+            var phases = new ConcurrentQueue<TerminalShellIntegrationPhase>();
+            var progress = new ConcurrentQueue<TerminalProgressState>();
+            mirror.ShellIntegrationChanged += value => phases.Enqueue(value.Phase);
+            mirror.ProgressChanged += value => progress.Enqueue(value.State);
+            if (!throughRelay)
+            {
+                var waiting = await ReadActivityFrameAsync(view, metadata =>
+                    metadata.GetProperty("shellIntegration").GetProperty("phase").GetString() == "prompt");
+                Assert.AreEqual(12, waiting.GetProperty("progress").GetProperty("percentage").GetInt32());
+            }
+
+            var firstStreams = CreateStreams();
+            var firstAccept = firstServer.AddClient(firstStreams.Server, cancellation.Token);
+            streams.Writer.TryWrite(firstStreams.Client);
+            firstHandle = await firstAccept.WaitAsync(Timeout, cancellation.Token);
+            await WaitAsync(mirror, snapshot => snapshot.ContainsText("first") &&
+                snapshot.ShellIntegration.Phase == TerminalShellIntegrationPhase.Executing &&
+                snapshot.ShellIntegration.LastExitCode == -7 && snapshot.Progress.Percentage == 63);
+            TestSeq.AreEqual(new[] { TerminalShellIntegrationPhase.Executing }, phases);
+            TestSeq.AreEqual(new[] { TerminalProgressState.Error }, progress);
+            if (throughRelay)
+            {
+                (downstreamHandle, downstreamClient) = await ConnectAsync(relay);
+                downstream = Hex1bTerminal.CreateBuilder().WithWorkload(downstreamClient).WithPresentation(view).Build();
+            }
+            var first = await ReadActivityFrameAsync(view, metadata =>
+                metadata.GetProperty("shellIntegration").GetProperty("phase").GetString() == "executing");
+            Assert.AreEqual(-7, first.GetProperty("shellIntegration").GetProperty("lastExitCode").GetInt32());
+            Assert.AreEqual(63, first.GetProperty("progress").GetProperty("percentage").GetInt32());
+            Assert.AreEqual(JsonValueKind.String, first.GetProperty("peer").GetProperty("id").ValueKind);
+            if (throughRelay)
+            {
+                localBrowser = await relay.CreateBrowserViewAsync("local browser", cancellation.Token);
+                var local = await ReadActivityFrameAsync(localBrowser, metadata =>
+                    metadata.GetProperty("shellIntegration").GetProperty("phase").GetString() == "executing");
+                localPeerId = local.GetProperty("peer").GetProperty("id").GetString();
+                Assert.IsNotNull(localPeerId);
+                Assert.AreNotEqual(firstHandle.PeerId, localPeerId);
+                Assert.AreNotEqual(downstreamHandle!.PeerId, localPeerId);
+                Assert.IsFalse(local.GetProperty("peer").GetProperty("isPrimary").GetBoolean());
+                await localBrowser.HandleMessageAsync(
+                    """{"type":"requestPrimary","columns":20,"rows":10}"""u8.ToArray(), cancellation.Token);
+                var primary = await ReadActivityFrameAsync(localBrowser, metadata =>
+                    metadata.GetProperty("peer").GetProperty("isPrimary").GetBoolean());
+                Assert.AreEqual(localPeerId, primary.GetProperty("peer").GetProperty("id").GetString());
+                Assert.AreEqual(localPeerId, primary.GetProperty("peer").GetProperty("primaryId").GetString());
+                Assert.AreEqual(localPeerId, relay.PrimaryPeerId);
+            }
+
+            await firstHandle.DisposeAsync();
+            placeholder.Write("Waiting again");
+            await WaitAsync(mirror, snapshot => snapshot.ContainsText("Waiting again") &&
+                snapshot.ShellIntegration.Phase == TerminalShellIntegrationPhase.Unknown);
+            if (localBrowser is not null)
+            {
+                var fallback = await ReadActivityFrameAsync(localBrowser, metadata =>
+                    metadata.GetProperty("shellIntegration").GetProperty("phase").GetString() == "unknown");
+                Assert.AreEqual(localPeerId, fallback.GetProperty("peer").GetProperty("id").GetString());
+                Assert.IsTrue(fallback.GetProperty("peer").GetProperty("isPrimary").GetBoolean());
+            }
+
+            var secondStreams = CreateStreams();
+            var secondAccept = secondServer.AddClient(secondStreams.Server, cancellation.Token);
+            streams.Writer.TryWrite(secondStreams.Client);
+            secondHandle = await secondAccept.WaitAsync(Timeout, cancellation.Token);
+            await WaitAsync(mirror, snapshot => snapshot.ContainsText("second") &&
+                snapshot.ShellIntegration.Phase == TerminalShellIntegrationPhase.Finished &&
+                snapshot.ShellIntegration.LastExitCode == 3 && snapshot.Progress.Percentage == 90);
+            var second = await ReadActivityFrameAsync(view, metadata =>
+                metadata.GetProperty("shellIntegration").GetProperty("phase").GetString() == "finished");
+            Assert.AreEqual(3, second.GetProperty("shellIntegration").GetProperty("lastExitCode").GetInt32());
+            Assert.AreEqual("warning", second.GetProperty("progress").GetProperty("state").GetString());
+            Assert.AreEqual(90, second.GetProperty("progress").GetProperty("percentage").GetInt32());
+            if (localBrowser is not null)
+            {
+                var reconnected = await ReadActivityFrameAsync(localBrowser, metadata =>
+                    metadata.GetProperty("shellIntegration").GetProperty("phase").GetString() == "finished");
+                Assert.AreEqual(localPeerId, reconnected.GetProperty("peer").GetProperty("id").GetString());
+                Assert.IsTrue(reconnected.GetProperty("peer").GetProperty("isPrimary").GetBoolean());
+                Assert.AreEqual(3, reconnected.GetProperty("shellIntegration").GetProperty("lastExitCode").GetInt32());
+            }
+            if (downstream is not null)
+            {
+                Assert.AreEqual(mirror.Progress, downstream.Progress);
+                Assert.AreEqual(mirror.ShellIntegration, downstream.ShellIntegration);
+            }
+            TestSeq.AreEqual(new[]
+            {
+                TerminalShellIntegrationPhase.Executing,
+                TerminalShellIntegrationPhase.Unknown,
+                TerminalShellIntegrationPhase.Finished
+            }, phases);
+        }
+        finally
+        {
+            cancellation.Cancel();
+            try { await running.WaitAsync(Timeout, TestContext.Current.CancellationToken); }
+            catch (OperationCanceledException) { }
+            if (localBrowser is not null) await localBrowser.DisposeAsync();
+            if (downstream is not null) await downstream.DisposeAsync();
+            if (downstreamClient is not null) await downstreamClient.DisposeAsync();
+            if (downstreamHandle is not null) await downstreamHandle.DisposeAsync();
+            if (firstHandle is not null) await firstHandle.DisposeAsync();
+            if (secondHandle is not null) await secondHandle.DisposeAsync();
+        }
+#pragma warning restore HEX1B002
+    }
+
+    [TestMethod]
+    [DataRow(0, null)]
+    [DataRow(1, 0)]
+    [DataRow(2, 100)]
+    [DataRow(3, null)]
+    [DataRow(4, 42)]
+    public async Task ReadOutputAsync_NativeAnsiReplay_RestoresProgressWithoutShellSequences(int state, int? percentage)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var server = new Hmp1PresentationAdapter(20, 5);
+        await using var producer = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithPresentation(server).WithDimensions(20, 5).Build();
+        producer.ApplyTokens(AnsiTokenizer.Tokenize(Activity(state, percentage, 0, null).BuildProgressReplay() +
+            "\x1b]133;D;-7\a\x1b]133;A\a"));
+        var connection = await ConnectAsync(server);
+        await using var handle = connection.Handle;
+        await using var client = connection.Client;
+        using var timeout = new CancellationTokenSource(Timeout);
+        var bytes = await client.ReadOutputAsync(timeout.Token);
+        var ansi = Encoding.UTF8.GetString(bytes.Span);
+        StringAssert.Contains(ansi, Activity(state, percentage, 0, null).BuildProgressReplay());
+        Assert.IsFalse(ansi.Contains("]133;"));
+        using var nativeWorkload = new Hex1bAppWorkloadAdapter();
+        await using var native = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(nativeWorkload).WithHeadless().Build();
+        native.ApplyTokens(AnsiTokenizer.Tokenize(ansi));
+        Assert.AreEqual(producer.Progress, native.Progress);
+        Assert.AreEqual(TerminalShellIntegrationPhase.Unknown, native.ShellIntegration.Phase);
+    }
+
+    [TestMethod]
+    [DataRow("")]
+    [DataRow("{}")]
+    [DataRow("null")]
+    [DataRow("{")]
+    [DataRow("""{"progress":null,"shellIntegration":{"phase":0,"lastExitCode":null}}""")]
+    [DataRow("""{"progress":{"state":0},"shellIntegration":{"phase":0,"lastExitCode":null}}""")]
+    [DataRow("""{"progress":{"state":0,"percentage":0},"shellIntegration":{"phase":0,"lastExitCode":null}}""")]
+    [DataRow("""{"progress":{"state":1,"percentage":null},"shellIntegration":{"phase":0,"lastExitCode":null}}""")]
+    [DataRow("""{"progress":{"state":2,"percentage":101},"shellIntegration":{"phase":0,"lastExitCode":null}}""")]
+    [DataRow("""{"progress":{"state":3,"percentage":7},"shellIntegration":{"phase":0,"lastExitCode":null}}""")]
+    [DataRow("""{"progress":{"state":4,"percentage":-1},"shellIntegration":{"phase":0,"lastExitCode":null}}""")]
+    [DataRow("""{"progress":{"state":5,"percentage":null},"shellIntegration":{"phase":0,"lastExitCode":null}}""")]
+    [DataRow("""{"progress":{"state":0,"percentage":null},"shellIntegration":{"phase":5,"lastExitCode":null}}""")]
+    [DataRow("""{"progress":{"state":0,"percentage":null},"shellIntegration":{"phase":0,"lastExitCode":0}}""")]
+    [DataRow("""{"progress":{"state":0,"percentage":null},"shellIntegration":{"phase":4,"lastExitCode":2147483648}}""")]
+    [DataRow("""{"progress":{"state":0,"percentage":null},"shellIntegration":{"phase":4,"lastExitCode":"0"}}""")]
+    [DataRow("""{"progress":{"state":0,"percentage":null,"state":1},"shellIntegration":{"phase":0,"lastExitCode":null}}""")]
+    [DataRow("""{"progress":{"state":0,"percentage":null},"shellIntegration":{"phase":0,"lastExitCode":null},"extra":true}""")]
+    public async Task ConnectAsync_MalformedActivityCheckpoint_FailsWithoutPublishingReplay(string payload)
+    {
+        var streams = CreateStreams();
+        await using var wire = streams.Server;
+        await using var client = Hmp1TestHelpers.NewClient(streams.Client);
+        using var timeout = new CancellationTokenSource(Timeout);
+        var connecting = client.ConnectAsync(timeout.Token);
+        await Hmp1Protocol.ReadFrameAsync(wire, timeout.Token);
+        await Hmp1Protocol.WriteHelloAsync(wire, 20, 5, timeout.Token);
+        await Hmp1Protocol.WriteFrameAsync(wire, Hmp1FrameType.StateSync, "screen"u8.ToArray(), timeout.Token);
+        await Hmp1Protocol.WriteFrameAsync(wire, Hmp1FrameType.ActivityState, Encoding.UTF8.GetBytes(payload), timeout.Token);
+        await Assert.ThrowsExactlyAsync<InvalidDataException>(() => connecting.WaitAsync(timeout.Token));
+        Assert.IsFalse(client.IsConnected);
+    }
+
+    [TestMethod]
+    [DataRow("missing")]
+    [DataRow("incomplete")]
+    [DataRow("oversize")]
+    [DataRow("wrong-frame")]
+    public async Task ConnectAsync_InvalidCheckpointFraming_FailsConnection(string failure)
+    {
+        var streams = CreateStreams();
+        await using var wire = streams.Server;
+        await using var client = Hmp1TestHelpers.NewClient(streams.Client);
+        using var timeout = new CancellationTokenSource(Timeout);
+        var connecting = client.ConnectAsync(timeout.Token);
+        await Hmp1Protocol.ReadFrameAsync(wire, timeout.Token);
+        await Hmp1Protocol.WriteHelloAsync(wire, 20, 5, timeout.Token);
+        await Hmp1Protocol.WriteFrameAsync(wire, Hmp1FrameType.StateSync, "screen"u8.ToArray(), timeout.Token);
+        if (failure is "incomplete" or "oversize")
+        {
+            var header = new byte[5];
+            header[0] = (byte)Hmp1FrameType.ActivityState;
+            BinaryPrimitives.WriteInt32LittleEndian(header.AsSpan(1),
+                failure == "oversize" ? Hmp1ActivityState.MaxPayloadSize + 1 : 10);
+            await wire.WriteAsync(header, timeout.Token);
+            await wire.FlushAsync(timeout.Token);
+        }
+        if (failure == "wrong-frame")
+            await Hmp1Protocol.WriteFrameAsync(wire, Hmp1FrameType.Output, "live"u8.ToArray(), timeout.Token);
+        if (failure is "incomplete" or "missing")
+            await wire.DisposeAsync();
+        if (failure is "incomplete" or "oversize")
+            await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => connecting.WaitAsync(timeout.Token));
+        else
+            await Assert.ThrowsExactlyAsync<InvalidDataException>(() => connecting.WaitAsync(timeout.Token));
+        Assert.IsFalse(client.IsConnected);
+    }
+
+    [TestMethod]
+    public async Task ReadPumpAsync_InvalidSubsequentCheckpoint_DisconnectsWithoutApplyingPartialReplay()
+    {
+        var streams = CreateStreams();
+        await using var wire = streams.Server;
+        await using var client = Hmp1TestHelpers.NewClient(streams.Client);
+        await HandshakeAsync(wire, client, "initial", Activity(1, 25, 3, -7));
+        await using var mirror = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(client).WithHeadless().Build();
+        await WaitAsync(mirror, snapshot => snapshot.ContainsText("initial") && snapshot.Progress.Percentage == 25);
+        await Hmp1Protocol.WriteFrameAsync(wire, Hmp1FrameType.StateSync,
+            "\x1b"u8.ToArray(), TestContext.Current.CancellationToken);
+        await Hmp1Protocol.WriteFrameAsync(wire, Hmp1FrameType.ActivityState,
+            "{}"u8.ToArray(), TestContext.Current.CancellationToken);
+        await client.DisconnectedTask.WaitAsync(Timeout, TestContext.Current.CancellationToken);
+        Assert.AreEqual(25, mirror.Progress.Percentage);
+        Assert.AreEqual(TerminalShellIntegrationPhase.Executing, mirror.ShellIntegration.Phase);
+        Assert.AreEqual(-7, mirror.ShellIntegration.LastExitCode);
+    }
+
+    private static Hmp1ActivityState Activity(int state, int? percentage, int phase, int? exitCode) => new()
+    {
+        Progress = new() { State = state, Percentage = percentage },
+        ShellIntegration = new() { Phase = phase, LastExitCode = exitCode }
+    };
+
+    private static async Task<JsonElement> ReadActivityFrameAsync(
+        Hwt1PresentationAdapter view, Func<JsonElement, bool> predicate)
+    {
+        using var timeout = new CancellationTokenSource(Timeout);
+        while (true)
+        {
+            var frame = await view.ReadFrameAsync(timeout.Token);
+            var length = BinaryPrimitives.ReadInt32LittleEndian(frame.Span[4..]);
+            using var metadata = JsonDocument.Parse(frame.Slice(8, length));
+            var root = metadata.RootElement;
+            await view.HandleMessageAsync(Encoding.UTF8.GetBytes(
+                $$"""{"type":"ack","revision":{{root.GetProperty("revision").GetUInt32()}}}"""), timeout.Token);
+            if (predicate(root))
+                return root.Clone();
+        }
+    }
+
+    private static async Task WaitAsync(Hex1bTerminal terminal, Func<Hex1bTerminalSnapshot, bool> predicate)
+    {
+        using var snapshot = await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(predicate, Timeout, "authoritative HMP activity applied")
+            .Build().ApplyAsync(terminal, TestContext.Current.CancellationToken);
+    }
+
+    private static async Task WriteSyncAsync(Stream stream, string ansi, Hmp1ActivityState activity)
+    {
+        await Hmp1Protocol.WriteFrameAsync(stream, Hmp1FrameType.StateSync,
+            Encoding.UTF8.GetBytes(ansi), TestContext.Current.CancellationToken);
+        await Hmp1Protocol.WriteActivityStateAsync(stream, activity, TestContext.Current.CancellationToken);
+    }
+
+    private static async Task HandshakeAsync(Stream stream, Hmp1WorkloadAdapter client, string ansi, Hmp1ActivityState activity)
+    {
+        using var timeout = new CancellationTokenSource(Timeout);
+        var connecting = client.ConnectAsync(timeout.Token);
+        await Hmp1Protocol.ReadFrameAsync(stream, timeout.Token);
+        await Hmp1Protocol.WriteHelloAsync(stream, 20, 5, "upstream", null, [], timeout.Token);
+        await WriteSyncAsync(stream, ansi, activity);
+        await connecting.WaitAsync(timeout.Token);
+    }
+
+    private static async Task<(Hmp1ClientHandle Handle, Hmp1WorkloadAdapter Client)> ConnectAsync(Hmp1PresentationAdapter server)
+    {
+        var streams = CreateStreams();
+        var client = Hmp1TestHelpers.NewClient(streams.Client);
+        using var timeout = new CancellationTokenSource(Timeout);
+        var accepting = server.AddClient(streams.Server, TestContext.Current.CancellationToken);
+        try
+        {
+            await client.ConnectAsync(timeout.Token);
+            return (await accepting.WaitAsync(timeout.Token), client);
+        }
+        catch
+        {
+            await client.DisposeAsync();
+            await streams.Server.DisposeAsync();
+            throw;
+        }
+    }
+
+    private static (Stream Server, Stream Client) CreateStreams()
+    {
+        var toClient = new Pipe();
+        var toServer = new Pipe();
+        return (new DuplexStream(toServer.Reader.AsStream(), toClient.Writer.AsStream()),
+            new DuplexStream(toClient.Reader.AsStream(), toServer.Writer.AsStream()));
+    }
+
+    private class ReplayPresentationGate : IHex1bTerminalPresentationAdapter
+    {
+        private readonly HeadlessPresentationAdapter _headless = new(20, 5);
+        internal TaskCompletionSource Entered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        internal TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        internal bool Fail { get; set; }
+        internal Action? Invalidated { get; set; }
+        public int Width => _headless.Width;
+        public int Height => _headless.Height;
+        public TerminalCapabilities Capabilities => _headless.Capabilities;
+        public event Action<int, int>? Resized { add => _headless.Resized += value; remove => _headless.Resized -= value; }
+        public event Action? Disconnected { add => _headless.Disconnected += value; remove => _headless.Disconnected -= value; }
+        public async ValueTask WriteOutputAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default)
+        {
+            Entered.TrySetResult();
+            await Release.Task.WaitAsync(ct);
+            if (Fail)
+            {
+                Fail = false;
+                throw new InvalidOperationException("Replay presentation failed.");
+            }
+        }
+        public ValueTask<ReadOnlyMemory<byte>> ReadInputAsync(CancellationToken ct = default) => _headless.ReadInputAsync(ct);
+        public ValueTask FlushAsync(CancellationToken ct = default) => ValueTask.CompletedTask;
+        public void InvalidatePresentation() => Invalidated?.Invoke();
+        public ValueTask EnterRawModeAsync(CancellationToken ct = default) => ValueTask.CompletedTask;
+        public ValueTask ExitRawModeAsync(CancellationToken ct = default) => ValueTask.CompletedTask;
+        public (int Row, int Column) GetCursorPosition() => (0, 0);
+        public ValueTask DisposeAsync() => _headless.DisposeAsync();
+    }
+
+    private sealed class ReplayImpactGate : ReplayPresentationGate, ICellImpactAwarePresentationAdapter
+    {
+        public ValueTask WriteOutputWithImpactsAsync(IReadOnlyList<AppliedToken> appliedTokens, CancellationToken ct = default)
+            => WriteOutputAsync(ReadOnlyMemory<byte>.Empty, ct);
+    }
+
+    private sealed class FailingReplayFilter : IHex1bTerminalWorkloadFilter
+    {
+        public ValueTask OnOutputAsync(IReadOnlyList<AnsiToken> tokens, TimeSpan elapsed, CancellationToken ct = default)
+            => throw new InvalidOperationException("Replay workload filter failed.");
+        public ValueTask OnSessionStartAsync(int width, int height, DateTimeOffset timestamp, CancellationToken ct = default)
+            => ValueTask.CompletedTask;
+        public ValueTask OnFrameCompleteAsync(TimeSpan elapsed, CancellationToken ct = default) => ValueTask.CompletedTask;
+        public ValueTask OnInputAsync(IReadOnlyList<AnsiToken> tokens, TimeSpan elapsed, CancellationToken ct = default)
+            => ValueTask.CompletedTask;
+        public ValueTask OnResizeAsync(int width, int height, TimeSpan elapsed, CancellationToken ct = default)
+            => ValueTask.CompletedTask;
+        public ValueTask OnSessionEndAsync(TimeSpan elapsed, CancellationToken ct = default) => ValueTask.CompletedTask;
+    }
+
+    private sealed class DuplexStream(Stream input, Stream output) : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanWrite => true;
+        public override bool CanSeek => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public override int Read(byte[] buffer, int offset, int count) => input.Read(buffer, offset, count);
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+            => input.ReadAsync(buffer, cancellationToken);
+        public override void Write(byte[] buffer, int offset, int count) => output.Write(buffer, offset, count);
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            => output.WriteAsync(buffer, cancellationToken);
+        public override void Flush() => output.Flush();
+        public override Task FlushAsync(CancellationToken cancellationToken) => output.FlushAsync(cancellationToken);
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                input.Dispose();
+                output.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/tests/Hex1b.Tests/Hmp1/Hmp1SixelStateReplayTests.cs
+++ b/tests/Hex1b.Tests/Hmp1/Hmp1SixelStateReplayTests.cs
@@ -78,6 +78,7 @@ public class Hmp1SixelStateReplayTests
             ?? throw new AssertFailedException("Server closed the stream before sending Hello.");
         var stateSync = await Hmp1Protocol.ReadFrameAsync(clientStream, cts.Token)
             ?? throw new AssertFailedException("Server closed the stream before sending StateSync.");
+        await Hmp1Protocol.ReadActivityStateAsync(clientStream, cts.Token);
         var sixelReplay = await Hmp1Protocol.ReadFrameAsync(clientStream, cts.Token)
             ?? throw new AssertFailedException("Server closed the stream before sending Sixel replay.");
 
@@ -192,6 +193,7 @@ public class Hmp1SixelStateReplayTests
             ?? throw new AssertFailedException("Server closed the stream before sending Hello.");
         var stateSync = await Hmp1Protocol.ReadFrameAsync(clientStream, cts.Token)
             ?? throw new AssertFailedException("Server closed the stream before sending StateSync.");
+        await Hmp1Protocol.ReadActivityStateAsync(clientStream, cts.Token);
         var sixelReplay = await Hmp1Protocol.ReadFrameAsync(clientStream, cts.Token)
             ?? throw new AssertFailedException("Server closed the stream before sending Sixel replay.");
 

--- a/tests/Hex1b.Tests/Hmp1/Hmp1StateReplayCursorRegressionTests.cs
+++ b/tests/Hex1b.Tests/Hmp1/Hmp1StateReplayCursorRegressionTests.cs
@@ -158,6 +158,7 @@ public class Hmp1StateReplayCursorRegressionTests
             ?? throw new AssertFailedException("Server closed the stream before sending Hello.");
         var stateSync = await Hmp1Protocol.ReadFrameAsync(clientStream, cts.Token)
             ?? throw new AssertFailedException("Server closed the stream before sending StateSync.");
+        await Hmp1Protocol.ReadActivityStateAsync(clientStream, cts.Token);
         var kgpReplay = await Hmp1Protocol.ReadFrameAsync(clientStream, cts.Token)
             ?? throw new AssertFailedException("Server closed the stream before sending KGP replay.");
 

--- a/tests/Hex1b.Tests/Hwt1ActivityTests.cs
+++ b/tests/Hex1b.Tests/Hwt1ActivityTests.cs
@@ -1,0 +1,133 @@
+using System.Buffers.Binary;
+using System.Text;
+using System.Text.Json;
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests;
+
+[TestClass]
+public class Hwt1ActivityTests
+{
+    [TestMethod]
+    public async Task ReadFrameAsync_ActivityOnlyOutput_CarriesDefaultsChangesAndClearsWithoutCells()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var view = new Hwt1PresentationAdapter(20, 10);
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithPresentation(view).WithDimensions(20, 10).Build();
+        var initial = await ReadFrameAsync(view);
+        AssertActivity(initial.Metadata, "none", null, "unknown", null);
+        foreach (var (sequence, state, percentage, phase, exitCode) in new (string, string, int?, string, int?)[]
+        {
+            ("\x1b]9;4;3\a\x1b]133;C\a", "indeterminate", null, "executing", null),
+            ("\x1b]9;4;1;50\a", "normal", 50, "executing", null),
+            ("\x1b]9;4;4;50\a", "warning", 50, "executing", null),
+            ("\x1b]9;4;2;50\a\x1b]133;D;-1\a", "error", 50, "finished", -1),
+            ("\x1b]133;A\a\x1b]133;B\a", "error", 50, "commandLine", -1),
+            ("\x1b]9;4;0\a", "none", null, "commandLine", -1),
+            ("\x1b" + "c", "none", null, "unknown", null),
+        })
+        {
+            terminal.ApplyTokens(AnsiTokenizer.Tokenize(sequence));
+            var frame = await ReadFrameAsync(view);
+            AssertActivity(frame.Metadata, state, percentage, phase, exitCode);
+            Assert.AreEqual(0, frame.CellCount);
+            Assert.IsFalse(frame.Metadata.GetProperty("full").GetBoolean());
+        }
+        AssertActivity(initial.Metadata, "none", null, "unknown", null);
+    }
+
+    [TestMethod]
+    public async Task ReadFrameAsync_UnacknowledgedActivity_CoalescesAndResyncRetainsFinalState()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var view = new Hwt1PresentationAdapter(20, 10);
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithPresentation(view).WithDimensions(20, 10).Build();
+        var initial = await ReadFrameAsync(view, acknowledge: false);
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize(
+            "\x1b]133;A\a\x1b]133;B\a\x1b]133;C\a\x1b]9;4;3\a" +
+            "\x1b]9;4;1;100\a\x1b]133;D;0\a\x1b]9;4;0\a"));
+        await AcknowledgeAsync(view, initial.Metadata);
+        var frame = await ReadFrameAsync(view);
+        AssertActivity(frame.Metadata, "none", null, "finished", 0);
+        Assert.AreEqual(0, frame.CellCount);
+        await view.HandleMessageAsync("""{"type":"resync"}"""u8.ToArray(), TestContext.Current.CancellationToken);
+        var resync = await ReadFrameAsync(view);
+        Assert.IsTrue(resync.Metadata.GetProperty("full").GetBoolean());
+        AssertActivity(resync.Metadata, "none", null, "finished", 0);
+    }
+
+    [TestMethod]
+    public async Task ProducerBackedViews_LateAttachmentHistoryAndReconnect_KeepCurrentActivity()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var server = new Hmp1PresentationAdapter(20, 10);
+        await using var producer = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithPresentation(server).WithDimensions(20, 10).WithScrollback(100).Build();
+        producer.ApplyTokens(AnsiTokenizer.Tokenize(
+            string.Concat(Enumerable.Range(0, 20).Select(row => $"row{row:00}\r\n")) +
+            "\x1b]9;4;1;20\a\x1b]133;C\a"));
+        await using var first = await server.CreateBrowserViewAsync("first", TestContext.Current.CancellationToken);
+        AssertActivity((await ReadFrameAsync(first)).Metadata, "normal", 20, "executing", null);
+        await first.HandleMessageAsync("""{"type":"viewport","requestId":1,"delta":-100}"""u8.ToArray(),
+            TestContext.Current.CancellationToken);
+        var historical = await ReadFrameAsync(first);
+        Assert.IsFalse(historical.Metadata.GetProperty("history").GetProperty("following").GetBoolean());
+        producer.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]9;4;2;20\a\x1b]133;D;1\a"));
+        var changed = await ReadFrameAsync(first);
+        AssertActivity(changed.Metadata, "error", 20, "finished", 1);
+        Assert.AreEqual(0, changed.CellCount);
+        await using var late = await server.CreateBrowserViewAsync("late", TestContext.Current.CancellationToken);
+        AssertActivity((await ReadFrameAsync(late)).Metadata, "error", 20, "finished", 1);
+        await late.DisposeAsync();
+        producer.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]9;4;0\a\x1b]133;D\a"));
+        await using var reconnected = await server.CreateBrowserViewAsync("reconnected", TestContext.Current.CancellationToken);
+        AssertActivity((await ReadFrameAsync(reconnected)).Metadata, "none", null, "finished", null);
+    }
+
+    [TestMethod]
+    public async Task ReadFrameAsync_SynchronizedActivity_WaitsForCompletedSnapshot()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var view = new Hwt1PresentationAdapter(20, 10);
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithPresentation(view).WithDimensions(20, 10).Build();
+        await ReadFrameAsync(view);
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[?2026h\x1b]9;4;3\a\x1b]133;C\a"));
+        var pending = ReadFrameAsync(view);
+        Assert.IsFalse(pending.IsCompleted);
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]9;4;1;50\a\x1b[?2026l"));
+        AssertActivity((await pending).Metadata, "normal", 50, "executing", null);
+    }
+
+    private static void AssertActivity(JsonElement metadata, string state, int? percentage, string phase, int? exitCode)
+    {
+        var progress = metadata.GetProperty("progress");
+        var shell = metadata.GetProperty("shellIntegration");
+        Assert.AreEqual(state, progress.GetProperty("state").GetString());
+        Assert.AreEqual(percentage, progress.GetProperty("percentage").Deserialize<int?>());
+        Assert.AreEqual(phase, shell.GetProperty("phase").GetString());
+        Assert.AreEqual(exitCode, shell.GetProperty("lastExitCode").Deserialize<int?>());
+    }
+
+    private static async Task<(JsonElement Metadata, int CellCount)> ReadFrameAsync(
+        Hwt1PresentationAdapter view, bool acknowledge = true)
+    {
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(5));
+        var bytes = await view.ReadFrameAsync(timeout.Token);
+        var length = BinaryPrimitives.ReadInt32LittleEndian(bytes.Span[4..]);
+        using var document = JsonDocument.Parse(bytes.Slice(8, length));
+        var metadata = document.RootElement.Clone();
+        var count = BinaryPrimitives.ReadInt32LittleEndian(bytes.Span[(8 + length)..]);
+        if (acknowledge)
+            await AcknowledgeAsync(view, metadata);
+        return (metadata, count);
+    }
+
+    private static Task AcknowledgeAsync(Hwt1PresentationAdapter view, JsonElement metadata)
+        => view.HandleMessageAsync(Encoding.UTF8.GetBytes(
+            $$"""{"type":"ack","revision":{{metadata.GetProperty("revision").GetUInt32()}}}"""),
+            TestContext.Current.CancellationToken);
+}

--- a/tests/Hex1b.Tests/Hwt1Hmp1IntegrationTests.cs
+++ b/tests/Hex1b.Tests/Hwt1Hmp1IntegrationTests.cs
@@ -892,6 +892,7 @@ public class Hwt1Hmp1IntegrationTests
         Assert.AreEqual(Hmp1FrameType.ClientHello, hello!.Value.Type);
         await Hmp1Protocol.WriteHelloAsync(server, width, height, peerId, primaryId, [], TestContext.Current.CancellationToken);
         await Hmp1Protocol.WriteFrameAsync(server, Hmp1FrameType.StateSync, state, TestContext.Current.CancellationToken);
+        await Hmp1Protocol.WriteActivityStateAsync(server, Hmp1ActivityState.Default, TestContext.Current.CancellationToken);
         await connect.WaitAsync(TimeSpan.FromSeconds(5));
     }
 

--- a/tests/Hex1b.Tests/OscProgressTests.cs
+++ b/tests/Hex1b.Tests/OscProgressTests.cs
@@ -1,0 +1,256 @@
+using System.Text;
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests;
+
+[TestClass]
+public class OscProgressTests
+{
+    [TestMethod]
+    [DataRow("0", TerminalProgressState.None, null)]
+    [DataRow("0;", TerminalProgressState.None, null)]
+    [DataRow("0;ignored", TerminalProgressState.None, null)]
+    [DataRow("1;0", TerminalProgressState.Normal, 0)]
+    [DataRow("1;100", TerminalProgressState.Normal, 100)]
+    [DataRow("1;007", TerminalProgressState.Normal, 7)]
+    [DataRow("2;25", TerminalProgressState.Error, 25)]
+    [DataRow("3", TerminalProgressState.Indeterminate, null)]
+    [DataRow("3;", TerminalProgressState.Indeterminate, null)]
+    [DataRow("3;-99999999999999", TerminalProgressState.Indeterminate, null)]
+    [DataRow("4;80", TerminalProgressState.Warning, 80)]
+    public async Task Osc9_ValidProgress_UpdatesWithoutCellOrCursorEffects(
+        string payload, TerminalProgressState state, int? percentage)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("content"));
+        var token = TestSeq.IsType<OscToken>(TestSeq.Single(
+            AnsiTokenizer.Tokenize($"\x1b]9;4;{payload}\x07")));
+        Assert.AreEqual("4", token.Parameters);
+        Assert.AreEqual(payload, token.Payload);
+        var impacts = TestSeq.Single(terminal.ApplyTokensWithImpacts([token]));
+
+        Assert.AreEqual(state, terminal.Progress.State);
+        Assert.AreEqual(percentage, terminal.Progress.Percentage);
+        Assert.AreEqual(0, impacts.CellImpacts.Count);
+        Assert.AreEqual(impacts.CursorXBefore, impacts.CursorXAfter);
+        Assert.AreEqual(impacts.CursorYBefore, impacts.CursorYAfter);
+        using var snapshot = terminal.CreateSnapshot();
+        Assert.AreEqual(terminal.Progress, snapshot.Progress);
+        Assert.IsTrue(snapshot.ContainsText("content"));
+        Assert.AreEqual(TerminalShellIntegrationPhase.Unknown, snapshot.ShellIntegration.Phase);
+    }
+
+    [TestMethod]
+    [DataRow("9")]
+    [DataRow("9;4")]
+    [DataRow("9;4;")]
+    [DataRow("9;5;1;50")]
+    [DataRow("9;4;5;50")]
+    [DataRow("9;4;01;50")]
+    [DataRow("9;4;+1;50")]
+    [DataRow("9;4;1")]
+    [DataRow("9;4;1;")]
+    [DataRow("9;4;1;-1")]
+    [DataRow("9;4;1;+1")]
+    [DataRow("9;4;1;101")]
+    [DataRow("9;4;1;2147483648")]
+    [DataRow("9;4;1;999999999999999999999999")]
+    [DataRow("9;4;1; 50")]
+    [DataRow("9;4;1;50 ")]
+    [DataRow("9;4;1;1.0")]
+    [DataRow("9;4;1;５０")]
+    [DataRow("9;4;1;50;")]
+    [DataRow("9;4;0;ignored;extra")]
+    [DataRow("9;4;3;;")]
+    public async Task Osc9_InvalidProgress_IgnoresUntrustedMutation(string body)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+        terminal.ApplyTokens([new OscToken("9", "4", "2;40")]);
+        var before = terminal.Progress;
+        var changes = 0;
+        terminal.ProgressChanged += _ => changes++;
+
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize($"\x1b]{body}\x07"));
+
+        Assert.AreEqual(before, terminal.Progress);
+        Assert.AreEqual(0, changes);
+    }
+
+    [TestMethod]
+    public async Task ProgressChanged_DefaultsAndRepeatedValues_OnlyNotifiesDistinctChanges()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+        var changes = new List<TerminalProgress>();
+        terminal.ProgressChanged += progress =>
+        {
+            Assert.AreEqual(progress, terminal.Progress);
+            changes.Add(progress);
+        };
+        Assert.AreEqual(0, changes.Count);
+        Assert.AreEqual(TerminalProgressState.None, terminal.Progress.State);
+        Assert.IsNull(terminal.Progress.Percentage);
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize(
+            "\x1b]9;4;0\x07\x1b]9;4;1;10\x07\x1b]9;4;1;010\x07" +
+            "\x1b]9;4;3\x07\x1b]9;4;3;ignored\x07\x1b]9;4;0\x07"));
+
+        TestSeq.AreEqual(new[]
+        {
+            new TerminalProgress(TerminalProgressState.Normal, 10),
+            new TerminalProgress(TerminalProgressState.Indeterminate, null),
+            TerminalProgress.Default
+        }, changes);
+    }
+
+    [TestMethod]
+    [DataRow("\x1b]", "\x07")]
+    [DataRow("\x1b]", "\x1b\\")]
+    [DataRow("\u009d", "\u009c")]
+    public async Task RawOutput_EveryByteSplit_AppliesOnlyCompleteProgress(string introducer, string terminator)
+    {
+        var bytes = Encoding.UTF8.GetBytes($"{introducer}9;4;4;73{terminator}");
+        for (var split = 1; split < bytes.Length; split++)
+        {
+            using var workload = new Hex1bAppWorkloadAdapter();
+            await using var terminal = Hex1bTerminal.CreateBuilder()
+                .WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+            var changed = new TaskCompletionSource<TerminalProgress>(TaskCreationOptions.RunContinuationsAsynchronously);
+            terminal.ProgressChanged += state => changed.TrySetResult(state);
+
+            workload.Write(bytes.AsMemory(0, split));
+            workload.Write(bytes.AsMemory(split));
+            var progress = await changed.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+            Assert.AreEqual(TerminalProgressState.Warning, progress.State);
+            Assert.AreEqual(73, progress.Percentage);
+            using var snapshot = terminal.CreateSnapshot();
+            Assert.AreEqual(0, snapshot.CursorX);
+            Assert.AreEqual(0, snapshot.CursorY);
+            Assert.AreEqual("", snapshot.GetText().Trim());
+        }
+    }
+
+    [TestMethod]
+    [DataRow("\x1b[!p")]
+    [DataRow("\x1b[2J")]
+    [DataRow("\x1b[?1049h\x1b[?1049l")]
+    public async Task ScreenChange_PreservesActivity_AndRisClearsBoth(string sequence)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]9;4;2;25\x07\x1b]133;D;-1\x07"));
+        using var before = terminal.CreateSnapshot();
+
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize(sequence));
+        terminal.Resize(30, 8);
+        Assert.AreEqual(before.Progress, terminal.Progress);
+        Assert.AreEqual(before.ShellIntegration, terminal.ShellIntegration);
+
+        terminal.ApplyTokens([RisToken.Instance]);
+        Assert.AreEqual(TerminalProgress.Default, terminal.Progress);
+        Assert.AreEqual(TerminalShellIntegration.Default, terminal.ShellIntegration);
+        Assert.AreEqual(TerminalProgressState.Error, before.Progress.State);
+        Assert.AreEqual(-1, before.ShellIntegration.LastExitCode);
+    }
+
+    [TestMethod]
+    public async Task CreateSnapshot_ScrollbackAndHistoricalText_CapturesImmutableCurrentActivity()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithHeadless().WithDimensions(20, 3).WithScrollback().Build();
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize(
+            "old\r\nmiddle\r\nnew\r\nlast\x1b]9;4;4;90\x07\x1b]133;D;7\x07"));
+        using var captured = terminal.CreateSnapshot(10);
+        using var historical = new Hex1bTerminalSnapshot(terminal,
+            terminal.CaptureSnapshotState(0, ScrollbackWidth.CurrentTerminal, textViewportTop: 0),
+            ScrollbackWidth.CurrentTerminal, TerminalCell.Empty);
+        Assert.IsTrue(historical.ContainsText("old"));
+        Assert.AreEqual(captured.Progress, historical.Progress);
+        Assert.AreEqual(captured.ShellIntegration, historical.ShellIntegration);
+
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]9;4;0\x07\x1b]133;A\x07"));
+        Assert.AreEqual(TerminalProgressState.Warning, captured.Progress.State);
+        Assert.AreEqual(90, historical.Progress.Percentage);
+        Assert.AreEqual(TerminalShellIntegrationPhase.Finished, captured.ShellIntegration.Phase);
+        Assert.AreEqual(7, historical.ShellIntegration.LastExitCode);
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public async Task RawOutput_ValidAndIgnoredActivity_PreservesPassthrough(bool tokenFiltered)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var presentation = new ActivityCapturePresentation();
+        var builder = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithPresentation(presentation).WithDimensions(20, 5);
+        if (tokenFiltered)
+            builder.AddPresentationFilter(presentation);
+        await using var terminal = builder.Build();
+        const string output =
+            "\u009d9;4;1;80\u009c\x1b]133;D;-3\x1b\\" +
+            "\x1b]9;4;1;-1\x07\x1b]133;unsupported\x07\x1b]133;;D;0\x07" + "done";
+        workload.Write(output);
+        var captured = await presentation.Output.Task.WaitAsync(
+            TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        var expected = tokenFiltered
+            ? AnsiTokenSerializer.Serialize(AnsiTokenizer.Tokenize(output))
+            : output;
+        Assert.AreEqual(expected, Encoding.UTF8.GetString(captured));
+        using var snapshot = await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.ContainsText("done"), TimeSpan.FromSeconds(5), "activity and following text applied")
+            .Build().ApplyAsync(terminal, TestContext.Current.CancellationToken);
+        Assert.AreEqual(80, snapshot.Progress.Percentage);
+        Assert.AreEqual(-3, snapshot.ShellIntegration.LastExitCode);
+    }
+
+    private sealed class ActivityCapturePresentation :
+        IHex1bTerminalPresentationAdapter, IHex1bTerminalPresentationFilter
+    {
+        private readonly HeadlessPresentationAdapter _headless = new(20, 5);
+        public TaskCompletionSource<byte[]> Output { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public int Width => _headless.Width;
+        public int Height => _headless.Height;
+        public TerminalCapabilities Capabilities => _headless.Capabilities;
+        public event Action<int, int>? Resized
+        {
+            add => _headless.Resized += value;
+            remove => _headless.Resized -= value;
+        }
+        public event Action? Disconnected
+        {
+            add => _headless.Disconnected += value;
+            remove => _headless.Disconnected -= value;
+        }
+        public ValueTask WriteOutputAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default)
+        {
+            Output.TrySetResult(data.ToArray());
+            return ValueTask.CompletedTask;
+        }
+        public ValueTask<ReadOnlyMemory<byte>> ReadInputAsync(CancellationToken ct = default)
+            => _headless.ReadInputAsync(ct);
+        public ValueTask FlushAsync(CancellationToken ct = default) => ValueTask.CompletedTask;
+        public ValueTask EnterRawModeAsync(CancellationToken ct = default) => ValueTask.CompletedTask;
+        public ValueTask ExitRawModeAsync(CancellationToken ct = default) => ValueTask.CompletedTask;
+        public (int Row, int Column) GetCursorPosition() => (0, 0);
+        public ValueTask DisposeAsync() => _headless.DisposeAsync();
+        public ValueTask OnSessionStartAsync(int width, int height, DateTimeOffset timestamp, CancellationToken ct = default)
+            => ValueTask.CompletedTask;
+        public ValueTask<IReadOnlyList<AnsiToken>> OnOutputAsync(
+            IReadOnlyList<AppliedToken> appliedTokens, TimeSpan elapsed, CancellationToken ct = default)
+            => ValueTask.FromResult<IReadOnlyList<AnsiToken>>(appliedTokens.Select(applied => applied.Token).ToArray());
+        public ValueTask OnInputAsync(IReadOnlyList<AnsiToken> tokens, TimeSpan elapsed, CancellationToken ct = default)
+            => ValueTask.CompletedTask;
+        public ValueTask OnResizeAsync(int width, int height, TimeSpan elapsed, CancellationToken ct = default)
+            => ValueTask.CompletedTask;
+        public ValueTask OnSessionEndAsync(TimeSpan elapsed, CancellationToken ct = default)
+            => ValueTask.CompletedTask;
+    }
+}

--- a/tests/Hex1b.Tests/OscShellIntegrationTests.cs
+++ b/tests/Hex1b.Tests/OscShellIntegrationTests.cs
@@ -1,0 +1,261 @@
+using System.Text;
+using Hex1b.Automation;
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests;
+
+[TestClass]
+public class OscShellIntegrationTests
+{
+    [TestMethod]
+    [DataRow("A", TerminalShellIntegrationPhase.Prompt, null)]
+    [DataRow("B", TerminalShellIntegrationPhase.CommandLine, null)]
+    [DataRow("C", TerminalShellIntegrationPhase.Executing, null)]
+    [DataRow("D", TerminalShellIntegrationPhase.Finished, null)]
+    [DataRow("D;", TerminalShellIntegrationPhase.Finished, null)]
+    [DataRow("D;0", TerminalShellIntegrationPhase.Finished, 0)]
+    [DataRow("D;17", TerminalShellIntegrationPhase.Finished, 17)]
+    [DataRow("D;-1", TerminalShellIntegrationPhase.Finished, -1)]
+    [DataRow("D;+7", TerminalShellIntegrationPhase.Finished, 7)]
+    [DataRow("D;0007", TerminalShellIntegrationPhase.Finished, 7)]
+    [DataRow("D;-2147483648", TerminalShellIntegrationPhase.Finished, int.MinValue)]
+    [DataRow("D;2147483647", TerminalShellIntegrationPhase.Finished, int.MaxValue)]
+    public async Task Osc133_ValidMarker_AppliesWithoutRequiringEarlierMarkers(
+        string body, TerminalShellIntegrationPhase phase, int? exitCode)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+        var token = TestSeq.IsType<OscToken>(TestSeq.Single(
+            AnsiTokenizer.Tokenize($"\x1b]133;{body}\x07")));
+        if (body == "D")
+        {
+            Assert.AreEqual("", token.Parameters);
+            Assert.AreEqual("D", token.Payload);
+        }
+        var impacts = TestSeq.Single(terminal.ApplyTokensWithImpacts([token]));
+        Assert.AreEqual(phase, terminal.ShellIntegration.Phase);
+        Assert.AreEqual(exitCode, terminal.ShellIntegration.LastExitCode);
+        Assert.AreEqual(0, impacts.CellImpacts.Count);
+        Assert.AreEqual(impacts.CursorXBefore, impacts.CursorXAfter);
+        Assert.AreEqual(impacts.CursorYBefore, impacts.CursorYAfter);
+        Assert.AreEqual(TerminalProgress.Default, terminal.Progress);
+
+        var roundTrip = TestSeq.Single(AnsiTokenizer.Tokenize(AnsiTokenSerializer.Serialize(token)));
+        terminal.ApplyTokens([RisToken.Instance, roundTrip]);
+        Assert.AreEqual(phase, terminal.ShellIntegration.Phase);
+        Assert.AreEqual(exitCode, terminal.ShellIntegration.LastExitCode);
+    }
+
+    [TestMethod]
+    [DataRow("")]
+    [DataRow("E")]
+    [DataRow("a")]
+    [DataRow(";A")]
+    [DataRow(";B")]
+    [DataRow(";C")]
+    [DataRow(";D")]
+    [DataRow(";D;0")]
+    [DataRow(";D;")]
+    [DataRow("A;")]
+    [DataRow("A;prompt=1")]
+    [DataRow("B;")]
+    [DataRow("C;extra")]
+    [DataRow("D; ")]
+    [DataRow("D;0 ")]
+    [DataRow("D; 0")]
+    [DataRow("D;+")]
+    [DataRow("D;-")]
+    [DataRow("D;1.0")]
+    [DataRow("D;bad")]
+    [DataRow("D;１２")]
+    [DataRow("D;2147483648")]
+    [DataRow("D;-2147483649")]
+    [DataRow("D;999999999999999999999999")]
+    [DataRow("D;0;")]
+    [DataRow("D;;")]
+    public async Task Osc133_InvalidMarkerOrArguments_DoesNotMutateState(string body)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+        terminal.ApplyTokens([new OscToken("133", "D", "27")]);
+        var before = terminal.ShellIntegration;
+        var changes = 0;
+        terminal.ShellIntegrationChanged += _ => changes++;
+        var tokens = AnsiTokenizer.Tokenize($"\x1b]133;{body}\x07");
+        terminal.ApplyTokens(tokens);
+        Assert.AreEqual(before, terminal.ShellIntegration);
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize(string.Concat(tokens.Select(AnsiTokenSerializer.Serialize))));
+        Assert.AreEqual(before, terminal.ShellIntegration);
+        Assert.AreEqual(0, changes);
+    }
+
+    [TestMethod]
+    public async Task ShellIntegration_MarkersRetainLatestResult_AndDoNotChangeProgress()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+        terminal.ApplyTokens([new OscToken("9", "4", "2;40")]);
+        var changes = new List<TerminalShellIntegration>();
+        terminal.ShellIntegrationChanged += state =>
+        {
+            Assert.AreEqual(state, terminal.ShellIntegration);
+            changes.Add(state);
+        };
+        Assert.AreEqual(TerminalShellIntegration.Default, terminal.ShellIntegration);
+        Assert.AreEqual(0, changes.Count);
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize(
+            "\x1b]133;D;-9\x07\x1b]133;A\x07\x1b]133;B\x07\x1b]133;C\x07" +
+            "\x1b]133;C\x07\x1b]133;A\x07\x1b]133;D\x07\x1b]133;D;\x07"));
+        TestSeq.AreEqual(new[]
+        {
+            new TerminalShellIntegration(TerminalShellIntegrationPhase.Finished, -9),
+            new TerminalShellIntegration(TerminalShellIntegrationPhase.Prompt, -9),
+            new TerminalShellIntegration(TerminalShellIntegrationPhase.CommandLine, -9),
+            new TerminalShellIntegration(TerminalShellIntegrationPhase.Executing, -9),
+            new TerminalShellIntegration(TerminalShellIntegrationPhase.Prompt, -9),
+            new TerminalShellIntegration(TerminalShellIntegrationPhase.Finished, null)
+        }, changes);
+        Assert.AreEqual(new TerminalProgress(TerminalProgressState.Error, 40), terminal.Progress);
+        terminal.ApplyTokens([new OscToken("9", "4", "0")]);
+        Assert.AreEqual(TerminalShellIntegrationPhase.Finished, terminal.ShellIntegration.Phase);
+    }
+
+    [TestMethod]
+    [DataRow("\x1b]", "\x07")]
+    [DataRow("\x1b]", "\x1b\\")]
+    [DataRow("\u009d", "\u009c")]
+    public async Task RawOutput_EveryByteSplit_ParsesShellResult(string introducer, string terminator)
+    {
+        var bytes = Encoding.UTF8.GetBytes($"{introducer}133;D;-2147483648{terminator}");
+        for (var split = 1; split < bytes.Length; split++)
+        {
+            using var workload = new Hex1bAppWorkloadAdapter();
+            await using var terminal = Hex1bTerminal.CreateBuilder()
+                .WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+            var changed = new TaskCompletionSource<TerminalShellIntegration>(TaskCreationOptions.RunContinuationsAsynchronously);
+            terminal.ShellIntegrationChanged += state => changed.TrySetResult(state);
+            workload.Write(bytes.AsMemory(0, split));
+            workload.Write(bytes.AsMemory(split));
+            var state = await changed.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+            Assert.AreEqual(TerminalShellIntegrationPhase.Finished, state.Phase);
+            Assert.AreEqual(int.MinValue, state.LastExitCode);
+        }
+    }
+
+    [TestMethod]
+    [DataRow("A")]
+    [DataRow("B")]
+    [DataRow("C")]
+    [DataRow("D")]
+    [DataRow("D;0")]
+    public async Task RawOutput_EveryByteSplit_EmptyMarkerDoesNotBecomeValid(string remainder)
+    {
+        var bytes = Encoding.UTF8.GetBytes($"\x1b]133;;{remainder}\x1b\\done");
+        for (var split = 1; split < bytes.Length; split++)
+        {
+            using var workload = new Hex1bAppWorkloadAdapter();
+            await using var terminal = Hex1bTerminal.CreateBuilder()
+                .WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+            terminal.ApplyTokens([new OscToken("133", "D", "-7")]);
+            workload.Write(bytes.AsMemory(0, split));
+            workload.Write(bytes.AsMemory(split));
+            using var snapshot = await new Hex1bTerminalInputSequenceBuilder()
+                .WaitUntil(s => s.ContainsText("done"), TimeSpan.FromSeconds(5), "invalid marker consumed")
+                .Build().ApplyAsync(terminal, TestContext.Current.CancellationToken);
+            Assert.AreEqual(TerminalShellIntegrationPhase.Finished, snapshot.ShellIntegration.Phase);
+            Assert.AreEqual(-7, snapshot.ShellIntegration.LastExitCode);
+        }
+    }
+
+    [TestMethod]
+    public async Task ActivityRestore_IntermediateRisAndMarkers_OnlyPublishesFinalPair()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]9;4;1;10\x07\x1b]133;C\x07"));
+        var progress = new TerminalProgress(TerminalProgressState.Warning, 80);
+        var shell = new TerminalShellIntegration(TerminalShellIntegrationPhase.Prompt, 3);
+        var progressEvents = new List<TerminalProgress>();
+        var shellEvents = new List<TerminalShellIntegration>();
+        terminal.ProgressChanged += value =>
+        {
+            Assert.AreEqual(shell, terminal.ShellIntegration);
+            using var snapshot = terminal.CreateSnapshot();
+            Assert.AreEqual(progress, snapshot.Progress);
+            Assert.AreEqual(shell, snapshot.ShellIntegration);
+            progressEvents.Add(value);
+        };
+        terminal.ShellIntegrationChanged += shellEvents.Add;
+
+        terminal.BeginActivityStateRestore();
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b" + "c\x1b]9;4;3\x07\x1b]133;D\x07"));
+        terminal.BeginActivityStateRestore();
+        terminal.RestoreActivityState(progress, shell);
+        terminal.EndActivityStateRestore();
+        Assert.AreEqual(0, progressEvents.Count);
+        Assert.AreEqual(0, shellEvents.Count);
+        terminal.EndActivityStateRestore();
+        TestSeq.AreEqual(new[] { progress }, progressEvents);
+        TestSeq.AreEqual(new[] { shell }, shellEvents);
+
+        terminal.BeginActivityStateRestore();
+        terminal.ApplyTokens([RisToken.Instance]);
+        terminal.RestoreActivityState(progress, shell);
+        terminal.EndActivityStateRestore();
+        Assert.AreEqual(1, progressEvents.Count);
+        Assert.AreEqual(1, shellEvents.Count);
+    }
+
+    [TestMethod]
+    public async Task CreateSnapshot_ConcurrentActivityRestore_CapturesOneConsistentPair()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var writer = Task.Run(async () =>
+        {
+            await started.Task;
+            for (var i = 0; i < 500; i++)
+            {
+                var value = i % 2;
+                terminal.RestoreActivityState(
+                    new TerminalProgress(TerminalProgressState.Normal, value),
+                    new TerminalShellIntegration(TerminalShellIntegrationPhase.Finished, value));
+            }
+        }, TestContext.Current.CancellationToken);
+        started.SetResult();
+        for (var i = 0; i < 500; i++)
+        {
+            using var snapshot = terminal.CreateSnapshot();
+            Assert.AreEqual(snapshot.Progress.Percentage, snapshot.ShellIntegration.LastExitCode);
+        }
+        await writer.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+    }
+
+    [TestMethod]
+    public async Task IndependentTerminals_Disposal_DoesNotClearOrFabricateActivity()
+    {
+        using var firstWorkload = new Hex1bAppWorkloadAdapter();
+        using var secondWorkload = new Hex1bAppWorkloadAdapter();
+        await using var first = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(firstWorkload).WithHeadless().WithDimensions(20, 5).Build();
+        await using var second = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(secondWorkload).WithHeadless().WithDimensions(20, 5).Build();
+        first.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]9;4;3\x07\x1b]133;C\x07"));
+        var changes = 0;
+        first.ProgressChanged += _ => changes++;
+        first.ShellIntegrationChanged += _ => changes++;
+        await first.DisposeAsync();
+
+        Assert.AreEqual(TerminalProgressState.Indeterminate, first.Progress.State);
+        Assert.AreEqual(TerminalShellIntegrationPhase.Executing, first.ShellIntegration.Phase);
+        Assert.AreEqual(0, changes);
+        Assert.AreEqual(TerminalProgress.Default, second.Progress);
+        Assert.AreEqual(TerminalShellIntegration.Default, second.ShellIntegration);
+    }
+}

--- a/tests/Hex1b.Tests/TerminalWidgetHandleActivityTests.cs
+++ b/tests/Hex1b.Tests/TerminalWidgetHandleActivityTests.cs
@@ -1,0 +1,212 @@
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests;
+
+[TestClass]
+public class TerminalWidgetHandleActivityTests
+{
+    [TestMethod]
+    public async Task StandaloneHandle_AppliedTokens_MatchesAuthoritativeReducer()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+        await using var handle = new TerminalWidgetHandle(20, 5);
+        var progressChanges = 0;
+        var shellChanges = 0;
+        var invalidations = 0;
+        handle.ProgressChanged += _ => progressChanges++;
+        handle.ShellIntegrationChanged += _ => shellChanges++;
+        handle.OutputReceived += () => invalidations++;
+        Assert.AreEqual(TerminalProgress.Default, handle.Progress);
+        Assert.AreEqual(TerminalShellIntegration.Default, handle.ShellIntegration);
+        Assert.AreEqual(0, progressChanges + shellChanges);
+
+        foreach (var sequence in new[]
+        {
+            "\x1b]9;4;0\x07", "\x1b]9;4;1;50\x07", "\x1b]9;4;1;050\x07",
+            "\x1b]9;4;2;75\x07", "\x1b]9;4;3;ignored\x07", "\x1b]9;4;4;90\x07",
+            "\x1b]9;4;1;-1\x07", "\x1b]133;D;-3\x07", "\x1b]133;A\x07",
+            "\x1b]133;B\x07", "\x1b]133;C\x07", "\x1b]133;C\x07",
+            "\x1b]133;D\x07", "\x1b]133;D;\x07", "\x1b]133;D;invalid\x07"
+        })
+        {
+            await handle.WriteOutputWithImpactsAsync(
+                terminal.ApplyTokensWithImpacts(AnsiTokenizer.Tokenize(sequence)),
+                TestContext.Current.CancellationToken);
+            Assert.AreEqual(terminal.Progress, handle.Progress);
+            Assert.AreEqual(terminal.ShellIntegration, handle.ShellIntegration);
+        }
+
+        Assert.AreEqual(4, progressChanges);
+        Assert.AreEqual(5, shellChanges);
+        Assert.AreEqual(9, invalidations);
+    }
+
+    [TestMethod]
+    public async Task StandaloneHandle_CopyMode_UpdatesLiveWithoutReplayingQueuedActivity()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+        await using var handle = new TerminalWidgetHandle(20, 5);
+        await handle.WriteOutputWithImpactsAsync(terminal.ApplyTokensWithImpacts(AnsiTokenizer.Tokenize("old")));
+        handle.EnterCopyMode();
+        var progressChanges = new List<TerminalProgress>();
+        var shellChanges = new List<TerminalShellIntegration>();
+        handle.ProgressChanged += progressChanges.Add;
+        handle.ShellIntegrationChanged += shellChanges.Add;
+        await handle.WriteOutputWithImpactsAsync(terminal.ApplyTokensWithImpacts(AnsiTokenizer.Tokenize(
+            "\x1b]9;4;3\x07\x1b]133;C\x07\x1b" + "c")));
+        await handle.WriteOutputWithImpactsAsync(terminal.ApplyTokensWithImpacts(AnsiTokenizer.Tokenize(
+            "\x1b]9;4;4;80\x07\x1b]133;D;5\x07new")));
+        Assert.AreEqual("o", handle.GetCell(0, 0).Character);
+        Assert.AreEqual(new TerminalProgress(TerminalProgressState.Warning, 80), handle.Progress);
+        Assert.AreEqual(new TerminalShellIntegration(TerminalShellIntegrationPhase.Finished, 5), handle.ShellIntegration);
+        Assert.AreEqual(3, progressChanges.Count);
+        Assert.AreEqual(3, shellChanges.Count);
+
+        handle.ExitCopyMode();
+
+        Assert.AreEqual("n", handle.GetCell(0, 0).Character);
+        Assert.AreEqual(3, progressChanges.Count);
+        Assert.AreEqual(3, shellChanges.Count);
+        Assert.AreEqual(terminal.Progress, handle.Progress);
+        Assert.AreEqual(terminal.ShellIntegration, handle.ShellIntegration);
+    }
+
+    [TestMethod]
+    public async Task AttachedHandle_CopyModeAndRestore_KeepsAuthoritativeLivePair()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithDimensions(20, 5).WithTerminalWidget(out var handle).Build();
+        var firstCell = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        handle.OutputReceived += () =>
+        {
+            if (handle.GetCell(0, 0).Character == "x")
+                firstCell.TrySetResult();
+        };
+        workload.Write("x");
+        await firstCell.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        handle.EnterCopyMode();
+        var received = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        handle.ShellIntegrationChanged += state =>
+        {
+            if (state.Phase == TerminalShellIntegrationPhase.Finished)
+                received.TrySetResult();
+        };
+        workload.Write("\x1b]9;4;2;30\x07\x1b]133;D;-4\x07y");
+        await received.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        using var output = await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.ContainsText("xy"), TimeSpan.FromSeconds(5), "child output applied")
+            .Build().ApplyAsync(terminal, TestContext.Current.CancellationToken);
+        Assert.AreEqual(" ", handle.GetCell(1, 0).Character);
+        Assert.AreEqual(terminal.Progress, handle.Progress);
+        Assert.AreEqual(terminal.ShellIntegration, handle.ShellIntegration);
+
+        var progress = new TerminalProgress(TerminalProgressState.Indeterminate, null);
+        var shell = new TerminalShellIntegration(TerminalShellIntegrationPhase.Executing, -4);
+        terminal.RestoreActivityState(progress, shell);
+        var changes = 0;
+        handle.ProgressChanged += _ => changes++;
+        handle.ShellIntegrationChanged += _ => changes++;
+        // An authoritative checkpoint supersedes metadata in any queued text.
+        handle.ExitCopyMode();
+        Assert.AreEqual(progress, handle.Progress);
+        Assert.AreEqual(shell, handle.ShellIntegration);
+        Assert.AreEqual(0, changes);
+    }
+
+    [TestMethod]
+    public async Task AttachedHandle_ResetAndReplacement_UnsubscribesOldTerminalAndDropsQueuedActivity()
+    {
+        using var oldWorkload = new Hex1bAppWorkloadAdapter();
+        using var newWorkload = new Hex1bAppWorkloadAdapter();
+        await using var oldTerminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(oldWorkload).WithHeadless().WithDimensions(20, 5).Build();
+        await using var newTerminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(newWorkload).WithHeadless().WithDimensions(20, 5).Build();
+        await using var handle = new TerminalWidgetHandle(20, 5);
+        var lifecycle = (ITerminalLifecycleAwarePresentationAdapter)handle;
+        lifecycle.TerminalCreated(oldTerminal);
+        oldTerminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]9;4;3\x07\x1b]133;C\x07"));
+        handle.EnterCopyMode();
+        await handle.WriteOutputWithImpactsAsync(oldTerminal.ApplyTokensWithImpacts(AnsiTokenizer.Tokenize("stale")));
+
+        handle.Reset();
+
+        Assert.IsFalse(handle.IsInCopyMode);
+        Assert.AreEqual(TerminalProgress.Default, handle.Progress);
+        Assert.AreEqual(TerminalShellIntegration.Default, handle.ShellIntegration);
+        await handle.WriteOutputWithImpactsAsync(oldTerminal.ApplyTokensWithImpacts(AnsiTokenizer.Tokenize(
+            "\x1b]9;4;2;99\x07\x1b]133;D;99\x07")));
+        Assert.AreEqual(TerminalProgress.Default, handle.Progress);
+        Assert.AreEqual(TerminalShellIntegration.Default, handle.ShellIntegration);
+
+        newTerminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]9;4;1;10\x07\x1b]133;B\x07"));
+        lifecycle.TerminalCreated(newTerminal);
+        oldTerminal.ApplyTokens([RisToken.Instance]);
+        handle.ExitCopyMode();
+        Assert.AreEqual(newTerminal.Progress, handle.Progress);
+        Assert.AreEqual(newTerminal.ShellIntegration, handle.ShellIntegration);
+        Assert.AreEqual(" ", handle.GetCell(0, 0).Character);
+    }
+
+    [TestMethod]
+    public async Task AttachedHandle_RestoreNotifications_SeeFinalPairAndSuppressUnchangedReplay()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+        await using var handle = new TerminalWidgetHandle(20, 5);
+        ((ITerminalLifecycleAwarePresentationAdapter)handle).TerminalCreated(terminal);
+        var progress = new TerminalProgress(TerminalProgressState.Normal, 50);
+        var shell = new TerminalShellIntegration(TerminalShellIntegrationPhase.Prompt, -1);
+        var changes = 0;
+        handle.ProgressChanged += _ =>
+        {
+            Assert.AreEqual(shell, handle.ShellIntegration);
+            changes++;
+        };
+        handle.ShellIntegrationChanged += _ =>
+        {
+            Assert.AreEqual(progress, handle.Progress);
+            changes++;
+        };
+        for (var restore = 0; restore < 2; restore++)
+        {
+            terminal.BeginActivityStateRestore();
+            terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b" + "c\x1b]133;C\x07"));
+            terminal.RestoreActivityState(progress, shell);
+            terminal.EndActivityStateRestore();
+        }
+        Assert.AreEqual(2, changes);
+    }
+
+    [TestMethod]
+    public async Task AttachedHandle_CompletionAndDisposal_RetainsActivityAndStopsNotifications()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+        await using var handle = new TerminalWidgetHandle(20, 5);
+        var lifecycle = (ITerminalLifecycleAwarePresentationAdapter)handle;
+        lifecycle.TerminalCreated(terminal);
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]9;4;3\x07\x1b]133;C\x07"));
+        var progress = handle.Progress;
+        var shell = handle.ShellIntegration;
+        var changes = 0;
+        handle.ProgressChanged += _ => changes++;
+        handle.ShellIntegrationChanged += _ => changes++;
+
+        lifecycle.TerminalCompleted(17);
+        await handle.DisposeAsync();
+        terminal.ApplyTokens([RisToken.Instance]);
+
+        Assert.AreEqual(17, handle.ExitCode);
+        Assert.AreEqual(progress, handle.Progress);
+        Assert.AreEqual(shell, handle.ShellIntegration);
+        Assert.AreEqual(0, changes);
+    }
+}


### PR DESCRIPTION
## Summary

- Interpret OSC 9;4 application progress and basic OSC 133 shell lifecycle markers as independent, authoritative terminal state.
- Expose immutable progress/shell values through `Hex1bTerminal`, snapshots, and `TerminalWidgetHandle`, with distinct-value change notifications.
- Carry complete state through HWT1 and expose browser getters plus `onProgressChange` and `onShellIntegrationChange` callbacks for host-owned chrome.
- Restore screen and activity consistently across HMP1 late attachment, relays, reconnects, and placeholder workloads, without synthesizing shell lifecycle events.
- Add a controlled WebTerminalDemo activity scene, optional status/progress chrome, and API/protocol documentation.

## Semantics

- Progress is independent of shell phase and terminal-process lifetime. No command history, output ranges, or inferred activity are added.
- Invalid OSC arguments leave state unchanged. BEL, ESC-backslash, and decoded C1 framing are supported, including fragmented input and filtered serialization.
- RIS clears activity; ordinary screen changes preserve it. Disconnect/exit retain the last reported values rather than inventing completion.
- Browser callbacks receive the initial authoritative state and distinct presented changes; intermediate transitions may coalesce.
- This is a coordinated first-party wire update: HMP1 requires an `ActivityState` checkpoint after each StateSync, and HWT1 requires complete activity metadata on every frame.

## Validation

- 1,033 combined C# regressions passed, covering OSC parsing, existing tokenizer/title behavior, snapshots, copy mode, HMP/HWT, and placeholder/reconnect paths.
- 40 focused browser tests passed, plus NodeNext and bundler consumer type checks.
- Web-terminal and WebTerminalDemo builds passed.
- Real-browser activity and title fixtures passed through direct and relayed views, including late attachment, resync, and reconnect.
- Focused review findings around replay atomicity, failed replay publication, reentrant callbacks, wrapped checkpoints, and relay peer identity are addressed.

Closes #519.

Producer-side convenience APIs for reporting OSC 9;4/OSC 133 from `Hex1bApp` require separate API design and are tracked in #520.