### PR TITLE
Fix web terminal reflow and improve demo resizing

### DIFF
--- a/docs/web-terminal.md
+++ b/docs/web-terminal.md
@@ -134,12 +134,20 @@ attached HWT1 adapters. Prefer an explicit strategy for a remote producer;
 parameterless builder `WithReflow()` auto-detects the *server's* environment,
 which need not describe the browser terminal. `NoReflowStrategy.Instance`
 selects crop behavior explicitly.
+Crop paths erase wide glyphs split at the right edge, preserving valid cell
+geometry for later screen replay instead of retaining an orphaned half glyph.
 
 For a directly attached `Hwt1PresentationAdapter`, the same
 `.WithReflow(GhosttyReflowStrategy.Instance)` opt-in applies. For views returned
 by `CreateBrowserViewAsync`, configure the **HMP1 producer only**; a view's
 reflow setting cannot override its producer. No browser configuration, transport
 replacement, or second ANSI model is required.
+
+The demo's optional HMP1 relay builds a terminal replica rather than a direct
+browser view. It explicitly gives that replica the producer's reflow provider,
+preserving the strategy and internal graphics-anchor mapping. HMP1 screen replay
+preserves soft line breaks, but the protocol does not negotiate a reflow strategy:
+hosts of other replicas must configure matching policies themselves.
 
 Ghostty reflow preserves hard line breaks while rewrapping soft continuations,
 including retained scrollback, styled and wide/combining text, and cursor and
@@ -158,8 +166,13 @@ Primary-peer resize authority, graphics ownership/anchor remapping, and HWT1
 frame refresh are unchanged. Resize/reflow invalidates existing selections
 rather than trying to preserve stale coordinates.
 
-WebTerminalDemo explicitly enables this policy for its **shell** scene only.
-Its generated text/graphics scenes and other adapter defaults are unchanged.
+WebTerminalDemo's **New terminal reflow** selector defaults to this policy for
+its **shell** scene and cropping for generated text/graphics scenes. Select a
+different built-in strategy before creating a terminal to compare behaviors;
+the choice is fixed for that producer and shared by every attached view.
+The sample reports the policy in its existing-terminal list and HTTP metadata.
+See [the demo's strategy selector](../samples/WebTerminalDemo/README.md#choose-a-reflow-strategy)
+for API and query-string options. Library adapter defaults are unchanged.
 Existing consumers must opt in after upgrading to a release containing this
 API; it is not available in 0.166.0. Upgrade `Hex1b` and
 `@hex1b/web-terminal` together to matching released versions.

--- a/docs/web-terminal.md
+++ b/docs/web-terminal.md
@@ -111,6 +111,59 @@ all of those fixed responsibilities. A shared change-feed/projection cache
 remains a possible optimization; this milestone does not establish multi-view
 throughput.
 
+### Shell reflow configuration
+
+Reflow belongs to the authoritative producer, not the browser. The HMP1 and
+directly attached HWT1 presentation adapters retain their **crop-and-extend
+default** for compatibility. Enable normal shell reflow before constructing the
+terminal (configuration snippet):
+
+```csharp
+using Hex1b;
+using Hex1b.Reflow;
+
+var presentation = new Hmp1PresentationAdapter(80, 24)
+    .WithReflow(GhosttyReflowStrategy.Instance);
+// Assign presentation to Hex1bTerminalOptions.PresentationAdapter, or use
+// WithPresentation(presentation) on Hex1bTerminalBuilder.
+// Configure ScrollbackCapacity / WithScrollback(...) on the terminal as well.
+```
+
+`Hex1bTerminalBuilder.WithReflow(strategy)` also configures HMP1 and directly
+attached HWT1 adapters. Prefer an explicit strategy for a remote producer;
+parameterless builder `WithReflow()` auto-detects the *server's* environment,
+which need not describe the browser terminal. `NoReflowStrategy.Instance`
+selects crop behavior explicitly.
+
+For a directly attached `Hwt1PresentationAdapter`, the same
+`.WithReflow(GhosttyReflowStrategy.Instance)` opt-in applies. For views returned
+by `CreateBrowserViewAsync`, configure the **HMP1 producer only**; a view's
+reflow setting cannot override its producer. No browser configuration, transport
+replacement, or second ANSI model is required.
+
+Ghostty reflow preserves hard line breaks while rewrapping soft continuations,
+including retained scrollback, styled and wide/combining text, and cursor and
+saved-cursor insertion positions. Retention remains bounded by the configured
+scrollback capacity **in physical rows**: narrowing can evict the oldest rows
+when that limit is exceeded. Previously cropped or evicted text cannot be
+recovered by enabling reflow later. Alternate-screen layouts still crop on
+resize; the saved main screen and history reflow to the current dimensions when
+the application returns to the main screen.
+
+The browser's minimum requested width is 20 columns. Native HMP1 peers can
+request narrower grids; a glyph wider than the entire grid is dropped, matching
+the terminal's normal printing behavior at that width.
+
+Primary-peer resize authority, graphics ownership/anchor remapping, and HWT1
+frame refresh are unchanged. Resize/reflow invalidates existing selections
+rather than trying to preserve stale coordinates.
+
+WebTerminalDemo explicitly enables this policy for its **shell** scene only.
+Its generated text/graphics scenes and other adapter defaults are unchanged.
+Existing consumers must opt in after upgrading to a release containing this
+API; it is not available in 0.166.0. Upgrade `Hex1b` and
+`@hex1b/web-terminal` together to matching released versions.
+
 Multi-head testing also exposed a replay gap: a late viewer could repaint a
 KGP animation's current image but then remained frozen once the producer stopped
 writing bytes. HMP1 now replays all composed animation frames and playback

--- a/samples/WebTerminalDemo/CreateTerminalRequest.cs
+++ b/samples/WebTerminalDemo/CreateTerminalRequest.cs
@@ -1,3 +1,28 @@
+using Hex1b.Reflow;
+
 namespace WebTerminalDemo;
 
-internal sealed record CreateTerminalRequest(string Scene = "mixed", int Columns = 100, int Rows = 30, string? Name = null);
+internal sealed record CreateTerminalRequest(
+    string Scene = "mixed", int Columns = 100, int Rows = 30, string? Name = null,
+    DemoReflowStrategy ReflowStrategy = DemoReflowStrategy.Default)
+{
+    public DemoReflowStrategy ResolvedReflowStrategy => ReflowStrategy == DemoReflowStrategy.Default
+        ? Scene == "shell" ? DemoReflowStrategy.Ghostty : DemoReflowStrategy.None
+        : ReflowStrategy;
+
+    public ITerminalReflowProvider? GetReflowProvider() => ResolvedReflowStrategy switch
+    {
+        DemoReflowStrategy.None => null,
+        DemoReflowStrategy.Auto => AutoReflowStrategy.Instance,
+        DemoReflowStrategy.Alacritty => AlacrittyReflowStrategy.Instance,
+        DemoReflowStrategy.Foot => FootReflowStrategy.Instance,
+        DemoReflowStrategy.Ghostty => GhosttyReflowStrategy.Instance,
+        DemoReflowStrategy.ITerm2 => ITerm2ReflowStrategy.Instance,
+        DemoReflowStrategy.Kitty => KittyReflowStrategy.Instance,
+        DemoReflowStrategy.Vte => VteReflowStrategy.Instance,
+        DemoReflowStrategy.WezTerm => WezTermReflowStrategy.Instance,
+        DemoReflowStrategy.WindowsTerminal => WindowsTerminalReflowStrategy.Instance,
+        DemoReflowStrategy.Xterm => XtermReflowStrategy.Instance,
+        _ => throw new ArgumentOutOfRangeException(nameof(ReflowStrategy), ReflowStrategy, "Unknown reflow strategy.")
+    };
+}

--- a/samples/WebTerminalDemo/DemoReflowStrategy.cs
+++ b/samples/WebTerminalDemo/DemoReflowStrategy.cs
@@ -1,0 +1,20 @@
+using System.Text.Json.Serialization;
+
+namespace WebTerminalDemo;
+
+[JsonConverter(typeof(JsonStringEnumConverter<DemoReflowStrategy>))]
+internal enum DemoReflowStrategy
+{
+    Default,
+    None,
+    Auto,
+    Alacritty,
+    Foot,
+    Ghostty,
+    ITerm2,
+    Kitty,
+    Vte,
+    WezTerm,
+    WindowsTerminal,
+    Xterm
+}

--- a/samples/WebTerminalDemo/Hmp1BrowserView.cs
+++ b/samples/WebTerminalDemo/Hmp1BrowserView.cs
@@ -30,6 +30,8 @@ internal sealed class Hmp1BrowserView : IAsyncDisposable
         Hmp1PresentationAdapter producer, string? name, CancellationToken ct)
     {
         var view = new Hmp1BrowserView(name, ct);
+        if (producer.ReflowEnabled)
+            view.Presentation.WithReflow(producer);
         var connected = false;
         try
         {

--- a/samples/WebTerminalDemo/Program.cs
+++ b/samples/WebTerminalDemo/Program.cs
@@ -44,6 +44,8 @@ app.MapPost("/api/terminals", (CreateTerminalRequest request) =>
         return Results.BadRequest(new { error = "columns must be 20..300 and rows must be 10..100." });
     if (!IsValidName(request.Name))
         return Results.BadRequest(new { error = "name must contain 1..80 printable characters when supplied." });
+    if (!Enum.IsDefined(request.ReflowStrategy))
+        return Results.BadRequest(new { error = "reflowStrategy must identify a supported reflow strategy." });
     try
     {
         var instance = terminals.Create(request);

--- a/samples/WebTerminalDemo/README.md
+++ b/samples/WebTerminalDemo/README.md
@@ -170,6 +170,7 @@ origin:
 | `fonts.browser.js` | Real font-rendered borders at five raster scales, Nerd Font symbols, delayed worker font readiness, per-view font selection, and font-load failure cleanup. |
 | `sizing.browser.js` | Auto font-size controls, fixed-grid presets, keyboard selection, resize authority, and retained sizing policy across primary handoff. |
 | `floating.browser.js` | Real workers/WebSockets/HMP1, dragging, primary-only resize, takeover, detach/reattach, and independent instances. |
+| `resize-handles.browser.js` | Eight-direction window resizing, proximity highlights, pointer capture/cancellation, size/origin limits, and primary versus secondary/fixed-grid sizing. |
 | `lifecycle.browser.js` | Closure overlays, native close details before/after mounting, rejected upgrades, local initialization failures, explicit reconnect, per-view isolation, and owner completion through direct/relay transports. |
 | `input.browser.js` | Real POSIX shell input, Backspace, history, paste, MouseTest, thumbnail coordinates, and window-chrome focus. Build `samples/MouseTest` in Release first. |
 | `tapes.browser.js` | Scene-filtered tapes in an existing shell, shared-view output, retained identity/geometry, overlap rejection, cancellation, visible failures, and shutdown cleanup. |
@@ -206,6 +207,12 @@ fixtures remain focused, explicitly invoked checks; they are not a claim of
 broad HMP graphics/performance stability or a browser/device compatibility matrix.
 
 ## Shared instances and floating views
+
+Drag a window's title bar to move it. Resize from any of its four edges or four
+corners: each bar highlights as the pointer approaches the border, shows the
+appropriate resize cursor, and stays highlighted while dragging. Top and left
+handles keep the opposite edge fixed, stopping at the workspace origin; all
+handles respect the window's 240×180 minimum and 3200×2200 maximum size.
 
 - **New terminal** creates a persistent producer, initially 100×30, and mounts a
   view that explicitly requests primary.

--- a/samples/WebTerminalDemo/README.md
+++ b/samples/WebTerminalDemo/README.md
@@ -45,6 +45,16 @@ with your privileges. Do not put this sample behind a reverse proxy or expose
 it to other users.** Closing a view does not stop its terminal: use **End terminal**
 to terminate the shared workload explicitly.
 
+The **Interactive shell** scene enables
+`Hmp1PresentationAdapter.WithReflow(GhosttyReflowStrategy.Instance)` on its
+shared producer. Narrowing wraps shell output and widening rejoins soft wraps;
+hard newlines remain separate. Retained history participates, subject to the
+sample's 1,000-physical-row scrollback limit. Alternate-screen applications
+still use crop/redraw semantics; their saved main screen reflows on return.
+Selections are invalidated by resize. Generated text/graphics scenes retain
+crop behavior. The library's adapter defaults have not changed: consumers must
+[opt in on their producer](../../docs/web-terminal.md#shell-reflow-configuration).
+
 ## Play a scenario tape
 
 Create an **Interactive shell** terminal, or select one under **Existing terminal**.
@@ -129,6 +139,7 @@ origin:
 | `tapes.browser.js` | Scene-filtered tapes in an existing shell, shared-view output, retained identity/geometry, overlap rejection, cancellation, visible failures, and shutdown cleanup. |
 | `hyperlinks.browser.js` | Real OSC 8 output through HWT1 and the worker, Ctrl/Cmd activation, safe new tabs, selection/capture isolation, read-only thumbnails, destination updates, and scrollback. |
 | `history.browser.js` | Shared producer history, independent viewports, character/word/logical-line/block selection, held/released wheel scrolling, clipboard intent, capture override, read-only inspection, and eviction. Clipboard writes are intercepted rather than changing the user's clipboard. |
+| `reflow.browser.js` | Real shell output and retained history through repeated shrink/grow cycles, hard/soft breaks, wide/combining text, primary-only resize, selection invalidation, and editing a pending shell command. |
 | `bindings.browser.js` | Per-view input overrides, named actions, Windows-style right-click copy/paste, clipboard failures/races, capture ownership, and native text/paste/IME paths. Clipboard access is mocked. |
 | `selection-ui.browser.js` | Default, augmented, and replaced selection controls; host CSS, highlight parts, canvas alignment, focus/input isolation, action reuse, UI errors, and disposal. |
 | `graphics.browser.js` | Sixel and KGP in mixed WebGPU/WebGL2 views, renderer controls/diagnostics, cached-image movement, and late attachment to silent server-driven animation. |

--- a/samples/WebTerminalDemo/README.md
+++ b/samples/WebTerminalDemo/README.md
@@ -45,7 +45,7 @@ with your privileges. Do not put this sample behind a reverse proxy or expose
 it to other users.** Closing a view does not stop its terminal: use **End terminal**
 to terminate the shared workload explicitly.
 
-The **Interactive shell** scene enables
+By default, the **Interactive shell** scene enables
 `Hmp1PresentationAdapter.WithReflow(GhosttyReflowStrategy.Instance)` on its
 shared producer. Narrowing wraps shell output and widening rejoins soft wraps;
 hard newlines remain separate. Retained history participates, subject to the
@@ -54,6 +54,42 @@ still use crop/redraw semantics; their saved main screen reflows on return.
 Selections are invalidated by resize. Generated text/graphics scenes retain
 crop behavior. The library's adapter defaults have not changed: consumers must
 [opt in on their producer](../../docs/web-terminal.md#shell-reflow-configuration).
+
+## Choose a reflow strategy
+
+Use **New terminal reflow** before clicking **New terminal** to compare the
+built-in strategies without editing sample code. **Default** preserves the
+scene policy above. You can explicitly select Ghostty, VTE, Kitty, WezTerm,
+Alacritty, Windows Terminal, Foot, iTerm2, xterm, or **None (crop)**.
+The iTerm2 and xterm strategies currently use crop behavior in Hex1b.
+Cropping erases a wide glyph split by the right edge rather than retaining an
+unpaired lead cell that would wrap incorrectly during replay.
+**Auto (server environment)** detects the server's terminal environment, not
+the browser; use a named strategy for reproducible comparisons.
+
+The selection is applied once to the shared HMP1 producer during creation.
+Changing the picker or attaching another view does not change an existing
+terminal. The **Existing terminal** list shows each instance's reflow policy,
+with Default resolved to Ghostty or None.
+
+Both **Direct HWT1** and **HMP1 relay -> HWT1** honor the selection. Each demo
+relay replica inherits its producer's reflow provider, including graphics-anchor
+mapping; only the primary peer can resize the shared terminal. HMP1 does not
+negotiate a reflow strategy with arbitrary remote consumers, so other hosts that
+build terminal replicas must configure matching producer and replica policies.
+
+For a repeatable experiment, open `/?scene=shell&reflow=Vte`; the `reflow`
+query parameter uses the option values shown below and requests a new terminal
+unless `empty=1` is also supplied. The HTTP creation API accepts the same choice:
+
+```json
+{"scene":"shell","columns":80,"rows":24,"reflowStrategy":"Vte"}
+```
+
+Valid values are `Default`, `None`, `Auto`, `Alacritty`, `Foot`, `Ghostty`,
+`ITerm2`, `Kitty`, `Vte`, `WezTerm`, `WindowsTerminal`, and `Xterm`.
+Omitting `reflowStrategy` uses Default; unknown values are rejected with HTTP
+400. Creation responses and `GET /api/terminals` include `reflowStrategy`.
 
 ## Play a scenario tape
 
@@ -140,6 +176,7 @@ origin:
 | `hyperlinks.browser.js` | Real OSC 8 output through HWT1 and the worker, Ctrl/Cmd activation, safe new tabs, selection/capture isolation, read-only thumbnails, destination updates, and scrollback. |
 | `history.browser.js` | Shared producer history, independent viewports, character/word/logical-line/block selection, held/released wheel scrolling, clipboard intent, capture override, read-only inspection, and eviction. Clipboard writes are intercepted rather than changing the user's clipboard. |
 | `reflow.browser.js` | Real shell output and retained history through repeated shrink/grow cycles, hard/soft breaks, wide/combining text, primary-only resize, selection invalidation, and editing a pending shell command. |
+| `reflow-options.browser.js` | Creation-time strategy selection through the playground and HTTP API, preserved defaults, shared-instance policy, and real shell crop versus reflow through direct and relay views. |
 | `bindings.browser.js` | Per-view input overrides, named actions, Windows-style right-click copy/paste, clipboard failures/races, capture ownership, and native text/paste/IME paths. Clipboard access is mocked. |
 | `selection-ui.browser.js` | Default, augmented, and replaced selection controls; host CSS, highlight parts, canvas alignment, focus/input isolation, action reuse, UI errors, and disposal. |
 | `graphics.browser.js` | Sixel and KGP in mixed WebGPU/WebGL2 views, renderer controls/diagnostics, cached-image movement, and late attachment to silent server-driven animation. |
@@ -297,6 +334,8 @@ bounded in-memory duplex pipes. This uses the real HMP1 handshake, state/image
 replay, live output, input, and primary/resize messages without requiring a
 socket or another process. Closing the view disposes its peer and replica, not
 the shared producer. Attaching again or reloading creates a new replica.
+Initial screen replay preserves hard breaks and soft continuations, including
+wide-character wrap padding, so already-wrapped output can reflow after attaching.
 
 The selector applies to newly opened views, including thumbnails. Existing
 views retain their transport; their title and selected-view metrics show it.

--- a/samples/WebTerminalDemo/TerminalInstance.cs
+++ b/samples/WebTerminalDemo/TerminalInstance.cs
@@ -1,4 +1,5 @@
 using Hex1b;
+using Hex1b.Reflow;
 using Microsoft.Extensions.Logging;
 
 namespace WebTerminalDemo;
@@ -34,6 +35,8 @@ internal sealed class TerminalInstance
         _stop = new CancellationTokenSource();
         Stopping = _stop.Token;
         Presentation = new Hmp1PresentationAdapter(request.Columns, request.Rows);
+        if (_scene == "shell")
+            Presentation.WithReflow(GhosttyReflowStrategy.Instance);
         _demo = _scene == "shell" ? null : new DemoWorkload(_scene, request.Columns, request.Rows);
         var child = _demo is null ? new Hex1bTerminalChildProcess(
             OperatingSystem.IsWindows() ? "cmd.exe" : Environment.GetEnvironmentVariable("SHELL") ?? "/bin/sh",

--- a/samples/WebTerminalDemo/TerminalInstance.cs
+++ b/samples/WebTerminalDemo/TerminalInstance.cs
@@ -1,5 +1,4 @@
 using Hex1b;
-using Hex1b.Reflow;
 using Microsoft.Extensions.Logging;
 
 namespace WebTerminalDemo;
@@ -18,6 +17,7 @@ internal sealed class TerminalInstance
     private readonly Action<TerminalInstance> _onCompleted;
     private readonly string _name;
     private readonly string _scene;
+    private readonly DemoReflowStrategy _reflowStrategy;
     private readonly DateTimeOffset _createdAt = DateTimeOffset.UtcNow;
     private Task _completion = Task.CompletedTask;
     private bool _stopping;
@@ -28,6 +28,7 @@ internal sealed class TerminalInstance
     {
         Id = Guid.NewGuid().ToString("N");
         _scene = request.Scene;
+        _reflowStrategy = request.ResolvedReflowStrategy;
         _tapes = tapeCatalog.ForScene(_scene);
         _name = request.Name?.Trim() ?? $"{char.ToUpperInvariant(_scene[0])}{_scene[1..]} {Id[..6]}";
         _logger = logger;
@@ -35,8 +36,8 @@ internal sealed class TerminalInstance
         _stop = new CancellationTokenSource();
         Stopping = _stop.Token;
         Presentation = new Hmp1PresentationAdapter(request.Columns, request.Rows);
-        if (_scene == "shell")
-            Presentation.WithReflow(GhosttyReflowStrategy.Instance);
+        if (request.GetReflowProvider() is { } reflow)
+            Presentation.WithReflow(reflow);
         _demo = _scene == "shell" ? null : new DemoWorkload(_scene, request.Columns, request.Rows);
         var child = _demo is null ? new Hex1bTerminalChildProcess(
             OperatingSystem.IsWindows() ? "cmd.exe" : Environment.GetEnvironmentVariable("SHELL") ?? "/bin/sh",
@@ -79,7 +80,7 @@ internal sealed class TerminalInstance
             return new(Id, _name, _scene, Presentation.Width, Presentation.Height,
                 Presentation.ClientCount, Presentation.PrimaryPeerId, _createdAt,
                 _demo?.Paused, _demo?.Rate, _demo?.Batch,
-                _tapes.Select(tape => tape.Info).ToArray(), _tapePlayback.Status);
+                _tapes.Select(tape => tape.Info).ToArray(), _tapePlayback.Status, _reflowStrategy);
     }
 
     public void Start() => _completion = Task.Run(RunLifetimeAsync);

--- a/samples/WebTerminalDemo/TerminalInstanceInfo.cs
+++ b/samples/WebTerminalDemo/TerminalInstanceInfo.cs
@@ -4,4 +4,4 @@ internal sealed record TerminalInstanceInfo(
     string Id, string Name, string Scene, int Columns, int Rows,
     int PeerCount, string? PrimaryPeerId, DateTimeOffset CreatedAt,
     bool? Paused, int? Rate, int? Batch,
-    IReadOnlyList<DemoTapeInfo> Tapes, TerminalTapeStatus? TapePlayback);
+    IReadOnlyList<DemoTapeInfo> Tapes, TerminalTapeStatus? TapePlayback, DemoReflowStrategy ReflowStrategy);

--- a/samples/WebTerminalDemo/client/main.ts
+++ b/samples/WebTerminalDemo/client/main.ts
@@ -4,6 +4,7 @@ interface TerminalInstance {
   id: string;
   name: string;
   scene: string;
+  reflowStrategy: string;
   columns: number;
   rows: number;
   peerCount: number;
@@ -111,6 +112,7 @@ function readInstance(value: unknown): TerminalInstance {
       !("id" in value) || typeof value.id !== "string" ||
       !("name" in value) || typeof value.name !== "string" ||
       !("scene" in value) || typeof value.scene !== "string" ||
+      !("reflowStrategy" in value) || typeof value.reflowStrategy !== "string" ||
       !("columns" in value) || typeof value.columns !== "number" ||
       !("rows" in value) || typeof value.rows !== "number" ||
       !("peerCount" in value) || typeof value.peerCount !== "number" ||
@@ -122,7 +124,7 @@ function readInstance(value: unknown): TerminalInstance {
     throw new Error("The server returned an invalid terminal instance");
   }
   return {
-    id: value.id, name: value.name, scene: value.scene,
+    id: value.id, name: value.name, scene: value.scene, reflowStrategy: value.reflowStrategy,
     columns: value.columns, rows: value.rows, peerCount: value.peerCount,
     paused: value.paused, rate: value.rate, batch: value.batch,
     tapes: value.tapes.map(readTape), tapePlayback: readTapePlayback(value.tapePlayback)
@@ -269,7 +271,7 @@ async function loadInstances(preferred?: string) {
   instancesSelect.replaceChildren(...instances.map(instance => {
     const option = document.createElement("option");
     option.value = instance.id;
-    option.textContent = `${instance.name} - ${instance.columns}x${instance.rows}, ${instance.peerCount} peers`;
+    option.textContent = `${instance.name} - ${instance.columns}x${instance.rows}, ${instance.peerCount} peers, reflow: ${instance.reflowStrategy}`;
     return option;
   }));
   if (instances.some(instance => instance.id === selectedId)) instancesSelect.value = selectedId;
@@ -718,7 +720,9 @@ async function mountView(view: TerminalView, primary = false, failure = "", focu
 }
 
 async function createInstance() {
-  const instance = readInstance(await api("/api/terminals", "POST", { scene: select("scene").value, columns: 100, rows: 30 }));
+  const instance = readInstance(await api("/api/terminals", "POST", {
+    scene: select("scene").value, columns: 100, rows: 30, reflowStrategy: select("reflow-strategy").value
+  }));
   await refreshInstances(instance.id);
   await openView(instance, { primary: true });
 }
@@ -785,11 +789,17 @@ try {
   const scene = parameters.get("scene");
   const requestedScene = scene !== null && [...select("scene").options].some(option => option.value === scene);
   if (requestedScene) select("scene").value = scene;
+  const reflow = parameters.get("reflow");
+  if (reflow !== null) {
+    if (![...select("reflow-strategy").options].some(option => option.value === reflow))
+      throw new Error("Invalid reflow query parameter");
+    select("reflow-strategy").value = reflow;
+  }
   const scale = parameters.get("scale");
   if (scale !== null && [...select("scale").options].some(option => option.value === scale)) select("scale").value = scale;
   await refreshInstances();
   if (parameters.get("empty") !== "1") {
-    if (instances.length && !requestedScene) await openView(instances[0]);
+    if (instances.length && !requestedScene && reflow === null) await openView(instances[0]);
     else await createInstance();
   }
 } catch (error) {

--- a/samples/WebTerminalDemo/client/main.ts
+++ b/samples/WebTerminalDemo/client/main.ts
@@ -80,6 +80,10 @@ const instancesSelect = select("instances");
 const views = new Map<string, TerminalView>();
 const tapeSelections = new Map<string, string>();
 const pendingTapeActions = new Set<string>();
+const resizeEdges = {
+  n: "top", ne: "top-right", e: "right", se: "bottom-right",
+  s: "bottom", sw: "bottom-left", w: "left", nw: "top-left"
+};
 let instances: TerminalInstance[] = [];
 let selected: TerminalView | undefined;
 let nextView = 0;
@@ -402,30 +406,51 @@ function changeSizing(view: TerminalView, sizing: Parameters<WebTerminal["setSiz
 
 function moveAndResize(view: TerminalView) {
   const signal = view.controller.signal;
-  const handles: [HTMLElement, boolean][] = [
-    [elementAt(view.element, ".view-titlebar", HTMLElement), false],
-    [elementAt(view.element, ".resize-handle", HTMLElement), true]
+  const handles: [HTMLElement, string | null][] = [
+    [elementAt(view.element, ".view-titlebar", HTMLElement), null],
+    ...Object.keys(resizeEdges).map((edge): [HTMLElement, string] =>
+      [elementAt(view.element, `.resize-handle[data-edge="${edge}"]`, HTMLElement), edge])
   ];
-  for (const [handle, resize] of handles) {
-    let gesture: { pointer: number; x: number; y: number; left: number; top: number; width: number; height: number } | undefined;
+  let activePointer: number | undefined;
+  for (const [handle, edge] of handles) {
+    let gesture: {
+      pointer: number; x: number; y: number; left: number; top: number;
+      width: number; height: number; scrollLeft: number; scrollTop: number
+    } | undefined;
     handle.addEventListener("pointerdown", event => {
-      if (event.button !== 0 || event.target instanceof Element && event.target.closest("button")) return;
+      if (activePointer !== undefined || event.button !== 0 ||
+          event.target instanceof Element && event.target.closest("button")) return;
       event.preventDefault();
       selectView(view);
       gesture = {
         pointer: event.pointerId, x: event.clientX, y: event.clientY,
         left: view.element.offsetLeft, top: view.element.offsetTop,
-        width: view.element.offsetWidth, height: view.element.offsetHeight
+        width: view.element.offsetWidth, height: view.element.offsetHeight,
+        scrollLeft: workspace.scrollLeft, scrollTop: workspace.scrollTop
       };
+      activePointer = event.pointerId;
+      handle.dataset.active = "true";
       handle.setPointerCapture(event.pointerId);
     }, { signal });
     handle.addEventListener("pointermove", event => {
       if (!gesture || gesture.pointer !== event.pointerId) return;
-      const dx = event.clientX - gesture.x;
-      const dy = event.clientY - gesture.y;
-      if (resize) {
-        view.element.style.width = `${Math.max(240, Math.min(3200, gesture.width + dx))}px`;
-        view.element.style.height = `${Math.max(180, Math.min(2200, gesture.height + dy))}px`;
+      const dx = event.clientX - gesture.x + workspace.scrollLeft - gesture.scrollLeft;
+      const dy = event.clientY - gesture.y + workspace.scrollTop - gesture.scrollTop;
+      if (edge) {
+        if (edge.includes("e") || edge.includes("w")) {
+          const west = edge.includes("w");
+          const width = Math.max(240, Math.min(west ? Math.min(3200, gesture.left + gesture.width) : 3200,
+            gesture.width + (west ? -dx : dx)));
+          view.element.style.width = `${width}px`;
+          if (west) view.element.style.left = `${gesture.left + gesture.width - width}px`;
+        }
+        if (edge.includes("n") || edge.includes("s")) {
+          const north = edge.includes("n");
+          const height = Math.max(180, Math.min(north ? Math.min(2200, gesture.top + gesture.height) : 2200,
+            gesture.height + (north ? -dy : dy)));
+          view.element.style.height = `${height}px`;
+          if (north) view.element.style.top = `${gesture.top + gesture.height - height}px`;
+        }
       } else {
         view.element.style.left = `${Math.max(0, gesture.left + dx)}px`;
         view.element.style.top = `${Math.max(0, gesture.top + dy)}px`;
@@ -434,11 +459,13 @@ function moveAndResize(view: TerminalView) {
     const end = (event: PointerEvent) => {
       if (!gesture || gesture.pointer !== event.pointerId) return;
       gesture = undefined;
+      activePointer = undefined;
+      delete handle.dataset.active;
       if (handle.hasPointerCapture(event.pointerId)) handle.releasePointerCapture(event.pointerId);
     };
     handle.addEventListener("pointerup", end, { signal });
     handle.addEventListener("pointercancel", end, { signal });
-    handle.addEventListener("lostpointercapture", () => { gesture = undefined; }, { signal });
+    handle.addEventListener("lostpointercapture", end, { signal });
   }
 }
 
@@ -530,7 +557,8 @@ async function openView(instance: TerminalInstance, { primary = false, thumbnail
         <option value="custom" hidden>Custom</option>
       </select>
     </footer>
-    <span class="resize-handle" title="Drag to resize view" aria-hidden="true"></span>`;
+    ${Object.entries(resizeEdges).map(([edge, label]) =>
+      `<span class="resize-handle" data-edge="${edge}" title="Drag ${label} to resize view" aria-hidden="true"></span>`).join("")}`;
   const header = elementAt(element, ".view-title", HTMLElement);
   const fallbackTitle = `${instance.name} / ${id} / ${transport === "hmp1" ? "HMP1 relay" : "Direct HWT1"}`;
   header.textContent = fallbackTitle;

--- a/samples/WebTerminalDemo/tests/floating.browser.js
+++ b/samples/WebTerminalDemo/tests/floating.browser.js
@@ -68,7 +68,7 @@ async page => {
       headers: { Origin: origin }, data: { paused: true }
     });
     const original = await authoritative(instanceId);
-    const secondaryHandle = await second.locator(".resize-handle").boundingBox();
+    const secondaryHandle = await second.locator('.resize-handle[data-edge="se"]').boundingBox();
     const resizeBefore = sent.filter(command => command.type === "resize").length;
     await test.mouse.move(secondaryHandle.x + 5, secondaryHandle.y + 5);
     await test.mouse.down();
@@ -93,7 +93,7 @@ async page => {
     const thumbnailSizes = [];
     for (const [width, height] of [[600, 180], [240, 180], [240, 500], [restoredSize.width, restoredSize.height]]) {
       const box = await second.boundingBox();
-      const handle = await second.locator(".resize-handle").boundingBox();
+      const handle = await second.locator('.resize-handle[data-edge="se"]').boundingBox();
       await test.mouse.move(handle.x + 5, handle.y + 5);
       await test.mouse.down();
       await test.mouse.move(handle.x + 5 + width - box.width, handle.y + 5 + height - box.height, { steps: 8 });
@@ -118,7 +118,7 @@ async page => {
     check(sent.filter(command => command.type === "resize").length === resizeBefore, "Shrinking a thumbnail emitted resize");
 
     await first.locator(".view-title").click();
-    const primaryHandle = await first.locator(".resize-handle").boundingBox();
+    const primaryHandle = await first.locator('.resize-handle[data-edge="se"]').boundingBox();
     await test.mouse.move(primaryHandle.x + 5, primaryHandle.y + 5);
     await test.mouse.down();
     await test.mouse.move(primaryHandle.x - 195, primaryHandle.y - 95, { steps: 10 });

--- a/samples/WebTerminalDemo/tests/reflow-options.browser.js
+++ b/samples/WebTerminalDemo/tests/reflow-options.browser.js
@@ -1,0 +1,285 @@
+async page => {
+  const origin = page.url().match(/^https?:\/\/[^/]+/)?.[0];
+  if (!origin) throw new Error("Navigate to the running WebTerminalDemo before invoking this fixture.");
+  const context = await page.context().browser().newContext({ viewport: { width: 1600, height: 1100 } });
+  const test = await context.newPage();
+  const instances = new Set();
+  const errors = [];
+  const sockets = [];
+  const results = [];
+  const strategies = ["Default", "None", "Auto", "Alacritty", "Foot", "Ghostty", "ITerm2",
+    "Kitty", "Vte", "WezTerm", "WindowsTerminal", "Xterm"];
+  let stage = "API options";
+  test.on("pageerror", error => errors.push(error.message));
+  test.on("websocket", socket => sockets.push(socket.url()));
+  const check = (condition, message) => { if (!condition) throw new Error(message); };
+  const list = async () => {
+    const response = await test.request.get(`${origin}/api/terminals`);
+    check(response.ok(), `Listing terminals failed: ${response.status()}`);
+    return response.json();
+  };
+  const remove = async id => {
+    const response = await test.request.delete(`${origin}/api/terminals/${id}`, { headers: { Origin: origin } });
+    check(response.status() === 204, `Deleting ${id} failed: ${response.status()}`);
+    instances.delete(id);
+  };
+  const create = async data => {
+    const response = await test.request.post(`${origin}/api/terminals`, {
+      headers: { Origin: origin }, data: { scene: "text", columns: 80, rows: 24, ...data }
+    });
+    check(response.status() === 201, `Creation failed: ${response.status()} ${await response.text()}`);
+    const instance = await response.json();
+    instances.add(instance.id);
+    return instance;
+  };
+  const waitViews = async (id, count) => test.waitForFunction(({ id, count }) => {
+    const views = [...webTerminalViews.values()].filter(view => view.instance.id === id);
+    return views.length === count && views.every(view => view.terminal?.connected && view.stats.gpu === "ready");
+  }, { id, count }, { timeout: 30000 });
+  const state = async () => test.evaluate(() => [...(window.webTerminalViews?.values() ?? [])].map(view => ({
+    id: view.id, instance: view.instance, transport: view.transport, text: view.terminal?.screenText,
+    geometry: view.terminal?.geometry, peer: view.terminal?.peer, stats: view.terminal?.stats,
+    selection: view.terminal?.selection
+  })));
+  const resize = async columns => {
+    await test.evaluate(columns => [...webTerminalViews.values()].find(view => view.terminal.peer.isPrimary)
+      .terminal.setSizing({ mode: "fixed", columns, rows: 24 }), columns);
+    await test.waitForFunction(columns => [...webTerminalViews.values()].every(view =>
+      view.terminal.geometry.columns === columns && view.terminal.stats.columns === columns &&
+      view.terminal.geometry.rows === 24), columns);
+  };
+  const shell = async (command, marker) => {
+    await test.evaluate(() => [...webTerminalViews.values()].find(view => view.terminal.peer.isPrimary).terminal.focus());
+    await test.keyboard.type(command);
+    await test.keyboard.press("Enter");
+    await test.waitForFunction(marker => {
+      const terminal = [...webTerminalViews.values()].find(view => view.terminal.peer.isPrimary).terminal;
+      return terminal.screenText.split("\n").some(row => row.trimEnd() === marker) &&
+        terminal.screenText.trimEnd().endsWith("OPT>");
+    }, marker, { timeout: 30000 });
+  };
+  const lines = ["__OPT_BEGIN__", `SHORT_${"0123456789".repeat(5)}_END`,
+    `WRAPPED_${"abcdefghij".repeat(10)}_END`, `UNI_${"界e\u0301".repeat(36)}_END!`,
+    "HARD_BOUNDARY", "__OPT_END__"];
+  const graphemes = line => [...new Intl.Segmenter("en", { granularity: "grapheme" }).segment(line)]
+    .map(item => item.segment);
+  const wrap = columns => lines.flatMap(line => {
+    const rows = [];
+    let row = "", width = 0;
+    for (const segment of graphemes(line)) {
+      const cells = segment === "界" ? 2 : 1;
+      if (width + cells > columns) { rows.push(row); row = ""; width = 0; }
+      row += segment;
+      width += cells;
+    }
+    rows.push(row);
+    return rows;
+  });
+  const crop = (line, columns) => {
+    let row = "", width = 0;
+    for (const segment of graphemes(line)) {
+      const cells = segment === "界" ? 2 : 1;
+      if (width + cells > columns) break;
+      row += segment;
+      width += cells;
+    }
+    return row;
+  };
+  const assertLogicalSelections = async () => {
+    for (const view of await state()) {
+      await test.evaluate(id => webTerminalViews.get(id).terminal.focus(), view.id);
+      for (const prefix of ["WRAPPED_", "UNI_"]) {
+        const expected = lines.find(line => line.startsWith(prefix));
+        const point = await test.evaluate(({ id, prefix }) => {
+          const terminal = webTerminalViews.get(id).terminal;
+          const row = terminal.screenText.split("\n").findIndex(line => line.startsWith(prefix));
+          if (row < 0) throw new Error(`Missing logical-line prefix ${prefix}`);
+          const rect = terminal.element.shadowRoot.querySelector("canvas").getBoundingClientRect();
+          return { x: rect.x + 2.5 * rect.width / terminal.geometry.columns,
+            y: rect.y + (row + .5) * rect.height / terminal.geometry.rows };
+        }, { id: view.id, prefix });
+        await test.mouse.click(point.x, point.y, { clickCount: 3 });
+        await test.waitForFunction(id => webTerminalViews.get(id).terminal.selection.status === "valid", view.id);
+        const selection = await test.evaluate(id => webTerminalViews.get(id).terminal.selection, view.id);
+        check(selection.mode === "line" && selection.text?.trimEnd() === expected,
+          `Logical selection ${view.transport} view ${view.id} ${prefix}: expected ${JSON.stringify(expected)} ` +
+          `(${expected.length} UTF-16 units), actual ${JSON.stringify(selection.text)} (${selection.text?.trimEnd().length})`);
+      }
+    }
+  };
+  const assertRows = async expected => {
+    const views = await state();
+    for (const view of views) {
+      const actual = view.text.split("\n").map(row => row.trimEnd());
+      const start = actual.indexOf("__OPT_BEGIN__");
+      check(start >= 0 && JSON.stringify(actual.slice(start, start + expected.length)) === JSON.stringify(expected),
+        `View ${view.id}: expected ${JSON.stringify(expected)}, actual ${JSON.stringify(actual)}`);
+    }
+  };
+  try {
+    await test.goto(`${origin}/health`);
+    for (const strategy of strategies) {
+      const instance = await create({ reflowStrategy: strategy });
+      const resolved = strategy === "Default" ? "None" : strategy;
+      check(instance.reflowStrategy === resolved, `POST resolved ${strategy} to ${instance.reflowStrategy}`);
+      check((await list()).find(item => item.id === instance.id)?.reflowStrategy === resolved,
+        `GET did not preserve ${strategy}`);
+      await remove(instance.id);
+    }
+    for (const scene of ["shell", "text"]) {
+      const instance = await create({ scene });
+      const resolved = scene === "shell" ? "Ghostty" : "None";
+      check(instance.reflowStrategy === resolved &&
+        (await list()).find(item => item.id === instance.id)?.reflowStrategy === resolved,
+      `Omitted strategy resolved incorrectly for ${scene}`);
+      await remove(instance.id);
+    }
+    const explicitDefaultShell = await create({ scene: "shell", reflowStrategy: "Default" });
+    check(explicitDefaultShell.reflowStrategy === "Ghostty", "Explicit shell Default did not resolve to Ghostty");
+    await remove(explicitDefaultShell.id);
+    for (const invalid of ["NotAReflowStrategy", 999]) {
+      const before = (await list()).map(instance => instance.id).sort();
+      const response = await test.request.post(`${origin}/api/terminals`, {
+        headers: { Origin: origin }, data: { scene: "text", columns: 80, rows: 24, reflowStrategy: invalid }
+      });
+      check(response.status() === 400, `Invalid strategy ${invalid} returned ${response.status()}`);
+      check(JSON.stringify(before) === JSON.stringify((await list()).map(instance => instance.id).sort()),
+        `Invalid strategy ${invalid} created a producer`);
+    }
+    results.push({ apiStrategies: strategies, defaults: { shell: "Ghostty", text: "None" }, invalidValuesRejected: 2 });
+
+    stage = "query automatic creation does not attach unrelated producer";
+    const unrelated = await create({ reflowStrategy: "None" });
+    const automatic = test.waitForResponse(response => response.url() === `${origin}/api/terminals` &&
+      response.request().method() === "POST" && response.status() === 201);
+    await test.goto(`${origin}/?renderer=webgl2&reflow=Vte`);
+    const automaticResponse = await automatic;
+    const autoInstance = await automaticResponse.json();
+    instances.add(autoInstance.id);
+    check(autoInstance.id !== unrelated.id && autoInstance.reflowStrategy === "Vte" &&
+      automaticResponse.request().postDataJSON().reflowStrategy === "Vte",
+    "Reflow query attached an existing producer instead of creating the requested policy");
+    await waitViews(autoInstance.id, 1);
+    check((await state()).every(view => view.instance.id === autoInstance.id), "Automatic view attached unrelated producer");
+    await test.goto(`${origin}/health`);
+    await remove(autoInstance.id);
+    await remove(unrelated.id);
+
+    const scenarios = ["Vte", "None", "Ghostty"].flatMap(strategy =>
+      [["direct", "direct"], ["hmp1", "hmp1"], ["direct", "hmp1"], ["hmp1", "direct"]]
+        .map(([primaryTransport, secondaryTransport]) => ({ strategy, primaryTransport, secondaryTransport })));
+    for (const { strategy, primaryTransport, secondaryTransport } of scenarios) {
+      const scenario = `${strategy} primary=${primaryTransport} secondary=${secondaryTransport}`;
+      stage = `${scenario}: actual creation controls`;
+      await test.goto(`${origin}/?empty=1&scene=shell&renderer=webgl2&reflow=Vte`);
+      check(await test.locator("#scene").inputValue() === "shell" &&
+        await test.locator("#reflow-strategy").inputValue() === "Vte", "Query did not preselect creation controls");
+      const options = await test.locator("#reflow-strategy option").evaluateAll(options => options.map(option => option.value));
+      check(JSON.stringify([...options].sort()) === JSON.stringify([...strategies].sort()),
+        `Incorrect strategy dropdown: ${JSON.stringify(options)}`);
+      await test.locator("#reflow-strategy").selectOption(strategy);
+      await test.locator("#transport").selectOption(primaryTransport);
+      const created = test.waitForResponse(response => response.url() === `${origin}/api/terminals` &&
+        response.request().method() === "POST" && response.status() === 201);
+      await test.locator("#create").click();
+      const response = await created;
+      const instance = await response.json();
+      instances.add(instance.id);
+      check(response.request().postDataJSON().reflowStrategy === strategy && instance.reflowStrategy === strategy,
+        "New terminal did not send and resolve the selected policy");
+      await waitViews(instance.id, 1);
+      await test.waitForFunction(() => [...webTerminalViews.values()].some(view => view.terminal.peer.isPrimary));
+      check((await test.locator(`#instances option[value="${instance.id}"]`).textContent()).includes(`reflow: ${strategy}`),
+        "Existing-instance picker does not display the producer policy");
+      await test.locator(".view-resolution").selectOption("80x24");
+      await resize(80);
+      await test.waitForFunction(() => /[$#%>]$/.test([...webTerminalViews.values()][0].terminal.screenText.trimEnd()));
+      await shell("exec /usr/bin/env -i PATH=/usr/bin:/bin TERM=xterm-256color LC_ALL=en_US.UTF-8 PS1='OPT> ' /bin/bash --noprofile --norc -i", "OPT>");
+      await shell("stty -echo; printf '\\033[2J\\033[H__OPT_CLEAN__\\n'", "__OPT_CLEAN__");
+      await shell(`printf '\\033[2J\\033[H'; printf '%s\\n' '${lines.join("' '")}'`, "__OPT_END__");
+      await assertRows(wrap(80));
+
+      stage = `${scenario}: late Attach after soft wrapping ignores changed creation selector`;
+      await test.locator("#reflow-strategy").selectOption(strategy === "None" ? "Ghostty" : "None");
+      await test.locator("#transport").selectOption(secondaryTransport);
+      await test.locator("#instances").selectOption(instance.id);
+      await test.locator("#attach").click();
+      await waitViews(instance.id, 2);
+      await test.waitForFunction(() => {
+        const views = [...webTerminalViews.values()];
+        return views[0].terminal.screenText === views[1].terminal.screenText;
+      });
+      check((await list()).find(item => item.id === instance.id)?.reflowStrategy === strategy &&
+        (await state()).every(view => view.instance.id === instance.id && view.instance.reflowStrategy === strategy),
+      "Changing creation policy mutated the producer or the attached view");
+      check((await state()).filter(view => view.peer.isPrimary).length === 1, "Attach changed primary authority");
+      const attached = await state();
+      check(attached.find(view => view.peer.isPrimary)?.transport === primaryTransport &&
+        attached.find(view => !view.peer.isPrimary)?.transport === secondaryTransport,
+      "Transport picker did not apply independently to the primary and secondary views");
+      for (const transport of [primaryTransport, secondaryTransport])
+        check(sockets.some(url => url.includes(`instance=${instance.id}`) && url.includes(`transport=${transport}`)),
+          `Missing actual ${transport} WebSocket for producer ${instance.id}`);
+      await assertRows(wrap(80));
+      await assertLogicalSelections();
+      const cropped = wrap(80).map(row => crop(row, 20));
+      for (const columns of [20, 40, 80]) {
+        stage = `${scenario}: exact output after resize to ${columns}`;
+        await resize(columns);
+        await test.waitForFunction(() => {
+          const views = [...webTerminalViews.values()];
+          return views[0].terminal.screenText === views[1].terminal.screenText;
+        });
+        await assertRows(strategy === "None" ? cropped : wrap(columns));
+        if (strategy !== "None") await assertLogicalSelections();
+      }
+      stage = `${scenario}: reattach retains producer policy despite new picker value`;
+      const secondary = (await state()).find(view => !view.peer.isPrimary);
+      await test.locator(`.terminal-window[data-view="${secondary.id}"] .close-view`).click();
+      await waitViews(instance.id, 1);
+      await test.locator("#reflow-strategy").selectOption("Auto");
+      await test.locator("#attach").click();
+      await waitViews(instance.id, 2);
+      await test.waitForFunction(() => {
+        const views = [...webTerminalViews.values()];
+        return views[0].terminal.screenText === views[1].terminal.screenText;
+      });
+      check((await list()).find(item => item.id === instance.id)?.reflowStrategy === strategy &&
+        (await state()).every(view => view.instance.reflowStrategy === strategy),
+      "Reattachment applied the new creation policy to the existing producer");
+      check((await state()).find(view => !view.peer.isPrimary)?.peer.id !== secondary.peer.id,
+        "Reattachment reused the previous peer");
+      await assertRows(strategy === "None" ? cropped : wrap(80));
+      if (strategy !== "None") await assertLogicalSelections();
+      for (const columns of [20, 80]) {
+        stage = `${scenario}: reattached exact output after resize to ${columns}`;
+        await resize(columns);
+        await test.waitForFunction(() => {
+          const views = [...webTerminalViews.values()];
+          return views[0].terminal.screenText === views[1].terminal.screenText;
+        });
+        await assertRows(strategy === "None" ? cropped : wrap(columns));
+        if (strategy !== "None") await assertLogicalSelections();
+      }
+      check((await state()).every(view => view.stats.gpu === "ready" && view.stats.renderer === "webgl2" &&
+        view.stats.warnings.length === 0 && view.stats.discardedFrames === 0), "GPU worker diagnostics failed");
+      results.push({ strategy, primaryTransport, secondaryTransport, widths: [80, 20, 40, 80, 20, 80],
+        views: 2, lateAttach: true, reattached: true,
+        logicalSelection: ["ASCII soft wraps", "wide/combining soft wraps with geometric padding"],
+        behavior: strategy === "None" ? "crop remains after grow" : "exact text reflow preserved" });
+      await test.goto(`${origin}/health`);
+      await remove(instance.id);
+    }
+    check(errors.length === 0, `Browser errors: ${errors.join("; ")}`);
+    return { passed: true, results, automaticQueryCreatedNewProducer: true, browserErrors: errors };
+  } catch (error) {
+    throw new Error(`${stage}: ${error.message}; ${JSON.stringify(await state())}`);
+  } finally {
+    try {
+      for (const id of instances)
+        await test.request.delete(`${origin}/api/terminals/${id}`, { headers: { Origin: origin } });
+    } finally {
+      await context.close();
+    }
+  }
+}

--- a/samples/WebTerminalDemo/tests/reflow.browser.js
+++ b/samples/WebTerminalDemo/tests/reflow.browser.js
@@ -1,0 +1,190 @@
+async page => {
+  const origin = page.url().match(/^https?:\/\/[^/]+/)?.[0];
+  if (!origin) throw new Error("Navigate to the running WebTerminalDemo before invoking this fixture.");
+  const context = await page.context().browser().newContext({ viewport: { width: 1600, height: 1000 } });
+  const test = await context.newPage();
+  const errors = [];
+  const results = [];
+  let instanceId;
+  let stage = "starting real shell";
+  test.on("pageerror", error => errors.push(error.message));
+  const check = (condition, message) => { if (!condition) throw new Error(message); };
+  const state = () => test.evaluate(() => ({
+    text: window.reflowPrimary?.screenText, viewport: window.reflowPrimary?.viewport,
+    geometry: window.reflowPrimary?.geometry, stats: window.reflowPrimary?.stats,
+    secondary: window.reflowSecondary && {
+      text: reflowSecondary.screenText, viewport: reflowSecondary.viewport,
+      peer: reflowSecondary.peer, selection: reflowSecondary.selection
+    }
+  }));
+  const waitLive = async () => {
+    await test.evaluate(() => reflowPrimary.scrollToLive());
+    await test.waitForFunction(() => !reflowPrimary.viewport.pending && reflowPrimary.viewport.followTail);
+  };
+  const command = async (text, marker) => {
+    await test.evaluate(() => reflowPrimary.focus());
+    await test.keyboard.type(text);
+    await test.keyboard.press("Enter");
+    await test.waitForFunction(marker => reflowPrimary.screenText.split("\n").some(row => row.trimEnd() === marker) &&
+      reflowPrimary.screenText.trimEnd().endsWith("RF>"), marker, { timeout: 30000 });
+  };
+  const resize = async columns => {
+    await test.evaluate(columns => reflowPrimary.setSizing({ mode: "fixed", columns, rows: 24 }), columns);
+    await test.waitForFunction(columns => reflowPrimary.geometry.columns === columns &&
+      reflowPrimary.stats.columns === columns && !reflowPrimary.viewport.pending &&
+      (!window.reflowSecondary || reflowSecondary.geometry.columns === columns), columns);
+  };
+  const lines = [
+    "__RF_BEGIN__",
+    `SHORT_${"0123456789".repeat(5)}_END`,
+    `WRAPPED_${"abcdefghij".repeat(11)}_END`,
+    "HARD_BOUNDARY",
+    `WIDE_${"界e\u0301".repeat(10)}_END`,
+    "__RF_END__"
+  ];
+  const wrapped = (columns, source = lines) => source.flatMap(line => {
+    const rows = [];
+    let row = "", width = 0;
+    for (const { segment } of new Intl.Segmenter("en", { granularity: "grapheme" }).segment(line)) {
+      const cells = segment === "界" ? 2 : 1;
+      if (width + cells > columns) { rows.push(row); row = ""; width = 0; }
+      row += segment;
+      width += cells;
+    }
+    rows.push(row);
+    return rows;
+  });
+  const assertText = async columns => {
+    const actual = (await state()).text.split("\n").map(row => row.trimEnd());
+    const start = actual.indexOf("__RF_BEGIN__");
+    const expected = wrapped(columns);
+    check(start >= 0 && JSON.stringify(actual.slice(start, start + expected.length)) === JSON.stringify(expected),
+      `Exact ${columns}-column reflow mismatch: expected ${JSON.stringify(expected)}, actual ${JSON.stringify(actual)}`);
+    results.push({ columns, rows: expected.length });
+  };
+  const history = async () => {
+    await test.evaluate(() => reflowPrimary.scrollLines(-100000));
+    await test.waitForFunction(() => !reflowPrimary.viewport.pending && reflowPrimary.viewport.top === 0);
+    const rows = [];
+    for (let pageIndex = 0; pageIndex < 100; pageIndex++) {
+      const snapshot = await state();
+      for (const [index, row] of snapshot.text.split("\n").entries())
+        rows[snapshot.viewport.top + index] = row.trimEnd();
+      if (snapshot.viewport.top === snapshot.viewport.liveTop) return rows.slice(0, snapshot.viewport.totalRows);
+      await test.evaluate(() => reflowPrimary.scrollLines(24));
+      await test.waitForFunction(() => !reflowPrimary.viewport.pending);
+    }
+    throw new Error("History traversal exceeded 100 pages");
+  };
+  try {
+    await test.goto(`${origin}/health`);
+    const created = await test.request.post(`${origin}/api/terminals`, {
+      headers: { Origin: origin }, data: { scene: "shell", columns: 80, rows: 24, name: "Reflow browser regression" }
+    });
+    check(created.status() === 201, `Shell creation failed: ${created.status()}`);
+    instanceId = (await created.json()).id;
+    await test.evaluate(async id => {
+      const { WebTerminal } = await import("/web-terminal/index.js");
+      const layout = document.createElement("div");
+      layout.style.cssText = "display:flex;gap:20px";
+      for (const name of ["primary", "secondary"]) {
+        const host = document.createElement("div");
+        host.id = `reflow-${name}`;
+        host.style.cssText = "width:760px;height:480px;flex:none";
+        layout.append(host);
+      }
+      document.body.replaceChildren(layout);
+      window.reflowPrimary = await WebTerminal.mount(document.getElementById("reflow-primary"), {
+        url: `/ws?instance=${id}&name=ReflowPrimary`,
+        renderer: "webgl2", sizing: { mode: "fixed", columns: 80, rows: 24 }
+      });
+      reflowPrimary.requestPrimary();
+    }, instanceId);
+    await test.waitForFunction(() => reflowPrimary.peer.isPrimary && reflowPrimary.stats.gpu === "ready" &&
+      /[$#%>]$/.test(reflowPrimary.screenText.trimEnd()), null, { timeout: 30000 });
+    await command("exec /usr/bin/env -i PATH=/usr/bin:/bin TERM=xterm-256color LC_ALL=en_US.UTF-8 PS1='RF> ' /bin/bash --noprofile --norc -i", "RF>");
+    await command("stty -echo; printf '\\033[2J\\033[H__RF_CLEAN__\\n'", "__RF_CLEAN__");
+    await command(`printf '\\033[2J\\033[H'; printf '%s\\n' '${lines.join("' '")}'`, "__RF_END__");
+    stage = "initial 80-column output";
+    await assertText(80);
+    stage = "secondary authority and selection";
+    await test.evaluate(async id => {
+      const { WebTerminal } = await import("/web-terminal/index.js");
+      window.reflowSecondary = await WebTerminal.mount(document.getElementById("reflow-secondary"), {
+        url: `/ws?instance=${id}&name=ReflowSecondary`, renderer: "webgl2",
+        sizing: { mode: "fixed", columns: 80, rows: 24 }
+      });
+    }, instanceId);
+    await test.waitForFunction(() => reflowSecondary.connected && reflowSecondary.stats.gpu === "ready" &&
+      reflowSecondary.screenText === reflowPrimary.screenText);
+    check(await test.evaluate(() => {
+      try { reflowSecondary.setSizing({ mode: "fixed", columns: 40, rows: 24 }); return false; }
+      catch (error) { return error.message.includes("primary"); }
+    }), "Secondary was allowed to resize the producer");
+    const selectionBounds = await test.evaluate(() => {
+      const rect = reflowSecondary.element.shadowRoot.querySelector("canvas").getBoundingClientRect();
+      return { x: rect.x, y: rect.y, width: rect.width / 80, height: rect.height / 24 };
+    });
+    await test.mouse.move(selectionBounds.x + selectionBounds.width * .5, selectionBounds.y + selectionBounds.height * .5);
+    await test.mouse.down();
+    await test.mouse.move(selectionBounds.x + selectionBounds.width * 11.5, selectionBounds.y + selectionBounds.height * .5, { steps: 4 });
+    await test.mouse.up();
+    await test.waitForFunction(() => reflowSecondary.selection.status === "valid");
+    check(await test.evaluate(() => reflowSecondary.selection.text === "__RF_BEGIN__"), "Selection did not resolve exact producer text");
+    for (const columns of [20, 40, 80, 20, 80]) {
+      stage = `resizing to ${columns} columns`;
+      await resize(columns);
+      await assertText(columns);
+      await test.waitForFunction(() => reflowSecondary.screenText === reflowPrimary.screenText);
+      check(await test.evaluate(() => reflowSecondary.selection.status === "invalidated"),
+        "Resize retained a stale selection");
+    }
+    stage = "creating scrollback";
+    const historyLines = Array.from({ length: 48 }, (_, index) =>
+      `H${String(index).padStart(3, "0")}_${"abcdefghij".repeat(3)}_END`);
+    await command(`printf '\\r\\033[2K'; printf '%s\\n' '${historyLines.join("' '")}' '__RF_HISTORY__'`, "__RF_HISTORY__");
+    const expectedHistory = [...lines, ...historyLines, "__RF_HISTORY__", "RF>"];
+    for (const columns of [80, 20, 40, 80, 20, 80]) {
+      stage = `checking complete ${columns}-column history`;
+      await waitLive();
+      await resize(columns);
+      const actual = await history();
+      const expected = wrapped(columns, expectedHistory);
+      check(JSON.stringify(actual.slice(0, expected.length)) === JSON.stringify(expected),
+        `Complete history mismatch: expected ${JSON.stringify(expected)}, actual ${JSON.stringify(actual)}`);
+      check(actual.slice(expected.length).every(row => row === ""), "Unexpected text after the prompt in history");
+      results.push({ columns, historyRows: expected.length });
+    }
+    await waitLive();
+    stage = "editing a pending prompt after resizing";
+    await command("stty echo; printf '\\r\\033[2K__RF_EDIT_READY__\\n'", "__RF_EDIT_READY__");
+    await test.evaluate(() => reflowPrimary.focus());
+    await test.keyboard.type("printf '__EDIT_OK__\\n'X");
+    await test.waitForFunction(() => reflowPrimary.screenText.includes("printf '__EDIT_OK__\\n'X"));
+    for (const columns of [20, 40, 80]) await resize(columns);
+    await test.keyboard.press("Backspace");
+    await test.keyboard.press("Enter");
+    await test.waitForFunction(() => reflowPrimary.screenText.split("\n").some(row => row.trimEnd() === "__EDIT_OK__") &&
+      reflowPrimary.screenText.trimEnd().endsWith("RF>"));
+    stage = "transferring primary authority";
+    await test.evaluate(() => reflowSecondary.requestPrimary());
+    await test.waitForFunction(() => reflowSecondary.peer.isPrimary && !reflowPrimary.peer.isPrimary);
+    await test.evaluate(() => reflowSecondary.setSizing({ mode: "fixed", columns: 40, rows: 24 }));
+    await test.waitForFunction(() => reflowPrimary.geometry.columns === 40 && reflowSecondary.geometry.columns === 40);
+    check(errors.length === 0, `Browser errors: ${errors.join("; ")}`);
+    check(await test.evaluate(() => [reflowPrimary, reflowSecondary].every(terminal =>
+      terminal.stats.gpu === "ready" && terminal.stats.renderer === "webgl2" &&
+      terminal.stats.warnings.length === 0 && terminal.stats.discardedFrames === 0)), "GPU rendering diagnostics failed");
+    return { passed: true, results, covered: ["exact live text", "soft and hard wraps", "wide and combining cells",
+      "complete scrollback", "secondary resize rejection", "selection invalidation", "pending prompt editing",
+      "primary transfer", "real shell through HMP producer and HWT GPU worker"], stats: (await state()).stats };
+  } catch (error) {
+    throw new Error(`${stage}: ${error.message}; ${JSON.stringify(await state())}`);
+  } finally {
+    try {
+      if (instanceId) await test.request.delete(`${origin}/api/terminals/${instanceId}`, { headers: { Origin: origin } });
+    } finally {
+      await context.close();
+    }
+  }
+}

--- a/samples/WebTerminalDemo/tests/resize-handles.browser.js
+++ b/samples/WebTerminalDemo/tests/resize-handles.browser.js
@@ -1,0 +1,279 @@
+async page => {
+  const origin = page.url().match(/^https?:\/\/[^/]+/)?.[0];
+  if (!origin) throw new Error("Navigate to the running WebTerminalDemo before invoking this fixture.");
+  const context = await page.context().browser().newContext({ viewport: { width: 1600, height: 1200 } });
+  const test = await context.newPage();
+  const instances = new Set();
+  const errors = [];
+  const commands = [];
+  const results = [];
+  const screenshots = [];
+  let stage = "starting";
+  test.on("pageerror", error => errors.push(error.message));
+  test.on("websocket", socket => socket.on("framesent", frame => {
+    if (typeof frame.payload === "string") {
+      const command = JSON.parse(frame.payload);
+      if (command.type === "resize") commands.push({ url: socket.url(), ...command });
+    }
+  }));
+  const check = (condition, message) => { if (!condition) throw new Error(message); };
+  const near = (actual, expected) => Math.abs(actual - expected) < 1;
+  const windowFor = id => test.locator(`.terminal-window[data-view="${id}"]`);
+  const handleFor = (id, edge) => windowFor(id).locator(`.resize-handle[data-edge="${edge}"]`);
+  const box = id => windowFor(id).evaluate(element => ({
+    left: element.offsetLeft, top: element.offsetTop, width: element.offsetWidth, height: element.offsetHeight
+  }));
+  const point = async (id, edge) => {
+    await test.evaluate(id => webTerminalViews.get(id).terminal.focus(), id);
+    const bounds = await windowFor(id).boundingBox();
+    return {
+      x: edge.includes("w") ? bounds.x - 3 : edge.includes("e") ? bounds.x + bounds.width + 3 : bounds.x + bounds.width / 2,
+      y: edge.includes("n") ? bounds.y - 3 : edge.includes("s") ? bounds.y + bounds.height + 3 : bounds.y + bounds.height / 2
+    };
+  };
+  const drag = async (id, edge, dx, dy) => {
+    const start = await point(id, edge);
+    await test.mouse.move(start.x, start.y);
+    await test.mouse.down();
+    await test.mouse.move(start.x + dx, start.y + dy, { steps: 5 });
+    check(await handleFor(id, edge).getAttribute("data-active") === "true", `${edge} did not capture the resize gesture`);
+    await test.mouse.up();
+    check(await handleFor(id, edge).getAttribute("data-active") === null, `${edge} stayed active after release`);
+  };
+  const setSize = async (id, width, height) => {
+    const before = await box(id);
+    await drag(id, "se", width - before.width, height - before.height);
+    const after = await box(id);
+    check(near(after.width, width) && near(after.height, height), `Expected ${width}x${height}: ${JSON.stringify(after)}`);
+  };
+  const waitAuto = async () => test.waitForFunction(() => {
+    const primary = [...webTerminalViews.values()].find(view => view.terminal?.peer.isPrimary);
+    if (!primary || primary.terminal.sizing.mode !== "auto") return false;
+    const mount = primary.element.querySelector(".terminal-mount").getBoundingClientRect();
+    const scale = primary.terminal.sizing.fontSize / 16;
+    const columns = Math.max(20, Math.min(300, Math.floor(mount.width / (10 * scale))));
+    const rows = Math.max(10, Math.min(100, Math.floor(mount.height / (20 * scale))));
+    return [...webTerminalViews.values()].every(view => view.terminal.geometry.columns === columns &&
+      view.terminal.geometry.rows === rows && view.stats.columns === columns && view.stats.rows === rows);
+  });
+  const metadata = async id => (await (await test.request.get(`${origin}/api/terminals`)).json())
+    .find(instance => instance.id === id);
+  const highlight = async (id, edge, opacity) => test.waitForFunction(({ id, edge, opacity }) => {
+    const element = webTerminalViews.get(id).element.querySelector(`.resize-handle[data-edge="${edge}"]`);
+    return Math.abs(Number(getComputedStyle(element, "::after").opacity) - opacity) < .01;
+  }, { id, edge, opacity });
+  const clearPointer = async () => { await test.mouse.move(5, 5); };
+  try {
+    for (const transport of ["direct", "hmp1"]) {
+      stage = `${transport}: creating primary`;
+      await test.goto(`${origin}/?empty=1&scene=text&renderer=webgl2&transport=${transport}`);
+      const created = test.waitForResponse(response => response.url() === `${origin}/api/terminals` &&
+        response.request().method() === "POST" && response.status() === 201);
+      await test.locator("#create").click();
+      const instanceId = (await (await created).json()).id;
+      instances.add(instanceId);
+      await test.waitForFunction(() => webTerminalViews.get("1")?.terminal?.peer.isPrimary &&
+        webTerminalViews.get("1").stats.gpu === "ready");
+      await test.request.post(`${origin}/api/terminals/${instanceId}/controls`, {
+        headers: { Origin: origin }, data: { paused: true }
+      });
+      await setSize("1", 600, 400);
+      const title = await windowFor("1").locator(".view-title").boundingBox();
+      const initial = await box("1");
+      await test.mouse.move(title.x + 40, title.y + title.height / 2);
+      await test.mouse.down();
+      await test.mouse.move(title.x + 40 + 120 - initial.left, title.y + title.height / 2 + 100 - initial.top, { steps: 5 });
+      await test.mouse.up();
+      const positioned = await box("1");
+      check(near(positioned.left, 120) && near(positioned.top, 100) &&
+        positioned.width === 600 && positioned.height === 400, "Titlebar drag changed size or failed to move");
+      await waitAuto();
+      const originalProducer = await metadata(instanceId);
+      const edges = { n: "ns-resize", ne: "nesw-resize", e: "ew-resize", se: "nwse-resize",
+        s: "ns-resize", sw: "nesw-resize", w: "ew-resize", nw: "nwse-resize" };
+      check(await windowFor("1").locator(".resize-handle").count() === 8, "Expected exactly eight resize handles");
+      for (const [edge, cursor] of Object.entries(edges)) {
+        stage = `${transport}: hover and physical ${edge} drag`;
+        await clearPointer();
+        await highlight("1", edge, .45);
+        const restingColor = await handleFor("1", edge).evaluate(element => getComputedStyle(element, "::after").borderColor);
+        const start = await point("1", edge);
+        await test.mouse.move(start.x, start.y);
+        await highlight("1", edge, 1);
+        check(await handleFor("1", edge).evaluate(element => getComputedStyle(element).cursor) === cursor,
+          `${edge} cursor was not ${cursor}`);
+        check(await handleFor("1", edge).evaluate(element => getComputedStyle(element, "::after").borderColor) !== restingColor,
+          `${edge} hover did not use accent color`);
+        check(await test.evaluate(({ x, y, edge }) => document.elementFromPoint(x, y)?.getAttribute("data-edge") === edge,
+          { ...start, edge }), `${edge} outer hitbox is clipped or obscured`);
+        if (transport === "direct" && ["n", "ne"].includes(edge)) {
+          const path = `.playwright-cli/resize-handles-hover-${edge}.png`;
+          await test.screenshot({ path });
+          screenshots.push(path);
+        }
+        const before = await box("1");
+        const dx = edge.includes("w") ? -25 : edge.includes("e") ? 25 : 0;
+        const dy = edge.includes("n") ? -20 : edge.includes("s") ? 20 : 0;
+        await test.mouse.down();
+        await test.mouse.move(start.x + dx, start.y + dy, { steps: 5 });
+        await highlight("1", edge, 1);
+        check(await handleFor("1", edge).getAttribute("data-active") === "true", `${edge} lost active highlight`);
+        check(await windowFor("1").locator(".view-titlebar").getAttribute("data-active") === null,
+          `${edge} resize was stolen by titlebar dragging`);
+        const after = await box("1");
+        check(near(after.width, before.width + Math.abs(dx)) && near(after.height, before.height + Math.abs(dy)),
+          `${edge} resized wrong axes: ${JSON.stringify({ before, after })}`);
+        check(near(after.left + (edge.includes("w") ? after.width : 0), before.left + (edge.includes("w") ? before.width : 0)) &&
+          near(after.top + (edge.includes("n") ? after.height : 0), before.top + (edge.includes("n") ? before.height : 0)),
+        `${edge} did not preserve opposite bounds`);
+        await test.mouse.up();
+        await clearPointer();
+        await highlight("1", edge, .45);
+        await drag("1", edge, -dx, -dy);
+      }
+
+      stage = `${transport}: captured pointer outside handle and maximum/minimum constraints`;
+      let start = await point("1", "se");
+      await test.mouse.move(start.x, start.y);
+      await test.mouse.down();
+      await test.mouse.move(start.x + 4000, start.y + 3000, { steps: 5 });
+      let constrained = await box("1");
+      check(constrained.width === 3200 && constrained.height === 2200, "Maximum window size not enforced");
+      await test.mouse.move(start.x - 1000, start.y - 800, { steps: 5 });
+      constrained = await box("1");
+      check(constrained.width === 240 && constrained.height === 180, "Minimum window size not enforced");
+      check(await handleFor("1", "se").getAttribute("data-active") === "true", "Captured pointer outside handle lost activation");
+      await highlight("1", "se", 1);
+      await test.mouse.move(start.x, start.y, { steps: 5 });
+      await test.mouse.up();
+      check((await box("1")).width === 600 && (await box("1")).height === 400, "Captured drag failed to restore dimensions");
+      await clearPointer();
+      await highlight("1", "se", .45);
+
+      stage = `${transport}: north/west workspace origin constraints`;
+      const beforeOrigin = await box("1");
+      await drag("1", "nw", -1000, -1000);
+      const atOrigin = await box("1");
+      check(atOrigin.left === 0 && atOrigin.top === 0 &&
+        atOrigin.left + atOrigin.width === beforeOrigin.left + beforeOrigin.width &&
+        atOrigin.top + atOrigin.height === beforeOrigin.top + beforeOrigin.height,
+      "North/west failed to clamp origin while preserving opposite bounds");
+      const topTitle = await windowFor("1").locator(".view-title").boundingBox();
+      await test.mouse.move(topTitle.x + 40, topTitle.y + topTitle.height / 2);
+      await test.mouse.down();
+      await test.mouse.move(topTitle.x + 160, topTitle.y + topTitle.height / 2 + 100, { steps: 5 });
+      await test.mouse.up();
+      await setSize("1", 600, 400);
+
+      for (const ending of ["pointercancel", "lostpointercapture"]) {
+        stage = `${transport}: ${ending} clears active gesture`;
+        const handle = handleFor("1", "e");
+        await handle.evaluate(element => element.addEventListener("gotpointercapture",
+          event => { element.dataset.testPointerId = String(event.pointerId); }, { once: true }));
+        start = await point("1", "e");
+        await test.mouse.move(start.x, start.y);
+        await test.mouse.down();
+        await test.mouse.move(start.x + 20, start.y + 10);
+        await handle.evaluate((element, ending) => {
+          const pointerId = Number(element.dataset.testPointerId);
+          if (!element.hasPointerCapture(pointerId)) throw new Error("Real pointer was not captured");
+          if (ending === "pointercancel")
+            element.dispatchEvent(new PointerEvent("pointercancel", { pointerId, bubbles: true }));
+          else element.releasePointerCapture(pointerId);
+        }, ending);
+        await test.mouse.move(start.x - 50, start.y + 100);
+        check(await handle.getAttribute("data-active") === null, `${ending} left stale active state`);
+        check((await box("1")).width === 620, `${ending} did not stop geometry updates`);
+        await test.mouse.up();
+        await clearPointer();
+        await highlight("1", "e", .45);
+        await setSize("1", 600, 400);
+      }
+
+      stage = `${transport}: primary Auto controls and resize authority`;
+      const fontBefore = await test.evaluate(() => webTerminalViews.get("1").terminal.sizing.fontSize);
+      const chromeBefore = await box("1");
+      await windowFor("1").locator(".font-smaller").click();
+      await test.waitForFunction(size => webTerminalViews.get("1").terminal.sizing.fontSize === size - 1, fontBefore);
+      check(JSON.stringify(await box("1")) === JSON.stringify(chromeBefore), "Border control click moved/resized window");
+      await drag("1", "e", 100, 0);
+      await waitAuto();
+      const afterAuto = await metadata(instanceId);
+      check(afterAuto.columns !== originalProducer.columns && commands.some(command => command.url.includes(`transport=${transport}`)),
+        "Primary Auto resize did not reach producer through selected transport");
+
+      stage = `${transport}: fixed grid changes view size only`;
+      await windowFor("1").locator(".view-resolution").selectOption("80x24");
+      await test.waitForFunction(() => webTerminalViews.get("1").stats.columns === 80 && webTerminalViews.get("1").stats.rows === 24);
+      const fixedCount = commands.length;
+      await drag("1", "se", -60, -40);
+      await test.waitForTimeout(250);
+      const afterFixed = await metadata(instanceId);
+      check(afterFixed.columns === 80 && afterFixed.rows === 24 && commands.length === fixedCount,
+        "Fixed grid resize changed the producer");
+
+      stage = `${transport}: secondary resize and close control`;
+      await windowFor("1").locator(".thumbnail").click();
+      await test.waitForFunction(() => webTerminalViews.get("2")?.terminal?.connected && webTerminalViews.get("2").stats.gpu === "ready");
+      const secondaryCount = commands.length;
+      const secondaryBefore = await box("2");
+      await drag("2", "sw", -50, 40);
+      const secondaryAfter = await box("2");
+      check(secondaryAfter.width === secondaryBefore.width + 50 && secondaryAfter.height === secondaryBefore.height + 40,
+        "Secondary view did not physically resize");
+      await test.waitForTimeout(250);
+      const afterSecondary = await metadata(instanceId);
+      check(afterSecondary.columns === 80 && afterSecondary.rows === 24 && commands.length === secondaryCount,
+        "Secondary view resize emitted a producer resize");
+      await windowFor("2").locator(".close-view").click();
+      await test.waitForFunction(() => webTerminalViews.size === 1);
+      check(await windowFor("1").locator("[data-active=true]").count() === 0, "Controls left active drag handles");
+
+      stage = `${transport}: workspace scrolling during captured resize`;
+      await setSize("1", 1800, 1000);
+      await test.locator("#workspace").evaluate(element => element.scrollTo(0, 0));
+      const beforeScroll = await box("1");
+      start = await point("1", "nw");
+      await test.mouse.move(start.x, start.y);
+      await test.mouse.down();
+      await test.locator("#workspace").evaluate(element => element.scrollTo(40, 30));
+      await test.waitForFunction(() => {
+        const workspace = document.getElementById("workspace");
+        return workspace.scrollLeft === 40 && workspace.scrollTop === 30;
+      });
+      await test.mouse.move(start.x + 1, start.y + 1);
+      const afterScroll = await box("1");
+      check(afterScroll.left === beforeScroll.left + 41 && afterScroll.top === beforeScroll.top + 31 &&
+        afterScroll.width === beforeScroll.width - 41 && afterScroll.height === beforeScroll.height - 31,
+      `Captured resize ignored workspace scroll delta: ${JSON.stringify({ beforeScroll, afterScroll })}`);
+      await test.mouse.up();
+      check(await handleFor("1", "nw").getAttribute("data-active") === null, "Scrolled gesture did not clean up");
+      check(await test.evaluate(() => webTerminalViews.get("1").stats.gpu === "ready" &&
+        webTerminalViews.get("1").stats.renderer === "webgl2" && webTerminalViews.get("1").stats.warnings.length === 0),
+      "GPU worker diagnostics failed");
+      results.push({ transport, edges: Object.keys(edges), constraints: "240x180..3200x2200",
+        pointerCancel: true, lostCapture: true, workspaceScroll: true,
+        primaryAuto: true, fixedAndSecondaryViewOnly: true });
+      await test.goto(`${origin}/health`);
+      const deleted = await test.request.delete(`${origin}/api/terminals/${instanceId}`, { headers: { Origin: origin } });
+      check(deleted.status() === 204, "Could not delete fixture producer");
+      instances.delete(instanceId);
+    }
+    check(errors.length === 0, `Browser errors: ${errors.join("; ")}`);
+    return { passed: true, results, screenshots, browserErrors: errors };
+  } catch (error) {
+    const state = await test.evaluate(() => [...(window.webTerminalViews?.values() ?? [])].map(view => ({
+      id: view.id, bounds: view.element.getBoundingClientRect().toJSON(), style: view.element.style.cssText,
+      active: [...view.element.querySelectorAll("[data-active=true]")].map(element => element.getAttribute("data-edge")),
+      geometry: view.terminal?.geometry, peer: view.terminal?.peer
+    })));
+    throw new Error(`${stage}: ${error.message}; ${JSON.stringify(state)}`);
+  } finally {
+    try {
+      for (const id of instances)
+        await test.request.delete(`${origin}/api/terminals/${id}`, { headers: { Origin: origin } });
+    } finally {
+      await context.close();
+    }
+  }
+}

--- a/samples/WebTerminalDemo/tests/sizing.browser.js
+++ b/samples/WebTerminalDemo/tests/sizing.browser.js
@@ -83,7 +83,7 @@ async page => {
     stage = "resizing a fixed-grid window";
     await first.locator(".view-title").click();
     const beforeFixedResize = resizeCount();
-    const handle = await first.locator(".resize-handle").boundingBox();
+    const handle = await first.locator('.resize-handle[data-edge="se"]').boundingBox();
     await test.mouse.move(handle.x + 5, handle.y + 5);
     await test.mouse.down();
     await test.mouse.move(handle.x - 175, handle.y - 95, { steps: 10 });

--- a/samples/WebTerminalDemo/wwwroot/index.html
+++ b/samples/WebTerminalDemo/wwwroot/index.html
@@ -161,6 +161,22 @@
           <option value="shell">Interactive shell</option>
         </select>
       </label>
+      <label>New terminal reflow
+        <select id="reflow-strategy" title="Chosen when creating a terminal; shared by every attached view.">
+          <option value="Default">Default (shell: Ghostty; other scenes: none)</option>
+          <option value="None">None (crop)</option>
+          <option value="Ghostty">Ghostty</option>
+          <option value="Vte">VTE</option>
+          <option value="Kitty">Kitty</option>
+          <option value="WezTerm">WezTerm</option>
+          <option value="Alacritty">Alacritty</option>
+          <option value="WindowsTerminal">Windows Terminal</option>
+          <option value="Foot">Foot</option>
+          <option value="ITerm2">iTerm2 (crop)</option>
+          <option value="Xterm">xterm (crop)</option>
+          <option value="Auto">Auto (server environment)</option>
+        </select>
+      </label>
       <label>New view maximum scale
         <select id="scale">
           <option value="auto">Device DPR (max 3×)</option>

--- a/samples/WebTerminalDemo/wwwroot/index.html
+++ b/samples/WebTerminalDemo/wwwroot/index.html
@@ -94,9 +94,9 @@
     #warnings { color: var(--cp-warning); white-space: pre-wrap; margin: 8px 0; }
     #workspace { position: relative; overflow: auto; flex: 1; min-height: 320px; background: var(--cp-bg-elevated); border: 1px solid var(--cp-border); border-radius: 16px; }
     #workspace.empty::before { content: "Create a terminal or attach a view above. Closing a view keeps its terminal running."; display: block; padding: 32px; color: var(--cp-text-muted); }
-    .terminal-window { position: absolute; display: flex; flex-direction: column; min-width: 240px; min-height: 180px; overflow: hidden; border: 1px solid var(--cp-border-strong); border-radius: .625rem; background: var(--cp-surface); }
+    .terminal-window { position: absolute; display: flex; flex-direction: column; min-width: 240px; min-height: 180px; border: 1px solid var(--cp-border-strong); border-radius: .625rem; background: var(--cp-surface); }
     .terminal-window.selected { border-color: var(--cp-accent); }
-    .view-titlebar { display: flex; flex: 0 0 36px; min-width: 0; align-items: center; gap: 8px; padding: 4px 8px; background: var(--cp-surface-soft); cursor: grab; touch-action: none; user-select: none; }
+    .view-titlebar { display: flex; flex: 0 0 36px; min-width: 0; align-items: center; gap: 8px; padding: 4px 8px; border-radius: .625rem .625rem 0 0; background: var(--cp-surface-soft); cursor: grab; touch-action: none; user-select: none; }
     .view-title { flex: 1; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; font-size: 12px; font-weight: 600; }
     .view-role { flex: none; font-size: 11px; color: var(--cp-text-muted); }
     .terminal-window[data-primary=true] .view-role { color: var(--cp-accent); font-weight: 600; }
@@ -129,7 +129,27 @@
     .view-resolution { width: 96px; }
     .font-size { flex: none; min-width: 28px; text-align: center; font: 10px Consolas, "Courier New", Courier, monospace; color: var(--cp-text-muted); }
     .view-status[data-level=error] { color: var(--cp-danger); }
-    .resize-handle { position: absolute; right: 3px; bottom: 3px; width: 16px; height: 16px; border-right: 3px solid var(--cp-border-strong); border-bottom: 3px solid var(--cp-border-strong); cursor: se-resize; touch-action: none; }
+    .resize-handle { position: absolute; z-index: 2; touch-action: none; user-select: none; }
+    .resize-handle::after { content: ""; position: absolute; border: 0 solid var(--cp-border-strong); border-radius: 3px; opacity: .45; pointer-events: none; transition: border-color 100ms, opacity 100ms; }
+    .resize-handle:hover::after, .resize-handle[data-active=true]::after { border-color: var(--cp-accent); opacity: 1; }
+    .resize-handle[data-edge=n], .resize-handle[data-edge=s] { left: 10px; right: 10px; height: 12px; cursor: ns-resize; }
+    .resize-handle[data-edge=n] { top: -6px; }
+    .resize-handle[data-edge=s] { bottom: -6px; }
+    .resize-handle[data-edge=n]::after, .resize-handle[data-edge=s]::after { inset: 5px 0; border-top-width: 2px; }
+    .resize-handle[data-edge=e], .resize-handle[data-edge=w] { top: 10px; bottom: 10px; width: 12px; cursor: ew-resize; }
+    .resize-handle[data-edge=e] { right: -6px; }
+    .resize-handle[data-edge=w] { left: -6px; }
+    .resize-handle[data-edge=e]::after, .resize-handle[data-edge=w]::after { inset: 0 5px; border-left-width: 2px; }
+    .resize-handle[data-edge=ne], .resize-handle[data-edge=nw],
+    .resize-handle[data-edge=se], .resize-handle[data-edge=sw] { z-index: 3; width: 20px; height: 20px; }
+    .resize-handle[data-edge=ne] { right: -10px; top: -10px; cursor: nesw-resize; }
+    .resize-handle[data-edge=nw] { left: -10px; top: -10px; cursor: nwse-resize; }
+    .resize-handle[data-edge=se] { right: -10px; bottom: -10px; cursor: nwse-resize; }
+    .resize-handle[data-edge=sw] { left: -10px; bottom: -10px; cursor: nesw-resize; }
+    .resize-handle[data-edge=ne]::after { inset: 9px 9px 0 0; border-top-width: 2px; border-right-width: 2px; }
+    .resize-handle[data-edge=nw]::after { inset: 9px 0 0 9px; border-top-width: 2px; border-left-width: 2px; }
+    .resize-handle[data-edge=se]::after { inset: 0 9px 9px 0; border-bottom-width: 2px; border-right-width: 2px; }
+    .resize-handle[data-edge=sw]::after { inset: 0 0 9px 9px; border-bottom-width: 2px; border-left-width: 2px; }
     .metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); gap: 12px; margin-top: 12px; }
     dt { font-size: 12px; color: var(--cp-text-muted); }
     dd { font: 15px/1.7 Consolas, "Courier New", Courier, monospace; margin: 0; }

--- a/src/Hex1b/Automation/TerminalRegionAnsiExtensions.cs
+++ b/src/Hex1b/Automation/TerminalRegionAnsiExtensions.cs
@@ -35,12 +35,13 @@ public static class TerminalRegionAnsiExtensions
         return RenderToAnsi(snapshot, options, snapshot.CursorX, snapshot.CursorY);
     }
 
-    // Replay preserves OSC 8 without changing the public ANSI export format.
-    internal static string ToAnsi(this Hex1bTerminalSnapshot snapshot, TerminalAnsiOptions options, bool includeHyperlinks)
-        => RenderToAnsi(snapshot, options, snapshot.CursorX, snapshot.CursorY, includeHyperlinks);
+    // Replay preserves semantic state without changing the public ANSI export format.
+    internal static string ToAnsi(this Hex1bTerminalSnapshot snapshot, TerminalAnsiOptions options,
+        bool includeHyperlinks, bool preserveSoftWrap = false)
+        => RenderToAnsi(snapshot, options, snapshot.CursorX, snapshot.CursorY, includeHyperlinks, preserveSoftWrap);
 
     private static string RenderToAnsi(IHex1bTerminalRegion region, TerminalAnsiOptions options, int? cursorX, int? cursorY,
-        bool includeHyperlinks = false)
+        bool includeHyperlinks = false, bool preserveSoftWrap = false)
     {
         var sb = new StringBuilder();
 
@@ -89,8 +90,10 @@ public static class TerminalRegionAnsiExtensions
         {
             if (row > 0)
             {
-                // Move to the next row: go to start of line and down one
-                sb.Append("\r\n");
+                // Soft breaks must be produced by autowrap, not cursor movement.
+                if (!preserveSoftWrap ||
+                    (region.GetCell(region.Width - 1, row - 1).Attributes & CellAttributes.SoftWrap) == 0)
+                    sb.Append("\r\n");
             }
             else
             {
@@ -103,6 +106,9 @@ public static class TerminalRegionAnsiExtensions
             {
                 var ch = cell.Character;
 
+                if (preserveSoftWrap && cell.IsWideWrapPadding)
+                    continue;
+
                 // Skip empty continuation cells (used for wide characters)
                 if (string.IsNullOrEmpty(ch))
                     continue;
@@ -113,14 +119,15 @@ public static class TerminalRegionAnsiExtensions
                 // that were never painted.
                 if (ch == "\0" || ch == "\uE000")
                 {
-                    if (!options.RenderNullAsSpace)
+                    if (!options.RenderNullAsSpace && !preserveSoftWrap)
                         continue;
                     ch = " ";
                 }
 
                 // Position cursor within the row using absolute column (relative to line start)
                 // CSI n G = Cursor Horizontal Absolute (move to column n)
-                sb.Append($"\x1b[{x + 1}G");
+                if (!preserveSoftWrap)
+                    sb.Append($"\x1b[{x + 1}G");
 
                 // Build SGR (Select Graphic Rendition) sequence
                 var sgrParts = new List<string>();

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -2712,6 +2712,12 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             {
                 newBuffer[y, x] = _screenBuffer[y, x];
             }
+            var edge = newBuffer[y, newWidth - 1];
+            if (!string.IsNullOrEmpty(edge.Character) && DisplayWidth.GetGraphemeWidth(edge.Character) > 1)
+            {
+                edge.TrackedHyperlink?.Release();
+                newBuffer[y, newWidth - 1] = TerminalCell.Empty;
+            }
         }
         
         // Release tracked objects from cells that are being removed
@@ -5138,6 +5144,10 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         {
             for (int x = 0; x < restoreWidth; x++)
                 SetCell(y, x, savedBuffer[y, x], restoreImpacts);
+            var edge = _screenBuffer[y, _width - 1];
+            if (restoreWidth == _width && !string.IsNullOrEmpty(edge.Character) &&
+                DisplayWidth.GetGraphemeWidth(edge.Character) > 1)
+                SetCell(y, _width - 1, TerminalCell.Empty, restoreImpacts);
         }
 
         for (int y = 0; y < _height; y++)

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -105,6 +105,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
     private volatile bool _disposed;
     private bool _inAlternateScreen;
     private TerminalCell[,]? _savedMainScreenBuffer; // Saved main screen when entering alternate screen
+    private bool _alternateScreenSavedPendingWrap;
     private int _alternateScreenSavedCursorX; // Saved cursor X for alternate screen (mode 1049)
     private int _alternateScreenSavedCursorY; // Saved cursor Y for alternate screen (mode 1049)
     private Task? _inputProcessingTask;
@@ -2497,6 +2498,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             else
             {
                 ResizeWithCrop(newWidth, newHeight);
+                _pendingWrap = false;
             }
             EnsureTabStops(newWidth);
             
@@ -2510,7 +2512,6 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             _scrollTop = 0;
             _scrollBottom = newHeight - 1;
             
-            _pendingWrap = false;
             PublishCaptureResizeUnsafe();
             deferNotification = _deferHmp1ReplayCallbacks;
         }
@@ -2546,7 +2547,11 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             _width, _height, newWidth, newHeight,
             _cursorX, _cursorY, _inAlternateScreen,
             _cursorSaved ? _savedCursorX : null,
-            _cursorSaved ? _savedCursorY : null);
+            _cursorSaved ? _savedCursorY : null)
+        {
+            PendingWrap = _pendingWrap,
+            SavedPendingWrap = _savedPendingWrap
+        };
 
         var kgpReflow = _kgpGraphicsState.PrepareActiveReflow(scrollbackEntries);
         var sixelReflow = _sixelGraphicsState.PrepareActiveReflow(scrollbackEntries);
@@ -2567,15 +2572,6 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         var result = hasKgpLineage
             ? internalResult.Reflow
             : reflowProvider.Reflow(context);
-
-        // Release tracked objects from old screen buffer (all cells)
-        for (int y = 0; y < _height; y++)
-        {
-            for (int x = 0; x < _width; x++)
-            {
-                _screenBuffer[y, x].TrackedHyperlink?.Release();
-            }
-        }
 
         // Apply the reflowed screen buffer
         var newBuffer = new TerminalCell[newHeight, newWidth];
@@ -2631,17 +2627,23 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 DiscardedRowCount: result.ScrollbackRows.Length);
         }
 
+        // Keep the old owners alive until both screen and history have acquired
+        // their replacements, including cells moving between the two.
+        foreach (var cell in _screenBuffer)
+            cell.TrackedHyperlink?.Release();
         _screenBuffer = newBuffer;
         _width = newWidth;
         _height = newHeight;
         _cursorX = Math.Clamp(result.CursorX, 0, newWidth - 1);
         _cursorY = Math.Clamp(result.CursorY, 0, newHeight - 1);
+        _pendingWrap = result.PendingWrap;
 
         // Update saved cursor if the reflow strategy reflowed it
         if (result.NewSavedCursorX.HasValue && result.NewSavedCursorY.HasValue)
         {
             _savedCursorX = Math.Clamp(result.NewSavedCursorX.Value, 0, newWidth - 1);
             _savedCursorY = Math.Clamp(result.NewSavedCursorY.Value, 0, newHeight - 1);
+            _savedPendingWrap = result.SavedPendingWrap;
         }
 
         if (hasKgpLineage)
@@ -4087,6 +4089,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                         spacerCell = spacerCell with
                         {
                             Character = " ",
+                            IsWideWrapPadding = true,
                             TrackedHyperlink = _currentHyperlink,
                             Attributes = spacerCell.Attributes | CellAttributes.SoftWrap
                         };
@@ -5036,6 +5039,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         // This uses separate fields from DECSC/DECRC to avoid conflicts
         _alternateScreenSavedCursorX = _cursorX;
         _alternateScreenSavedCursorY = _cursorY;
+        _alternateScreenSavedPendingWrap = _pendingWrap;
         
         // Always save the main screen buffer for internal state (needed for snapshots)
         // and for presentation adapters that don't handle alternate screen natively
@@ -5075,7 +5079,33 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
 
     private void DoExitAlternateScreen(List<CellImpact>? impacts = null)
     {
-        if (!RestoreMainScreenBuffer(impacts))
+        if (_inAlternateScreen && _savedMainScreenBuffer is { } main &&
+            (main.GetLength(1) != _width || main.GetLength(0) != _height) &&
+            _presentation is ITerminalReflowProvider { ReflowEnabled: true } provider)
+        {
+            var width = _width;
+            var height = _height;
+            foreach (var cell in _screenBuffer)
+                cell.TrackedHyperlink?.Release();
+            _screenBuffer = main;
+            _savedMainScreenBuffer = null;
+            _width = main.GetLength(1);
+            _height = main.GetLength(0);
+            _cursorX = _alternateScreenSavedCursorX;
+            _cursorY = _alternateScreenSavedCursorY;
+            _pendingWrap = _alternateScreenSavedPendingWrap;
+            _kgpGraphicsState.ExitAlternateScreen();
+            _sixelGraphicsState.ExitAlternateScreen();
+            _inAlternateScreen = false;
+            ResizeWithReflow(width, height, provider);
+            if (!Capabilities.HandlesAlternateScreenNatively && impacts is not null)
+            {
+                for (var y = 0; y < height; y++)
+                    for (var x = 0; x < width; x++)
+                        impacts.Add(new CellImpact(x, y, _screenBuffer[y, x]));
+            }
+        }
+        else if (!RestoreMainScreenBuffer(impacts))
             return;
 
         _kgpGraphicsState.ExitAlternateScreen();
@@ -5130,6 +5160,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         _savedMainScreenBuffer = null;
         _cursorX = Math.Clamp(_alternateScreenSavedCursorX, 0, _width - 1);
         _cursorY = Math.Clamp(_alternateScreenSavedCursorY, 0, _height - 1);
+        _pendingWrap = _alternateScreenSavedPendingWrap && _cursorX == _width - 1;
         return true;
     }
 

--- a/src/Hex1b/Hex1bTerminalBuilder.cs
+++ b/src/Hex1b/Hex1bTerminalBuilder.cs
@@ -1480,6 +1480,14 @@ public sealed class Hex1bTerminalBuilder
             {
                 console.WithReflow(strategy);
             }
+            else if (presentation is Hmp1PresentationAdapter muxer)
+            {
+                muxer.WithReflow(strategy);
+            }
+            else if (presentation is Hwt1PresentationAdapter browser)
+            {
+                browser.WithReflow(strategy);
+            }
         }
 
         // Resolve workload

--- a/src/Hex1b/Hmp1/Hmp1KgpStateReplay.cs
+++ b/src/Hex1b/Hmp1/Hmp1KgpStateReplay.cs
@@ -92,7 +92,7 @@ internal static class Hmp1KgpStateReplay
         }
 
         await AppendAsync(FormattableString.Invariant(
-            $"\x1b[{cursorY + 1};{cursorX + 1}H")).ConfigureAwait(false);
+            $"\x1b[{cursorY + 1}d\x1b[{cursorX + 1}G")).ConfigureAwait(false);
         foreach (var animation in animations)
             await AppendPlaybackAsync(animation).ConfigureAwait(false);
         await FlushAsync().ConfigureAwait(false);
@@ -216,8 +216,9 @@ internal static class Hmp1KgpStateReplay
         }
         controls.Append(",C=1,q=2");
 
+        // CUP would clear the replayed row's soft-wrap flag in reflowing replicas.
         return FormattableString.Invariant(
-            $"\x1b[{placement.Row + 1};{placement.Column + 1}H") +
+            $"\x1b[{placement.Row + 1}d\x1b[{placement.Column + 1}G") +
             BuildKgpSequence(controls.ToString(), string.Empty);
     }
 

--- a/src/Hex1b/Hmp1/Hmp1PresentationAdapter.cs
+++ b/src/Hex1b/Hmp1/Hmp1PresentationAdapter.cs
@@ -6,6 +6,7 @@ using System.Threading.Channels;
 using Hex1b.Automation;
 using Hex1b.Diagnostics;
 using Hex1b.Sixel;
+using Hex1b.Reflow;
 
 namespace Hex1b;
 
@@ -35,7 +36,8 @@ namespace Hex1b;
 /// fresh <see cref="Hmp1FrameType.StateSync"/> are broadcast to all peers.
 /// </para>
 /// </remarks>
-public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentationAdapter
+public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentationAdapter,
+    ITerminalReflowProvider, IInternalTerminalReflowProvider
 {
     private readonly List<Hmp1ClientSession> _sessions = [];
     private readonly object _sessionsLock = new();
@@ -45,6 +47,8 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
     private int _height;
     private string? _primaryPeerId;
     private bool _disposed;
+    private ITerminalReflowProvider _reflowStrategy = NoReflowStrategy.Instance;
+    private bool _reflowEnabled;
     private Hmp1SixelStateReplay.ReplayResult? _lastSixelReplayResult;
 
     internal Hex1bMetrics Metrics { get; set; } = Hex1bMetrics.Default;
@@ -83,6 +87,40 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
 
     /// <inheritdoc />
     public int Height => _height;
+
+    /// <summary>
+    /// Enables producer-side reflow using the specified strategy.
+    /// By default, resize crops the screen without reflow.
+    /// </summary>
+    /// <param name="strategy">The reflow strategy; use <see cref="GhosttyReflowStrategy.Instance"/> for shell terminals.</param>
+    /// <returns>This adapter for fluent configuration before terminal construction.</returns>
+    /// <remarks>
+    /// Configure the producer, not individual browser views. Primary-peer resize authority
+    /// is unchanged. Ghostty reflows main-screen text and retained scrollback, but not
+    /// alternate-screen layouts. Scrollback capacity still bounds retained history.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">The strategy is null.</exception>
+    public Hmp1PresentationAdapter WithReflow(ITerminalReflowProvider strategy)
+    {
+        _reflowStrategy = strategy ?? throw new ArgumentNullException(nameof(strategy));
+        _reflowEnabled = true;
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public bool ReflowEnabled => _reflowEnabled;
+
+    /// <inheritdoc/>
+    public bool ShouldClearSoftWrapOnAbsolutePosition => _reflowStrategy.ShouldClearSoftWrapOnAbsolutePosition;
+
+    /// <inheritdoc/>
+    public ReflowResult Reflow(ReflowContext context) => _reflowStrategy.Reflow(context);
+
+    bool IInternalTerminalReflowProvider.TryReflowWithAnchors(
+        ReflowContext context,
+        IReadOnlyList<TerminalReflowAnchor> anchors,
+        out InternalReflowResult result)
+        => InternalTerminalReflow.TryReflow(_reflowStrategy, context, anchors, out result);
 
     /// <summary>
     /// Gets the peer ID of the current primary, or <see langword="null"/> when

--- a/src/Hex1b/Hmp1/Hmp1PresentationAdapter.cs
+++ b/src/Hex1b/Hmp1/Hmp1PresentationAdapter.cs
@@ -449,7 +449,7 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
                     // ghosting on every fresh viewer connect or RoleChange-driven
                     // re-StateSync.)
                     IncludeTrailingNewline = false,
-                }, includeHyperlinks: true);
+                }, includeHyperlinks: true, preserveSoftWrap: true);
                 var suffix = BuildStateReplaySuffix(snap);
                 activityState = Hmp1ActivityState.Capture(snap);
                 var progress = activityState.BuildProgressReplay();

--- a/src/Hex1b/Hmp1/Hmp1SixelStateReplay.cs
+++ b/src/Hex1b/Hmp1/Hmp1SixelStateReplay.cs
@@ -285,7 +285,7 @@ internal static class Hmp1SixelStateReplay
     private static string BuildDamagePatchSequence(int row, int column, TerminalCell cell, HyperlinkData? activeHyperlink)
     {
         var sb = new StringBuilder();
-        sb.Append(FormattableString.Invariant($"\x1b[{row + 1};{column + 1}H"));
+        sb.Append(FormattableString.Invariant($"\x1b[{row + 1}d\x1b[{column + 1}G"));
         sb.Append("\x1b[0m");
 
         var attrs = cell.Attributes;
@@ -343,8 +343,9 @@ internal static class Hmp1SixelStateReplay
         CancellationToken cancellationToken,
         out string sequence)
     {
+        // Avoid CUP clearing soft-wrap flags established by the text replay.
         var cursor = FormattableString.Invariant(
-            $"\x1b[{placement.Row + 1};{placement.Column + 1}H");
+            $"\x1b[{placement.Row + 1}d\x1b[{placement.Column + 1}G");
         var cursorBytes = Encoding.UTF8.GetByteCount(cursor);
         if (cursorBytes > maximumBytes ||
             !TryGetReplayPayload(

--- a/src/Hex1b/Hwt1/Hwt1PresentationAdapter.cs
+++ b/src/Hex1b/Hwt1/Hwt1PresentationAdapter.cs
@@ -5,6 +5,7 @@ using System.Threading.Channels;
 using Hex1b.Sixel;
 using Hex1b.Tokens;
 using Hex1b.Automation;
+using Hex1b.Reflow;
 
 namespace Hex1b;
 
@@ -50,7 +51,8 @@ namespace Hex1b;
 /// These fields are current even when the view is displaying historical text.
 /// </remarks>
 public sealed class Hwt1PresentationAdapter :
-    ICellImpactAwarePresentationAdapter, ITerminalLifecycleAwarePresentationAdapter
+    ICellImpactAwarePresentationAdapter, ITerminalLifecycleAwarePresentationAdapter,
+    ITerminalReflowProvider, IInternalTerminalReflowProvider
 {
     private readonly Channel<bool> _dirty = Channel.CreateBounded<bool>(
         new BoundedChannelOptions(1) { FullMode = BoundedChannelFullMode.DropWrite });
@@ -74,6 +76,8 @@ public sealed class Hwt1PresentationAdapter :
     private long _outputBatches;
     private int _width;
     private int _height;
+    private ITerminalReflowProvider _reflowStrategy = NoReflowStrategy.Instance;
+    private bool _reflowEnabled;
     private TimeSpan _acknowledgementTimeout = TimeSpan.FromMinutes(2);
 
     /// <summary>Creates an HWT1 presentation adapter with the initial grid dimensions.</summary>
@@ -95,6 +99,41 @@ public sealed class Hwt1PresentationAdapter :
         _height = height;
         _timeProvider = timeProvider;
     }
+
+    /// <summary>
+    /// Enables reflow when this adapter is attached directly to a terminal.
+    /// By default, resize crops the screen without reflow.
+    /// </summary>
+    /// <param name="strategy">The reflow strategy; use <see cref="GhosttyReflowStrategy.Instance"/> for shell terminals.</param>
+    /// <returns>This adapter for fluent configuration before terminal construction.</returns>
+    /// <remarks>
+    /// For views created by <see cref="Hmp1PresentationAdapter.CreateBrowserViewAsync"/>,
+    /// configure <see cref="Hmp1PresentationAdapter.WithReflow"/> on the producer instead.
+    /// A view cannot change its producer's reflow policy. Ghostty reflows main-screen text
+    /// and retained scrollback, but not alternate-screen layouts.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">The strategy is null.</exception>
+    public Hwt1PresentationAdapter WithReflow(ITerminalReflowProvider strategy)
+    {
+        _reflowStrategy = strategy ?? throw new ArgumentNullException(nameof(strategy));
+        _reflowEnabled = true;
+        return this;
+    }
+
+    /// <inheritdoc/>
+    public bool ReflowEnabled => _reflowEnabled;
+
+    /// <inheritdoc/>
+    public bool ShouldClearSoftWrapOnAbsolutePosition => _reflowStrategy.ShouldClearSoftWrapOnAbsolutePosition;
+
+    /// <inheritdoc/>
+    public ReflowResult Reflow(ReflowContext context) => _reflowStrategy.Reflow(context);
+
+    bool IInternalTerminalReflowProvider.TryReflowWithAnchors(
+        ReflowContext context,
+        IReadOnlyList<TerminalReflowAnchor> anchors,
+        out InternalReflowResult result)
+        => InternalTerminalReflow.TryReflow(_reflowStrategy, context, anchors, out result);
 
     /// <summary>
     /// Gets or sets whether this view ignores client commands that modify the producer.

--- a/src/Hex1b/Hwt1/Hwt1ViewState.cs
+++ b/src/Hex1b/Hwt1/Hwt1ViewState.cs
@@ -369,6 +369,8 @@ internal sealed class Hwt1ViewState
             if (column >= buffer.RowWidth(row))
                 return null;
             var cell = buffer.Cell(row, column);
+            if (_mode != "rectangle" && cell.IsWideWrapPadding)
+                return cell with { Character = "" };
             return cell.Character is "\0" or "\uE000" ? cell with { Character = " " } : cell;
         }
     }

--- a/src/Hex1b/Reflow/ITerminalReflowProvider.cs
+++ b/src/Hex1b/Reflow/ITerminalReflowProvider.cs
@@ -81,7 +81,11 @@ public readonly record struct ReflowContext(
     int CursorY,
     bool InAlternateScreen,
     int? SavedCursorX = null,
-    int? SavedCursorY = null);
+    int? SavedCursorY = null)
+{
+    internal bool PendingWrap { get; init; }
+    internal bool SavedPendingWrap { get; init; }
+}
 
 /// <summary>
 /// A scrollback row passed to the reflow provider, containing cell data and the
@@ -115,4 +119,8 @@ public readonly record struct ReflowResult(
     int CursorX,
     int CursorY,
     int? NewSavedCursorX = null,
-    int? NewSavedCursorY = null);
+    int? NewSavedCursorY = null)
+{
+    internal bool PendingWrap { get; init; }
+    internal bool SavedPendingWrap { get; init; }
+}

--- a/src/Hex1b/Reflow/InternalTerminalReflow.cs
+++ b/src/Hex1b/Reflow/InternalTerminalReflow.cs
@@ -8,6 +8,9 @@ internal static class InternalTerminalReflow
         IReadOnlyList<TerminalReflowAnchor> anchors,
         out InternalReflowResult result)
     {
+        if (provider is IInternalTerminalReflowProvider internalProvider)
+            return internalProvider.TryReflowWithAnchors(context, anchors, out result);
+
         if (provider is AutoReflowStrategy auto)
         {
             return TryReflow(

--- a/src/Hex1b/Reflow/NoReflowStrategy.cs
+++ b/src/Hex1b/Reflow/NoReflowStrategy.cs
@@ -41,6 +41,9 @@ public sealed class NoReflowStrategy : ITerminalReflowProvider
             {
                 Array.Fill(row, TerminalCell.Empty);
             }
+            if (newWidth > 0 && !string.IsNullOrEmpty(row[^1].Character) &&
+                DisplayWidth.GetGraphemeWidth(row[^1].Character) > 1)
+                row[^1] = TerminalCell.Empty;
             screenRows[y] = row;
         }
 

--- a/src/Hex1b/Reflow/ReflowHelper.cs
+++ b/src/Hex1b/Reflow/ReflowHelper.cs
@@ -57,7 +57,11 @@ internal static class ReflowHelper
                     context.CursorX,
                     context.CursorY,
                     hasSavedCursor ? context.SavedCursorX : null,
-                    hasSavedCursor ? context.SavedCursorY : null),
+                    hasSavedCursor ? context.SavedCursorY : null)
+                {
+                    PendingWrap = context.PendingWrap,
+                    SavedPendingWrap = context.SavedPendingWrap
+                },
                 anchors.ToArray());
         }
 
@@ -67,16 +71,18 @@ internal static class ReflowHelper
         // Step 2: Group rows into logical lines using SoftWrap, and track which
         // logical line the cursor row belongs to (and optionally the saved cursor).
         int scrollbackRowCount = context.ScrollbackRows.Length;
-        int cursorAbsoluteRow = scrollbackRowCount + context.CursorY;
-        int savedCursorAbsoluteRow = hasSavedCursor ? scrollbackRowCount + context.SavedCursorY!.Value : -1;
+        int cursorAbsoluteRow = Math.Clamp(scrollbackRowCount + context.CursorY, 0, allRows.Count - 1);
+        int savedCursorAbsoluteRow = hasSavedCursor
+            ? Math.Clamp(scrollbackRowCount + context.SavedCursorY!.Value, 0, allRows.Count - 1)
+            : -1;
 
-        var (logicalLines, cursorLogicalLine, cursorRowInLogicalLine,
-             savedCursorLogicalLine, savedCursorRowInLogicalLine) =
+        var (logicalLines, cursorLogicalLine, _,
+             savedCursorLogicalLine, _) =
             GroupLogicalLinesWithCursors(allRows, cursorAbsoluteRow,
                 hasSavedCursor ? savedCursorAbsoluteRow : null);
         var rowLocations = BuildLogicalRowLocations(allRows);
         var anchorsByLogicalLine =
-            new Dictionary<int, List<(TerminalReflowAnchor Anchor, int RowInLine)>>();
+            new Dictionary<int, List<(TerminalReflowAnchor Anchor, int CellOffset)>>();
         foreach (var anchor in anchors)
         {
             if (anchor.Row < 0 || anchor.Row >= rowLocations.Length)
@@ -89,7 +95,7 @@ internal static class ReflowHelper
                 anchorsByLogicalLine.Add(location.LogicalLine, lineAnchors);
             }
 
-            lineAnchors.Add((anchor, location.RowInLine));
+            lineAnchors.Add((anchor, location.CellOffset));
         }
 
         // Step 3: Re-wrap all logical lines to the new width
@@ -106,39 +112,58 @@ internal static class ReflowHelper
         for (int lineIdx = 0; lineIdx < logicalLines.Count; lineIdx++)
         {
             var logicalLine = logicalLines[lineIdx];
+            var emptyLogicalLine = logicalLine.Count == 0;
+            var cursorOffset = lineIdx == cursorLogicalLine
+                ? rowLocations[cursorAbsoluteRow].CellOffset + context.CursorX + (context.PendingWrap ? 1 : 0)
+                : 0;
+            var savedCursorOffset = hasSavedCursor && lineIdx == savedCursorLogicalLine
+                ? rowLocations[savedCursorAbsoluteRow].CellOffset + context.SavedCursorX!.Value +
+                    (context.SavedPendingWrap ? 1 : 0)
+                : 0;
+            // Blank cells before an insertion point are significant even when
+            // trailing screen padding on the same logical line was trimmed.
+            var requiredLength = Math.Max(cursorOffset, savedCursorOffset);
+            while (logicalLine.Count < requiredLength)
+                logicalLine.Add(TerminalCell.Empty);
             var wrappedRows = WrapLogicalLine(logicalLine, context.NewWidth);
 
             if (!cursorFound && lineIdx == cursorLogicalLine)
             {
                 (newCursorRow, newCursorCol) = ComputeCursorInWrappedLine(
-                    logicalLine, wrappedRows, rowsSoFar,
-                    cursorRowInLogicalLine, context.CursorX,
-                    context.OldWidth, context.NewWidth);
+                    wrappedRows, rowsSoFar,
+                    cursorOffset,
+                    context.NewWidth);
                 cursorFound = true;
             }
 
             if (hasSavedCursor && !savedCursorFound && lineIdx == savedCursorLogicalLine)
             {
                 (newSavedCursorRow, newSavedCursorCol) = ComputeCursorInWrappedLine(
-                    logicalLine, wrappedRows, rowsSoFar,
-                    savedCursorRowInLogicalLine, context.SavedCursorX!.Value,
-                    context.OldWidth, context.NewWidth);
+                    wrappedRows, rowsSoFar,
+                    savedCursorOffset,
+                    context.NewWidth);
                 savedCursorFound = true;
             }
 
             if (anchorsByLogicalLine.TryGetValue(lineIdx, out var lineAnchors))
             {
-                foreach (var (anchor, rowInLine) in lineAnchors)
+                foreach (var (anchor, cellOffset) in lineAnchors)
                 {
-                    var (row, column) = ComputeAnchorInWrappedLine(
-                        logicalLine,
+                    if (emptyLogicalLine)
+                    {
+                        mappedAnchors.Add(anchor with
+                        {
+                            Row = rowsSoFar,
+                            Column = Math.Clamp(anchor.Column, 0, context.NewWidth - 1)
+                        });
+                        continue;
+                    }
+                    var (row, column) = ComputeCursorInWrappedLine(
                         wrappedRows,
                         rowsSoFar,
-                        rowInLine,
-                        anchor.Column,
-                        context.OldWidth,
+                        cellOffset + anchor.Column,
                         context.NewWidth);
-                    mappedAnchors.Add(anchor with { Row = row, Column = column });
+                    mappedAnchors.Add(anchor with { Row = row, Column = Math.Min(column, context.NewWidth - 1) });
                 }
             }
 
@@ -171,49 +196,22 @@ internal static class ReflowHelper
     /// Computes the new cursor position within re-wrapped rows for a given logical line.
     /// </summary>
     private static (int row, int col) ComputeCursorInWrappedLine(
-        List<TerminalCell> logicalLine, List<TerminalCell[]> wrappedRows, int rowsSoFar,
-        int cursorRowInLogicalLine, int cursorX, int oldWidth, int newWidth)
+        List<TerminalCell[]> wrappedRows, int rowsSoFar,
+        int cellOffsetInLine, int newWidth)
     {
-        int cellOffsetInLine = cursorRowInLogicalLine * oldWidth + cursorX;
-
-        if (logicalLine.Count == 0)
+        for (var row = 0; row < wrappedRows.Count; row++)
         {
-            return (rowsSoFar, 0);
+            for (var column = 0; column < newWidth; column++)
+            {
+                if (wrappedRows[row][column].IsWideWrapPadding)
+                    continue;
+                if (cellOffsetInLine == 0)
+                    return (rowsSoFar + row, column);
+                cellOffsetInLine--;
+            }
         }
-
-        int row = rowsSoFar + (cellOffsetInLine / newWidth);
-        int col = cellOffsetInLine % newWidth;
-
-        // Clamp to the last row of this wrapped line
-        if (row >= rowsSoFar + wrappedRows.Count)
-        {
-            row = rowsSoFar + wrappedRows.Count - 1;
-            col = Math.Min(col, newWidth - 1);
-        }
-
-        return (row, col);
-    }
-
-    private static (int row, int col) ComputeAnchorInWrappedLine(
-        List<TerminalCell> logicalLine,
-        List<TerminalCell[]> wrappedRows,
-        int rowsSoFar,
-        int rowInLogicalLine,
-        int column,
-        int oldWidth,
-        int newWidth)
-    {
-        if (logicalLine.Count == 0)
-            return (rowsSoFar, Math.Clamp(column, 0, newWidth - 1));
-
-        return ComputeCursorInWrappedLine(
-            logicalLine,
-            wrappedRows,
-            rowsSoFar,
-            rowInLogicalLine,
-            column,
-            oldWidth,
-            newWidth);
+        // The insertion point just beyond a full final row is pending wrap.
+        return (rowsSoFar + wrappedRows.Count - 1, newWidth);
     }
 
     /// <summary>
@@ -223,23 +221,11 @@ internal static class ReflowHelper
     {
         var allRows = new List<TerminalCell[]>(context.ScrollbackRows.Length + context.ScreenRows.Length);
 
-        // Add scrollback rows (may have different widths — normalize to OldWidth if needed)
+        // Retained rows may predate a crop resize. Their original cells and wrap
+        // boundaries, not today's viewport width, define their logical content.
         foreach (var sbRow in context.ScrollbackRows)
         {
-            if (sbRow.Cells.Length == context.OldWidth)
-            {
-                allRows.Add(sbRow.Cells);
-            }
-            else
-            {
-                // Normalize to current width for consistent processing
-                var normalized = new TerminalCell[context.OldWidth];
-                int copyLen = Math.Min(sbRow.Cells.Length, context.OldWidth);
-                Array.Copy(sbRow.Cells, normalized, copyLen);
-                for (int x = copyLen; x < context.OldWidth; x++)
-                    normalized[x] = TerminalCell.Empty;
-                allRows.Add(normalized);
-            }
+            allRows.Add(sbRow.Cells);
         }
 
         // Add screen rows
@@ -251,26 +237,26 @@ internal static class ReflowHelper
         return allRows;
     }
 
-    private static (int LogicalLine, int RowInLine)[] BuildLogicalRowLocations(
+    private static (int LogicalLine, int CellOffset)[] BuildLogicalRowLocations(
         List<TerminalCell[]> allRows)
     {
-        var locations = new (int LogicalLine, int RowInLine)[allRows.Count];
+        var locations = new (int LogicalLine, int CellOffset)[allRows.Count];
         var logicalLine = 0;
-        var rowInLine = 0;
+        var cellOffset = 0;
         for (var rowIndex = 0; rowIndex < allRows.Count; rowIndex++)
         {
-            locations[rowIndex] = (logicalLine, rowInLine);
+            locations[rowIndex] = (logicalLine, cellOffset);
             var row = allRows[rowIndex];
             var hasSoftWrap = row.Length > 0 &&
                 (row[^1].Attributes & CellAttributes.SoftWrap) != 0;
             if (hasSoftWrap)
             {
-                rowInLine++;
+                cellOffset += row.Count(cell => !cell.IsWideWrapPadding);
             }
             else
             {
                 logicalLine++;
-                rowInLine = 0;
+                cellOffset = 0;
             }
         }
 
@@ -313,6 +299,8 @@ internal static class ReflowHelper
                 for (int x = 0; x < row.Length; x++)
                 {
                     var cell = row[x];
+                    if (cell.IsWideWrapPadding)
+                        continue;
                     if (x == row.Length - 1)
                         cell = cell with { Attributes = cell.Attributes & ~CellAttributes.SoftWrap };
                     currentLine.Add(cell);
@@ -412,11 +400,22 @@ internal static class ReflowHelper
                 var cell = cells[cellIndex];
                 var graphemeWidth = GetCellDisplayWidth(cell);
 
+                // Match printing into a grid too narrow for this glyph, rather
+                // than retrying the same unplaceable glyph on unlimited rows.
+                if (graphemeWidth > newWidth)
+                {
+                    cellIndex++;
+                    for (var w = 1; w < graphemeWidth && cellIndex < cells.Count &&
+                        string.IsNullOrEmpty(cells[cellIndex].Character); w++)
+                        cellIndex++;
+                    continue;
+                }
+
                 // Wide character that doesn't fit at end of row
                 if (graphemeWidth > 1 && col + graphemeWidth > newWidth)
                 {
                     // Leave padding space at end of row
-                    row[col] = TerminalCell.Empty;
+                    row[col++] = TerminalCell.Empty with { IsWideWrapPadding = true };
                     break;
                 }
 
@@ -544,7 +543,11 @@ internal static class ReflowHelper
         }
 
         return new ReflowResult(screenRows, scrollbackRows, newCursorCol, newCursorRow,
-            newSavedCursorX, newSavedCursorY);
+            newSavedCursorX, newSavedCursorY)
+        {
+            PendingWrap = cursorCol >= context.NewWidth,
+            SavedPendingWrap = savedCursorCol >= context.NewWidth
+        };
     }
 
     private static bool IsEmptyRow(TerminalCell[] row)

--- a/src/Hex1b/TerminalCell.cs
+++ b/src/Hex1b/TerminalCell.cs
@@ -32,6 +32,9 @@ public readonly record struct TerminalCell(
     Hex1bColor? UnderlineColor = null,
     UnderlineStyle UnderlineStyle = UnderlineStyle.None)
 {
+    // A wide glyph wrapped before this cell; the blank is geometry, not text.
+    internal bool IsWideWrapPadding { get; init; }
+
     /// <summary>An empty cell with default attributes.</summary>
     public static readonly TerminalCell Empty = new(" ", null, null, CellAttributes.None, 0, default);
 

--- a/tests/Hex1b.Tests/Hex1b.Tests.csproj
+++ b/tests/Hex1b.Tests/Hex1b.Tests.csproj
@@ -36,6 +36,7 @@
     <Compile Include="../../samples/WebTerminalDemo/TerminalInstance.cs" Link="Samples/TerminalInstance.cs" />
     <Compile Include="../../samples/WebTerminalDemo/TerminalRegistry.cs" Link="Samples/TerminalRegistry.cs" />
     <Compile Include="../../samples/WebTerminalDemo/CreateTerminalRequest.cs" Link="Samples/CreateTerminalRequest.cs" />
+    <Compile Include="../../samples/WebTerminalDemo/DemoReflowStrategy.cs" Link="Samples/DemoReflowStrategy.cs" />
     <Compile Include="../../samples/WebTerminalDemo/TerminalInstanceInfo.cs" Link="Samples/TerminalInstanceInfo.cs" />
     <Compile Include="../../samples/WebTerminalDemo/TerminalControlsRequest.cs" Link="Samples/TerminalControlsRequest.cs" />
     <Compile Include="../../samples/WebTerminalDemo/DemoWorkload.cs" Link="Samples/DemoWorkload.cs" />

--- a/tests/Hex1b.Tests/VteGhosttyReflowTests.cs
+++ b/tests/Hex1b.Tests/VteGhosttyReflowTests.cs
@@ -277,8 +277,8 @@ public class VteGhosttyReflowTests
     /// 25 chars → ceil(25/3)=9 rows at width 3. Last row has "H" at col 0.
     /// Screen shows last 3 rows: "EFG", "H" — wait, need to trace more carefully.
     /// 25 chars at width 3: "1AB"(0) "CD2"(1) "EFG"(2) "H3I"(3) "JKL"(4) "4AB"(5) "CD5"(6) "EFG"(7) "H"(8)
-    /// Cursor was on 'H' at cell offset 4*5+4=24. At width 3: row=24/3=8, col=24%3=0.
-    /// Screen (rows=3): shows rows 6-8: "CD5", "EFG", "H". Cursor at (0, 2).
+    /// The pending-wrap insertion point is after 'H' at offset 25.
+    /// Screen (rows=3): shows rows 6-8: "CD5", "EFG", "H". Cursor at (1, 2).
     /// </remarks>
     [TestMethod]
     public void Ghostty_ResizeLessCols_PreviouslyWrappedWithScrollback()
@@ -295,9 +295,12 @@ public class VteGhosttyReflowTests
         terminal.Resize(3, 3);
 
         var snap = terminal.CreateSnapshot();
-        // Cursor was on 'H' (last char), should track to its new position
-        Assert.AreEqual(0, snap.CursorX);
+        // Pending wrap becomes an ordinary insertion point after 'H'.
+        Assert.AreEqual(1, snap.CursorX);
         Assert.AreEqual(2, snap.CursorY);
+        terminal.ApplyTokens([new TextToken("!")]);
+        using var appended = terminal.CreateSnapshot();
+        Assert.AreEqual("H!", appended.GetLineTrimmed(2));
     }
 
     #endregion

--- a/tests/Hex1b.Tests/WebTerminalDemoLifecycleTests.cs
+++ b/tests/Hex1b.Tests/WebTerminalDemoLifecycleTests.cs
@@ -4,6 +4,7 @@ using System.Net.Sockets;
 using System.Net.WebSockets;
 using System.Text;
 using System.Text.Json;
+using Hex1b.Reflow;
 using Microsoft.Extensions.Logging.Abstractions;
 using WebTerminalDemo;
 
@@ -12,6 +13,65 @@ namespace Hex1b.Tests;
 [TestClass]
 public class WebTerminalDemoLifecycleTests
 {
+    [TestMethod]
+    [DataRow(DemoReflowStrategy.None, null)]
+    [DataRow(DemoReflowStrategy.Auto, typeof(AutoReflowStrategy))]
+    [DataRow(DemoReflowStrategy.Alacritty, typeof(AlacrittyReflowStrategy))]
+    [DataRow(DemoReflowStrategy.Foot, typeof(FootReflowStrategy))]
+    [DataRow(DemoReflowStrategy.Ghostty, typeof(GhosttyReflowStrategy))]
+    [DataRow(DemoReflowStrategy.ITerm2, typeof(ITerm2ReflowStrategy))]
+    [DataRow(DemoReflowStrategy.Kitty, typeof(KittyReflowStrategy))]
+    [DataRow(DemoReflowStrategy.Vte, typeof(VteReflowStrategy))]
+    [DataRow(DemoReflowStrategy.WezTerm, typeof(WezTermReflowStrategy))]
+    [DataRow(DemoReflowStrategy.WindowsTerminal, typeof(WindowsTerminalReflowStrategy))]
+    [DataRow(DemoReflowStrategy.Xterm, typeof(XtermReflowStrategy))]
+    public void CreateRequest_ExplicitReflow_SelectsNamedProvider(object value, Type? providerType)
+    {
+        var strategy = (DemoReflowStrategy)value;
+        var request = new CreateTerminalRequest(ReflowStrategy: strategy);
+        Assert.AreEqual(providerType, request.GetReflowProvider()?.GetType());
+        var json = JsonSerializer.Serialize(request, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        var restored = JsonSerializer.Deserialize<CreateTerminalRequest>(json, new JsonSerializerOptions(JsonSerializerDefaults.Web))!;
+        Assert.AreEqual(strategy, restored.ReflowStrategy);
+    }
+
+    [TestMethod]
+    [DataRow("shell", DemoReflowStrategy.Default, DemoReflowStrategy.Ghostty, true)]
+    [DataRow("activity", DemoReflowStrategy.Default, DemoReflowStrategy.None, false)]
+    [DataRow("shell", DemoReflowStrategy.None, DemoReflowStrategy.None, false)]
+    [DataRow("activity", DemoReflowStrategy.Ghostty, DemoReflowStrategy.Ghostty, true)]
+    [DataRow("activity", DemoReflowStrategy.Vte, DemoReflowStrategy.Vte, true)]
+    public async Task Create_ReflowPolicy_IsAppliedToProducerAndReported(
+        string scene, object selected, object resolved, bool enabled)
+    {
+        await using var registry = CreateRegistry();
+        var info = registry.Create(new(scene, 40, 12, ReflowStrategy: (DemoReflowStrategy)selected))!;
+        using var first = registry.TryOpenView(info.Id).View!;
+        using var second = registry.TryOpenView(info.Id).View!;
+        Assert.AreEqual((DemoReflowStrategy)resolved, info.ReflowStrategy);
+        Assert.AreEqual((DemoReflowStrategy)resolved, TestSeq.Single(registry.List()).ReflowStrategy);
+        Assert.AreSame(first.Instance.Presentation, second.Instance.Presentation);
+        Assert.AreEqual(enabled, first.Instance.Presentation.ReflowEnabled);
+    }
+
+    [TestMethod]
+    public void CreateRequest_OmittedReflow_KeepsSceneDefault()
+    {
+        var request = JsonSerializer.Deserialize<CreateTerminalRequest>("""{"scene":"shell"}""",
+            new JsonSerializerOptions(JsonSerializerDefaults.Web))!;
+        Assert.AreEqual(DemoReflowStrategy.Default, request.ReflowStrategy);
+        Assert.AreSame(GhosttyReflowStrategy.Instance, request.GetReflowProvider());
+    }
+
+    [TestMethod]
+    public void CreateRequest_UnknownReflow_IsRejected()
+    {
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<CreateTerminalRequest>(
+            """{"reflowStrategy":"unknown"}""", new JsonSerializerOptions(JsonSerializerDefaults.Web)));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new CreateTerminalRequest(ReflowStrategy: (DemoReflowStrategy)999).GetReflowProvider());
+    }
+
     [TestMethod]
     [DataRow("close", 1000, "Demo: graceful view closure", false)]
     [DataRow("close", 1000, "Demo: graceful view closure", true)]

--- a/tests/Hex1b.Tests/WebTerminalDemoRelayTests.cs
+++ b/tests/Hex1b.Tests/WebTerminalDemoRelayTests.cs
@@ -2,6 +2,7 @@ using System.Buffers.Binary;
 using System.Text;
 using System.Text.Json;
 using Hex1b.Input;
+using Hex1b.Reflow;
 using Microsoft.Extensions.Time.Testing;
 using WebTerminalDemo;
 
@@ -10,6 +11,158 @@ namespace Hex1b.Tests;
 [TestClass]
 public class WebTerminalDemoRelayTests
 {
+    [TestMethod]
+    [DataRow(false, false)]
+    [DataRow(true, false)]
+    [DataRow(false, true)]
+    [DataRow(true, true)]
+    public async Task Relay_AttachAfterCrop_DoesNotReplaySplitWideGlyph(bool explicitCrop, bool alternate)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var server = new Hmp1PresentationAdapter(80, 10);
+        if (explicitCrop)
+            server.WithReflow(NoReflowStrategy.Instance);
+        await using var producer = Hex1bTerminal.CreateBuilder().WithWorkload(workload)
+            .WithPresentation(server).WithDimensions(80, 10).WithScrollback(100).Build();
+        var ct = TestContext.Current.CancellationToken;
+        var text = "UNI_" + string.Concat(Enumerable.Repeat("\u754ce\u0301", 36)) + "_END!";
+        workload.Write(text + "\r\n$ ");
+        using var ready = await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(snapshot => snapshot.GetLineTrimmed(2) == "$", TimeSpan.FromSeconds(5), "wide output consumed")
+            .Build().ApplyAsync(producer, ct);
+        if (alternate)
+            producer.EnterAlternateScreen();
+        producer.Resize(20, 10);
+        if (alternate)
+            producer.ExitAlternateScreen();
+        using (var cropped = producer.CreateSnapshot())
+            Assert.AreEqual(" ", cropped.GetCell(19, 0).Character, "A split wide glyph must be erased, not left without its tail.");
+        producer.Resize(40, 10);
+        producer.Resize(80, 10);
+
+        await using var relay = await Hmp1BrowserView.CreateAsync(server, "cropped-relay", ct);
+        Assert.AreEqual("UNI_" + string.Concat(Enumerable.Repeat("\u754ce\u0301", 5)),
+            await ReadFirstLogicalLineAsync(relay.Presentation));
+        Assert.AreEqual(0, producer.ScrollbackCount);
+        await relay.Presentation.HandleMessageAsync("""{"type":"resync"}"""u8.ToArray(), ct);
+        var frame = await ReadUntilAsync(relay.Presentation, frame => frame.GetProperty("full").GetBoolean());
+        Assert.AreEqual(10, frame.GetProperty("history").GetProperty("totalRows").GetInt32(),
+            "Replay must not introduce a new physical row.");
+    }
+
+    [TestMethod]
+    [DataRow(false, "none")]
+    [DataRow(true, "none")]
+    [DataRow(false, "kgp")]
+    [DataRow(true, "kgp")]
+    [DataRow(false, "sixel")]
+    [DataRow(true, "sixel")]
+    public async Task Relay_AttachAfterSoftWrap_PreservesLogicalLine(bool wideText, string graphics)
+    {
+        var text = new string('A', 79) + (wideText ? "\u754ce\u0301" : "BC") + new string('Z', 35);
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var server = new Hmp1PresentationAdapter(80, 10).WithReflow(GhosttyReflowStrategy.Instance);
+        await using var producer = Hex1bTerminal.CreateBuilder().WithWorkload(workload)
+            .WithPresentation(server).WithDimensions(80, 10).WithScrollback(100).Build();
+        var ct = TestContext.Current.CancellationToken;
+        workload.Write(text[..30] +
+            (graphics == "kgp" ? KgpTestHelper.BuildCommand("a=T,f=32,s=1,v=1,i=529,C=1,q=2", [255, 0, 0, 255]) : "") +
+            text[30..] + "\r\n$ " +
+            (graphics == "sixel" ? "\x1b" + "7\x1b[1d\x1b[31G\x1bPq#0;2;100;0;0~\x1b\\\x1b" + "8" : ""));
+        using var ready = await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(snapshot => snapshot.GetLineTrimmed(2) == "$" &&
+                (graphics != "sixel" || snapshot.SixelPlacements.Count == 1),
+                TimeSpan.FromSeconds(5), "wrapped output consumed")
+            .Build().ApplyAsync(producer, ct);
+        if (graphics == "sixel")
+        {
+            Assert.AreEqual(" ", ready.GetCell(30, 0).Character);
+            text = text[..30] + " " + text[31..];
+        }
+        await using var relay = await Hmp1BrowserView.CreateAsync(server, "late-reflow", ct);
+        await relay.Presentation.HandleMessageAsync("""{"type":"requestPrimary","columns":80,"rows":10}"""u8.ToArray(), ct);
+        await ReadUntilAsync(relay.Presentation, frame => frame.GetProperty("peer").GetProperty("isPrimary").GetBoolean());
+        Assert.AreEqual(text, await ReadFirstLogicalLineAsync(relay.Presentation));
+        var requestId = 1;
+        foreach (var width in new[] { 20, 40, 80 })
+        {
+            await relay.Presentation.HandleMessageAsync(JsonSerializer.SerializeToUtf8Bytes(
+                new { type = "resize", columns = width, rows = 10 }), ct);
+            await ReadUntilAsync(relay.Presentation, frame => frame.GetProperty("columns").GetInt32() == width);
+            requestId += 2;
+            Assert.AreEqual(text, await ReadFirstLogicalLineAsync(relay.Presentation, requestId));
+        }
+    }
+
+    [TestMethod]
+    [DataRow("Ghostty", true)]
+    [DataRow("Ghostty", false)]
+    [DataRow("Vte", true)]
+    [DataRow("None", true)]
+    public async Task Relay_Resize_UsesProducerReflowPolicy(string strategy, bool relayPrimary)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var server = new Hmp1PresentationAdapter(80, 10);
+        if (strategy != "None")
+            server.WithReflow(strategy == "Vte" ? VteReflowStrategy.Instance : GhosttyReflowStrategy.Instance);
+        await using var producer = Hex1bTerminal.CreateBuilder().WithWorkload(workload)
+            .WithPresentation(server).WithDimensions(80, 10).WithScrollback(100).Build();
+        var ct = TestContext.Current.CancellationToken;
+        await using var direct = await server.CreateBrowserViewAsync("direct", ct);
+        await using var relay = await Hmp1BrowserView.CreateAsync(server, "relay", ct);
+        var primary = relayPrimary ? relay.Presentation : direct;
+        await primary.HandleMessageAsync("""{"type":"requestPrimary","columns":80,"rows":10}"""u8.ToArray(), ct);
+        await ReadUntilAsync(primary, frame => frame.GetProperty("peer").GetProperty("isPrimary").GetBoolean());
+        var text = new string('a', 30) + "LINKED-" + new string('b', 30) + "-END";
+        workload.Write(text[..30] +
+            KgpTestHelper.BuildCommand("a=T,f=32,s=1,v=1,i=529,C=1,q=2", [255, 0, 0, 255]) +
+            text[30..] + "\r\n$ ");
+        using var ready = await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(snapshot => snapshot.GetLineTrimmed(1) == "$", TimeSpan.FromSeconds(5), "shell output consumed")
+            .Build().ApplyAsync(producer, ct);
+        Assert.AreEqual(text, await ReadFirstLogicalLineAsync(relay.Presentation));
+        var requestId = 1;
+        foreach (var width in new[] { 20, 40, 80, 20, 80 })
+        {
+            await primary.HandleMessageAsync(JsonSerializer.SerializeToUtf8Bytes(
+                new { type = "resize", columns = width, rows = 10 }), ct);
+            var relayedFrame = await ReadUntilAsync(relay.Presentation, frame => frame.GetProperty("columns").GetInt32() == width);
+            var directFrame = await ReadUntilAsync(direct, frame => frame.GetProperty("columns").GetInt32() == width);
+            if (strategy != "None")
+            {
+                var expectedImage = directFrame.GetProperty("placements")[0];
+                var relayedImage = relayedFrame.GetProperty("placements")[0];
+                Assert.AreEqual(expectedImage.GetProperty("x").GetDouble(), relayedImage.GetProperty("x").GetDouble());
+                Assert.AreEqual(expectedImage.GetProperty("y").GetDouble(), relayedImage.GetProperty("y").GetDouble());
+            }
+            var expected = strategy == "None" ? text[..20] : text;
+            requestId += 2;
+            Assert.AreEqual(expected, await ReadFirstLogicalLineAsync(direct, requestId), $"Producer policy at {width}");
+            Assert.AreEqual(expected, await ReadFirstLogicalLineAsync(relay.Presentation, requestId), $"Relay policy at {width}");
+        }
+    }
+
+    private static async Task<string?> ReadFirstLogicalLineAsync(Hwt1PresentationAdapter view, int requestId = 1)
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await view.HandleMessageAsync("""{"type":"resync"}"""u8.ToArray(), ct);
+        var history = (await ReadUntilAsync(view, frame => frame.GetProperty("full").GetBoolean()))
+            .GetProperty("history");
+        await view.HandleMessageAsync(JsonSerializer.SerializeToUtf8Bytes(new
+        {
+            type = "selection", action = "start", mode = "line", requestId, column = 0,
+            generation = history.GetProperty("generation").GetString(),
+            rowId = history.GetProperty("rowIds")[0].GetString()
+        }), ct);
+        var selected = await ReadUntilAsync(view, frame =>
+            frame.GetProperty("history").GetProperty("selection").GetProperty("status").GetString() == "valid");
+        var text = selected.GetProperty("history").GetProperty("selection").GetProperty("text").GetString();
+        await view.HandleMessageAsync(JsonSerializer.SerializeToUtf8Bytes(
+            new { type = "selection", action = "clear", requestId = requestId + 1 }), ct);
+        await ReadUntilAsync(view, frame => frame.GetProperty("history").GetProperty("selection").GetProperty("status").GetString() != "valid");
+        return text;
+    }
+
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]

--- a/tests/Hex1b.Tests/WebTerminalReflowTests.cs
+++ b/tests/Hex1b.Tests/WebTerminalReflowTests.cs
@@ -1,0 +1,360 @@
+using System.Buffers.Binary;
+using System.Text;
+using System.Text.Json;
+using Hex1b.Automation;
+using Hex1b.Reflow;
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests;
+
+[TestClass]
+public class WebTerminalReflowTests
+{
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public async Task Resize_ProducerAndBrowser_PreserveLogicalLinesAndHistory(bool direct)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var muxer = new Hmp1PresentationAdapter(80, 10).WithReflow(GhosttyReflowStrategy.Instance);
+        await using var standalone = new Hwt1PresentationAdapter(80, 10).WithReflow(GhosttyReflowStrategy.Instance);
+        await using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload)
+            .WithPresentation(direct ? standalone : muxer).WithDimensions(80, 10).WithScrollback(1000).Build();
+        await using var shared = direct ? null : await muxer.CreateBrowserViewAsync("primary");
+        var view = shared ?? standalone;
+        await FrameAsync(view);
+        await MessageAsync(view, new { type = "requestPrimary", columns = 80, rows = 10 });
+        var lines = Enumerable.Range(0, 30).Select(i =>
+            $"{i:D2}:" + new string((char)('A' + i % 26), i % 2 == 0 ? 63 : 107) + "-END").ToArray();
+        workload.Write(string.Join("\r\n", lines) + "\r\n$ ");
+        using var ready = await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.GetLineTrimmed(9) == "$", TimeSpan.FromSeconds(5), "all output consumed")
+            .Build().ApplyAsync(terminal, TestContext.Current.CancellationToken);
+        var expected = lines.Append("$").ToArray();
+
+        foreach (var width in new[] { 20, 37, 80, 23, 100, 80 })
+        {
+            await MessageAsync(view, new { type = "resize", columns = width, rows = 10 });
+            var frame = await FrameAsync(view);
+            Assert.AreEqual(width, frame.GetProperty("columns").GetInt32());
+            Assert.AreEqual(width, terminal.Width);
+            using var snapshot = terminal.CreateSnapshot(1000);
+            TestSeq.AreEqual(expected, LogicalLines(snapshot));
+        }
+    }
+
+    [TestMethod]
+    public async Task Resize_SecondaryCannotResizeOrChangeProducerReflow()
+    {
+        await using var muxer = new Hmp1PresentationAdapter(80, 10).WithReflow(GhosttyReflowStrategy.Instance);
+        await using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(new Hex1bAppWorkloadAdapter())
+            .WithPresentation(muxer).WithDimensions(80, 10).WithScrollback(100).Build();
+        await using var primary = await muxer.CreateBrowserViewAsync("primary");
+        await using var secondary = await muxer.CreateBrowserViewAsync("secondary");
+        secondary.WithReflow(NoReflowStrategy.Instance);
+        await MessageAsync(primary, new { type = "requestPrimary", columns = 80, rows = 10 });
+        var text = new string('x', 65) + "-END";
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize(text + "\r\n$ "));
+        await FrameAsync(primary);
+        await FrameAsync(secondary);
+
+        await MessageAsync(secondary, new { type = "resize", columns = 20, rows = 10 });
+        Assert.AreEqual(80, terminal.Width);
+        await MessageAsync(primary, new { type = "resize", columns = 20, rows = 10 });
+        Assert.AreEqual(20, (await FrameAsync(primary)).GetProperty("columns").GetInt32());
+        Assert.AreEqual(20, (await FrameAsync(secondary)).GetProperty("columns").GetInt32());
+        using var snapshot = terminal.CreateSnapshot(100);
+        TestSeq.AreEqual(new[] { text, "$" }, LogicalLines(snapshot));
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void Resize_UnconfiguredAdapters_KeepCropDefault(bool direct)
+    {
+        IHex1bTerminalPresentationAdapter adapter = direct
+            ? new Hwt1PresentationAdapter(80, 10) : new Hmp1PresentationAdapter(80, 10);
+        using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(new Hex1bAppWorkloadAdapter())
+            .WithPresentation(adapter).WithDimensions(80, 10).Build();
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("ABCDEFGHIJKLMNOPQRSTUVWXYZ-END\r\n$ "));
+        terminal.Resize(20, 10);
+        terminal.Resize(80, 10);
+        using var snapshot = terminal.CreateSnapshot();
+        Assert.AreEqual("ABCDEFGHIJKLMNOPQRST", snapshot.GetLineTrimmed(0));
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void WithReflow_Builder_ConfiguresWebAdapters(bool direct)
+    {
+        IHex1bTerminalPresentationAdapter adapter = direct
+            ? new Hwt1PresentationAdapter(80, 10) : new Hmp1PresentationAdapter(80, 10);
+        using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(new Hex1bAppWorkloadAdapter())
+            .WithPresentation(adapter).WithDimensions(80, 10).WithReflow(GhosttyReflowStrategy.Instance).Build();
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("ABCDEFGHIJKLMNOPQRSTUVWXYZ-END\r\n$ "));
+        terminal.Resize(20, 10);
+        terminal.Resize(80, 10);
+        using var snapshot = terminal.CreateSnapshot();
+        Assert.AreEqual("ABCDEFGHIJKLMNOPQRSTUVWXYZ-END", snapshot.GetLineTrimmed(0));
+    }
+
+    [TestMethod]
+    [DataRow(20)]
+    [DataRow(80)]
+    public void Resize_WideCombiningStyledText_PreservesCellsAndCursor(int initialWidth)
+    {
+        var adapter = new Hmp1PresentationAdapter(initialWidth, 10).WithReflow(GhosttyReflowStrategy.Instance);
+        using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(new Hex1bAppWorkloadAdapter())
+            .WithPresentation(adapter).WithDimensions(initialWidth, 10).WithScrollback(100).Build();
+        var text = new string('a', 19) + "\u754ce\u0301" + new string('b', 18) + "\u754c-END";
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[1;31m" + text + "\x1b[0m"));
+        terminal.Resize(80, 10);
+        using var before = terminal.CreateSnapshot();
+        Assert.AreEqual(text, before.GetLineTrimmed(0));
+        foreach (var width in new[] { 20, 21, 37, 80, 20, 80 })
+        {
+            terminal.Resize(width, 10);
+            using var resized = terminal.CreateSnapshot();
+            TestSeq.AreEqual(new[] { text }, LogicalLines(resized));
+        }
+        using var after = terminal.CreateSnapshot();
+        Assert.AreEqual(text, after.GetLineTrimmed(0));
+        Assert.AreEqual(before.CursorX, after.CursorX);
+        Assert.AreEqual(before.CursorY, after.CursorY);
+        for (var x = 0; x < before.Width; x++)
+        {
+            Assert.AreEqual(before.GetCell(x, 0).Character, after.GetCell(x, 0).Character);
+            Assert.AreEqual(before.GetCell(x, 0).Foreground, after.GetCell(x, 0).Foreground);
+            Assert.AreEqual(before.GetCell(x, 0).Attributes, after.GetCell(x, 0).Attributes);
+        }
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("!"));
+        using var edited = terminal.CreateSnapshot();
+        Assert.AreEqual(text + "!", edited.GetLineTrimmed(0));
+    }
+
+    [TestMethod]
+    public void Resize_SavedCursor_FollowsEditablePrompt()
+    {
+        var adapter = new Hmp1PresentationAdapter(80, 10).WithReflow(GhosttyReflowStrategy.Instance);
+        using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(new Hex1bAppWorkloadAdapter())
+            .WithPresentation(adapter).WithDimensions(80, 10).Build();
+        var prefix = "$ " + new string('x', 39);
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize(prefix + "\x1b" + "7tail"));
+        terminal.Resize(20, 10);
+        terminal.Resize(80, 10);
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b" + "8EDIT"));
+        using var snapshot = terminal.CreateSnapshot();
+        Assert.AreEqual(prefix + "EDIT", snapshot.GetLineTrimmed(0));
+    }
+
+    [TestMethod]
+    [DataRow(20, 40)]
+    [DataRow(40, 20)]
+    [DataRow(20, 20)]
+    public void Resize_PendingWrap_AppendsWithoutOverwriting(int oldWidth, int newWidth)
+    {
+        var adapter = new Hmp1PresentationAdapter(oldWidth, 10).WithReflow(GhosttyReflowStrategy.Instance);
+        using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(new Hex1bAppWorkloadAdapter())
+            .WithPresentation(adapter).WithDimensions(oldWidth, 10).Build();
+        var text = new string('a', oldWidth);
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize(text));
+        terminal.Resize(newWidth, 10);
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("!"));
+        using var snapshot = terminal.CreateSnapshot();
+        TestSeq.AreEqual(new[] { text + "!" }, LogicalLines(snapshot));
+    }
+
+    [TestMethod]
+    public void Resize_CursorAfterBlankCells_PreservesInsertionOffset()
+    {
+        var adapter = new Hmp1PresentationAdapter(80, 10).WithReflow(GhosttyReflowStrategy.Instance);
+        using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(new Hex1bAppWorkloadAdapter())
+            .WithPresentation(adapter).WithDimensions(80, 10).Build();
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("text\x1b[1;32H\x1b" + "7"));
+        terminal.Resize(20, 10);
+        Assert.AreEqual(11, terminal.CursorX);
+        Assert.AreEqual(1, terminal.CursorY);
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b" + "8!"));
+        terminal.Resize(80, 10);
+        using var snapshot = terminal.CreateSnapshot();
+        Assert.AreEqual("text" + new string(' ', 27) + "!", snapshot.GetLineTrimmed(0));
+    }
+
+    [TestMethod]
+    public void Resize_WhileAlternateActive_ReflowsMainOnReturnWithoutReflowingAlternate()
+    {
+        var adapter = new Hmp1PresentationAdapter(80, 10).WithReflow(GhosttyReflowStrategy.Instance);
+        using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(new Hex1bAppWorkloadAdapter())
+            .WithPresentation(adapter).WithDimensions(80, 10).WithScrollback(100).Build();
+        var lines = Enumerable.Range(0, 15).Select(i => $"{i:D2}:" + new string('x', 63) + "-END").ToArray();
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize(string.Join("\r\n", lines) + "\r\n$ \x1b[?1049h\x1b[H" +
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ"));
+        var historyCount = terminal.ScrollbackCount;
+        terminal.Resize(20, 10);
+        using (var alternate = terminal.CreateSnapshot())
+        {
+            Assert.IsTrue(alternate.InAlternateScreen);
+            Assert.AreEqual("ABCDEFGHIJKLMNOPQRST", alternate.GetLineTrimmed(0));
+            Assert.AreEqual("", alternate.GetLineTrimmed(1));
+        }
+        Assert.AreEqual(historyCount, terminal.ScrollbackCount);
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[?1049l"));
+        terminal.Resize(80, 10);
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("edited"));
+        using var restored = terminal.CreateSnapshot(100);
+        TestSeq.AreEqual(lines.Append("$ edited").ToArray(), LogicalLines(restored));
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public async Task Resize_GraphicsAndHyperlinks_KeepProducerOwnershipAndReflowAnchors(bool alternate)
+    {
+        await using var muxer = new Hmp1PresentationAdapter(80, 10).WithReflow(GhosttyReflowStrategy.Instance);
+        await using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(new Hex1bAppWorkloadAdapter())
+            .WithPresentation(muxer).WithDimensions(80, 10).WithScrollback(100).Build();
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize(new string('a', 30) +
+            KgpTestHelper.BuildCommand("a=T,f=32,s=1,v=1,i=529,C=1,q=2", [255, 0, 0, 255]) +
+            "\x1b]8;;https://example.test/reflow\x1b\\linked\x1b]8;;\x1b\\\r\n$ "));
+        await using var view = await muxer.CreateBrowserViewAsync();
+        await FrameAsync(view);
+        if (alternate)
+            terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[?1049h"));
+        await MessageAsync(view, new { type = "requestPrimary", columns = 20, rows = 10 });
+        if (alternate)
+        {
+            await FrameAsync(view);
+            terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[?1049l"));
+        }
+        var narrow = await FrameAsync(view);
+        Assert.AreEqual(1, narrow.GetProperty("placements").GetArrayLength());
+        using (var snapshot = terminal.CreateSnapshot())
+        {
+            var placement = TestSeq.Single(snapshot.KgpPlacements);
+            Assert.AreEqual(1, placement.Row);
+            Assert.AreEqual(10, placement.Column);
+            Assert.AreEqual("https://example.test/reflow", snapshot.GetCell(10, 1).HyperlinkData?.Uri);
+        }
+        await MessageAsync(view, new { type = "resize", columns = 80, rows = 10 });
+        await FrameAsync(view);
+        using var restored = terminal.CreateSnapshot();
+        var original = TestSeq.Single(restored.KgpPlacements);
+        Assert.AreEqual(0, original.Row);
+        Assert.AreEqual(30, original.Column);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual("https://example.test/reflow", restored.GetCell(30, 0).HyperlinkData?.Uri);
+    }
+
+    [TestMethod]
+    public async Task Resize_LogicalWideSelection_CopiesExactTextThenInvalidates()
+    {
+        await using var muxer = new Hmp1PresentationAdapter(80, 10).WithReflow(GhosttyReflowStrategy.Instance);
+        await using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(new Hex1bAppWorkloadAdapter())
+            .WithPresentation(muxer).WithDimensions(80, 10).WithScrollback(100).Build();
+        var text = new string('a', 19) + "\u754ce\u0301-END";
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize(text + "\r\n$ "));
+        await using var view = await muxer.CreateBrowserViewAsync();
+        await MessageAsync(view, new { type = "requestPrimary", columns = 20, rows = 10 });
+        var history = (await FrameAsync(view)).GetProperty("history");
+        var select = new
+        {
+            type = "selection", action = "start", mode = "line", requestId = 1, column = 0,
+            generation = history.GetProperty("generation").GetString(),
+            rowId = history.GetProperty("rowIds")[0].GetString()
+        };
+        await MessageAsync(view, select);
+        var selection = (await FrameAsync(view)).GetProperty("history").GetProperty("selection");
+        Assert.AreEqual("valid", selection.GetProperty("status").GetString());
+        Assert.AreEqual(text, selection.GetProperty("text").GetString());
+        await MessageAsync(view, new { type = "resize", columns = 80, rows = 10 });
+        var resized = (await FrameAsync(view)).GetProperty("history");
+        Assert.AreEqual("invalidated", resized.GetProperty("selection").GetProperty("status").GetString());
+        Assert.AreNotEqual(history.GetProperty("generation").GetString(), resized.GetProperty("generation").GetString());
+        await MessageAsync(view, select with { requestId = 2 });
+        Assert.AreEqual("invalidated", (await FrameAsync(view)).GetProperty("history")
+            .GetProperty("selection").GetProperty("status").GetString());
+    }
+
+    [TestMethod]
+    public void Resize_RetentionLimit_DiscardsOnlyOldestRows()
+    {
+        var adapter = new Hmp1PresentationAdapter(80, 10).WithReflow(GhosttyReflowStrategy.Instance);
+        using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(new Hex1bAppWorkloadAdapter())
+            .WithPresentation(adapter).WithDimensions(80, 10).WithScrollback(3).Build();
+        var text = string.Concat(Enumerable.Range(0, 600).Select(i => (char)('A' + i % 26)));
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize(text));
+        terminal.Resize(20, 10);
+        Assert.AreEqual(3, terminal.ScrollbackCount);
+        using var narrow = terminal.CreateSnapshot(3);
+        TestSeq.AreEqual(new[] { text[^260..] }, LogicalLines(narrow));
+        terminal.Resize(80, 10);
+        using var wide = terminal.CreateSnapshot(3);
+        TestSeq.AreEqual(new[] { text[^260..] }, LogicalLines(wide));
+    }
+
+    [TestMethod]
+    public void Resize_SavedPendingWrap_RestoresInsertionPointAfterGrow()
+    {
+        var adapter = new Hmp1PresentationAdapter(20, 10).WithReflow(GhosttyReflowStrategy.Instance);
+        using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(new Hex1bAppWorkloadAdapter())
+            .WithPresentation(adapter).WithDimensions(20, 10).Build();
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize(new string('a', 20) + "\x1b" + "7\r\nprompt"));
+        terminal.Resize(80, 10);
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b" + "8!"));
+        using var snapshot = terminal.CreateSnapshot();
+        Assert.AreEqual(new string('a', 20) + "!", snapshot.GetLineTrimmed(0));
+        Assert.AreEqual("prompt", snapshot.GetLineTrimmed(1));
+    }
+
+    [TestMethod]
+    public void Resize_OneColumnNativeGrid_DoesNotLoopOnUnplaceableWideGlyph()
+    {
+        var adapter = new Hmp1PresentationAdapter(20, 10).WithReflow(GhosttyReflowStrategy.Instance);
+        using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(new Hex1bAppWorkloadAdapter())
+            .WithPresentation(adapter).WithDimensions(20, 10).Build();
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("A\u754cB"));
+        terminal.Resize(1, 10);
+        using var snapshot = terminal.CreateSnapshot();
+        TestSeq.AreEqual(new[] { "AB" }, LogicalLines(snapshot));
+    }
+
+    private static string[] LogicalLines(Hex1bTerminalSnapshot snapshot)
+    {
+        var lines = new List<string>();
+        var line = new StringBuilder();
+        for (var y = 0; y < snapshot.Height; y++)
+        {
+            for (var x = 0; x < snapshot.Width; x++)
+            {
+                var cell = snapshot.GetCell(x, y);
+                if (!cell.IsWideWrapPadding)
+                    line.Append(cell.Character);
+            }
+            if (!snapshot.GetCell(snapshot.Width - 1, y).IsSoftWrap)
+            {
+                lines.Add(line.ToString().TrimEnd());
+                line.Clear();
+            }
+        }
+        if (line.Length > 0)
+            lines.Add(line.ToString().TrimEnd());
+        while (lines.Count > 0 && lines[^1].Length == 0)
+            lines.RemoveAt(lines.Count - 1);
+        return lines.ToArray();
+    }
+
+    private static Task MessageAsync(Hwt1PresentationAdapter view, object message)
+        => view.HandleMessageAsync(JsonSerializer.SerializeToUtf8Bytes(message), TestContext.Current.CancellationToken);
+
+    private static async Task<JsonElement> FrameAsync(Hwt1PresentationAdapter view)
+    {
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(5));
+        var bytes = await view.ReadFrameAsync(timeout.Token);
+        using var document = JsonDocument.Parse(bytes.Slice(8, BinaryPrimitives.ReadInt32LittleEndian(bytes.Span[4..])));
+        var frame = document.RootElement.Clone();
+        await MessageAsync(view, new { type = "ack", revision = frame.GetProperty("revision").GetUInt32() });
+        return frame;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #529.

- Add opt-in producer-side reflow for HMP1 and directly attached HWT1 adapters, preserving library crop defaults and graphics-anchor lineage.
- Preserve text, cursor insertion positions, retained history and saved main-screen content across resize cycles, including wide/combining text.
- Add creation-time strategy selection to WebTerminalDemo and honor it through direct HWT1 and HMP1 relay views.
- Preserve soft wraps during HMP1 text/graphics replay; erase split wide glyphs in crop paths to prevent extra rows on reconnect.
- Add highlighted resize handles to all four demo window edges and corners, with opposite-edge anchoring and pointer capture cleanup.

## Compatibility

Library adapter defaults remain crop-and-extend. Enable normal shell reflow with `.WithReflow(GhosttyReflowStrategy.Instance)` on the authoritative producer. Demo shell defaults to Ghostty; generated scenes default to crop. Primary resize authority and selection invalidation are unchanged. Fresh relay replicas receive the live screen and accumulate subsequent history; direct views retain pre-existing producer history.

## Validation

- Full core suite: **11,445 passed, 24 skipped, zero failures**.
- Demo build: zero warnings/errors.
- All 12 real-browser VTE/Ghostty/None × direct/relay primary-secondary combinations, including Unicode logical selections, late attachment and reconnects.
- Eight-direction resize browser regressions on both transports: hover/active highlights, cancellation, size/origin limits, scrolling and resize authority.
- Existing floating-window fixtures passed on both transports; sizing fixture passed.

No downstream dependency changes or package publication.