### PR TITLE
Add OSC 7 and OSC 133 terminal integration

### DIFF
--- a/docs/web-terminal-protocol.md
+++ b/docs/web-terminal-protocol.md
@@ -164,6 +164,8 @@ delta.
 | `title` | string | Required complete current workload window title on every full/delta frame; `""` means unset or explicitly cleared. At most 4,096 UTF-16 code units, no C0/DEL/C1 controls or unpaired surrogates. |
 | `progress` | object | Required complete OSC 9;4 state: `state` and nullable `percentage`, defined below. |
 | `shellIntegration` | object | Required complete OSC 133 state: `phase` and nullable `lastExitCode`, defined below. |
+| `workingDirectory` | object | Required complete OSC 7 state: nullable `uri`, `host`, `path`, defined below. |
+| `commandMark` | object or null | Latest OSC 133 marker only (not a history), defined below. |
 | `history` | object or null | Complete per-view text viewport, selection, and copy state, defined below. Null denotes a projection without history interaction metadata. |
 | `hyperlinks` | array of objects | Complete OSC 8 destination ranges for the presented viewport, including on cell-delta frames. |
 | `defaultBackground`, `defaultForeground` | integers | Resolved packed colors, using §3.3; producer emits opaque colors. |
@@ -222,7 +224,25 @@ the other states. `shellIntegration` initially contains
 `{ "phase": "unknown", "lastExitCode": null }`. Phase is one of `unknown`,
 `prompt`, `commandLine`, `executing`, `finished`. Last exit code is null or a
 signed 32-bit integer; Unknown requires null. Null does not imply success.
+`workingDirectory` initially contains `{ "uri": null, "host": null, "path": null }`
+from OSC 7. When set, `uri` is the raw `file://` URI as reported by the shell;
+`host` and `path` are derived from it (`host` is `""` for a local/unqualified
+authority). A malformed or non-`file` URI does not update this state.
 All properties are required, including explicit nulls.
+
+`commandMark` is `null` until the first OSC 133 marker, then `{ "phase", "exitCode",
+"rawParameters" }`: `phase` is one of `unknown`, `prompt`, `commandLine`, `executing`,
+`finished` (same enum as `shellIntegration.phase`); `exitCode` is null except on a
+`finished` mark, where it carries the reported OSC 133;D exit code as a signed 32-bit
+integer; `rawParameters` is the verbatim `key=value[;key=value...]` text trailing the
+marker (for example a `cmdline_url` extension on marker C), or null when none was
+present. This is the single most-recently-reported marker only, exactly mirroring how
+`shellIntegration` exposes only the current phase rather than a stream of past phases;
+it is not a command-mark history. `Hex1bTerminal.CommandMarks` keeps a bounded
+server-side history of marks, but that history itself is never sent over the wire —
+only this atomic "latest mark" projection is. Clients that want their own history
+should accumulate distinct `commandMark` values from
+`WebTerminalOptions.onCommandMarkChange` themselves.
 
 Both objects are captured atomically with the screen, sent on every full and
 delta frame, and remain current when inspecting historical rows. Metadata-only
@@ -232,7 +252,9 @@ or transport an event log. The browser validates fields before presenting,
 updates both getters, then invokes `onProgressChange` and
 `onShellIntegrationChange` for the initial state and distinct presented changes.
 Missing/malformed fields are fatal. Unchanged resyncs, discarded frames, and
-disposal do not notify.
+disposal do not notify. `workingDirectory` and `commandMark` follow the same
+validation, getter, and callback pattern via `onWorkingDirectoryChange` and
+`onCommandMarkChange`.
 
 HMP1 restores these values from its structured activity checkpoint as part of
 the StateSync transaction, before the replica is available to browser capture.
@@ -244,6 +266,7 @@ last reported values, not an invented completion. Hosts should combine these
 values with connection status. The
 [public client contract](../src/web-terminal/README.md#application-progress-and-shell-activity)
 describes callback semantics and the supported OSC argument forms.
+
 
 `cursor` has exactly these currently emitted fields:
 
@@ -1229,6 +1252,8 @@ not a recorded multi-head benchmark.
   "title": "",
   "progress": { "state": "none", "percentage": null },
   "shellIntegration": { "phase": "unknown", "lastExitCode": null },
+  "workingDirectory": { "uri": null, "host": null, "path": null },
+  "commandMark": null,
   "history": null,
   "hyperlinks": [],
   "defaultBackground": 4279769112,

--- a/samples/WebTerminalDemo/DemoTapeCatalog.cs
+++ b/samples/WebTerminalDemo/DemoTapeCatalog.cs
@@ -14,7 +14,11 @@ internal sealed class DemoTapeCatalog
             new("line-editing", "shell", "Editing and history", "Correct a command with Backspace, then replay it with Up.")
         ];
         if (!OperatingSystem.IsWindows())
+        {
             entries.Add(new("ansi-colors", "shell", "ANSI colors", "Use the shell's printf command to display colored text."));
+            entries.Add(new("shell-integration", "shell", "Shell integration",
+                "Use printf to emit OSC 7 working-directory and OSC 133 command-mark sequences across a few commands."));
+        }
 
         var options = new TapeParserOptions();
         options.SyntaxExtensions.Remove("Source");

--- a/samples/WebTerminalDemo/Tapes/shell/shell-integration.tape
+++ b/samples/WebTerminalDemo/Tapes/shell/shell-integration.tape
@@ -1,0 +1,38 @@
+# POSIX-shell printf; this tape is not offered for Windows cmd.exe.
+Set TypingSpeed 25ms
+Set WaitTimeout 10s
+Wait /([#$%>]|[^\x00-\x7f])$/
+
+# Report a working directory (OSC 7), then mark a fresh prompt (OSC 133;A).
+Type "printf '\033]7;file://localhost/home/demo/project\007\033]133;A\007'"
+Enter
+Sleep 300ms
+Wait /([#$%>]|[^\x00-\x7f])$/
+
+# Command 1: a successful build. B marks the start of input, C marks execution
+# (with a cmdline_url extension), and D reports the real exit code.
+Type "printf '\033]133;B\007'; printf '\033]133;C;cmdline_url=%s\007' 'npm%20run%20build'; echo 'Building project...' && sleep 0.3 && echo 'Build succeeded.'; printf '\033]133;D;%s\007' $?"
+Enter
+Sleep 800ms
+Wait /([#$%>]|[^\x00-\x7f])$/
+
+# Command 2: a failing command, so D reports a non-zero exit code.
+Type "printf '\033]133;A\007'"
+Enter
+Sleep 300ms
+Wait /([#$%>]|[^\x00-\x7f])$/
+Type "printf '\033]133;B\007'; printf '\033]133;C\007'; ls /no/such/path; printf '\033]133;D;%s\007' $?"
+Enter
+Sleep 800ms
+Wait /([#$%>]|[^\x00-\x7f])$/
+
+# Move into a different directory (OSC 7 changes again) for a final command.
+Type "printf '\033]7;file://localhost/home/demo/project/dist\007\033]133;A\007'"
+Enter
+Sleep 300ms
+Wait /([#$%>]|[^\x00-\x7f])$/
+Type "printf '\033]133;B\007'; printf '\033]133;C\007'; echo 'Deploying dist/...' && sleep 0.3 && echo 'Deploy complete.'; printf '\033]133;D;%s\007' $?"
+Enter
+Sleep 800ms
+Wait /([#$%>]|[^\x00-\x7f])$/
+Sleep 1s

--- a/samples/WebTerminalDemo/client/main.ts
+++ b/samples/WebTerminalDemo/client/main.ts
@@ -1,4 +1,4 @@
-import { WebTerminal, MIN_FONT_SIZE, MAX_FONT_SIZE, type TerminalCloseDetails } from "@hex1b/web-terminal";
+import { WebTerminal, MIN_FONT_SIZE, MAX_FONT_SIZE, getCmdlineUrl, type TerminalCloseDetails, type TerminalCommandMark } from "@hex1b/web-terminal";
 
 interface TerminalInstance {
   id: string;
@@ -30,6 +30,19 @@ interface TapePlayback {
   diagnostics: string[];
 }
 
+/**
+ * A single command-mark rail entry, demo-only bookkeeping layered on top of the library's
+ * `onCommandMarkChange` callback. `anchor` captures the viewport coordinates in effect when the
+ * command line started, letting the demo scroll back to (roughly) that point later. It is null
+ * when no viewport snapshot was available yet, in which case the dot cannot be jumped to.
+ */
+interface CommandMarkEntry {
+  phase: TerminalCommandMark["phase"];
+  exitCode: number | null;
+  cmdlineUrl: string | null;
+  anchor: { generation: string; top: number } | null;
+}
+
 interface TerminalView {
   id: string;
   instance: TerminalInstance;
@@ -45,6 +58,7 @@ interface TerminalView {
   transport: "direct" | "hmp1";
   viewport?: WebTerminal["viewport"];
   selection?: WebTerminal["selection"];
+  commandMarks: CommandMarkEntry[];
 }
 
 interface ViewClosure {
@@ -373,6 +387,44 @@ function showClosure(view: TerminalView, closure: ViewClosure) {
   return closure;
 }
 
+/** Rebuilds the left-edge command-mark dots for `view` from `view.commandMarks`. */
+function renderCommandMarksRail(view: TerminalView) {
+  const rail = elementAt(view.element, ".command-marks-rail", HTMLElement);
+  rail.replaceChildren(...view.commandMarks.map(entry => {
+    const dot = document.createElement("button");
+    dot.type = "button";
+    dot.className = "command-mark-dot";
+    dot.setAttribute("role", "listitem");
+    dot.dataset.phase = entry.phase;
+    if (entry.exitCode !== null) dot.dataset.exit = entry.exitCode === 0 ? "ok" : "error";
+    const description = entry.phase === "finished"
+      ? `Command finished${entry.exitCode === null ? "" : ` (exit ${entry.exitCode})`}`
+      : entry.phase === "executing" ? "Command running" : "Command entered";
+    const detail = [description, entry.cmdlineUrl ?? ""].filter(Boolean).join("\n");
+    dot.title = entry.anchor ? `${detail}\nClick to jump back to this point.`
+      : `${detail}\nThis point can no longer be located in scrollback.`;
+    dot.setAttribute("aria-label", dot.title.replace(/\n/g, ". "));
+    dot.disabled = entry.anchor === null;
+    dot.addEventListener("click", () => jumpToCommandMark(view, entry));
+    return dot;
+  }));
+}
+
+/**
+ * Scrolls `view`'s terminal back to where `entry.anchor` was captured, using a relative delta from
+ * the current viewport top (the library only exposes relative scrolling). Refuses to jump when the
+ * viewport generation has changed since capture (resize/reflow/reset/history-clear/alt-screen
+ * transition), since row coordinates are no longer comparable at that point.
+ */
+function jumpToCommandMark(view: TerminalView, entry: CommandMarkEntry) {
+  const viewport = view.viewport;
+  if (!view.terminal || !entry.anchor || !viewport?.available || viewport.generation !== entry.anchor.generation) {
+    report("That point is no longer reachable in scrollback (the view was reset, resized, or reflowed since).", "error");
+    return;
+  }
+  view.terminal.scrollLines(entry.anchor.top - viewport.top);
+}
+
 function connectionClosed(view: TerminalView, close: TerminalCloseDetails) {
   const stage = view.phase === "connected" ? "After mounting" : "Before mounting completed";
   const summary = close.code === 4000 ? "The producer has ended. This terminal cannot be reconnected."
@@ -499,8 +551,11 @@ async function openView(instance: TerminalInstance, { primary = false, thumbnail
       <span class="shell-status">Shell activity unknown</span>
       <progress class="activity-progress" max="100" hidden aria-label="Application progress"></progress>
       <span class="progress-status"></span>
+      <span class="cwd-status"></span>
+      <span class="command-mark-status"></span>
     </div>
     <div class="terminal-stage">
+      <div class="command-marks-rail" role="list" aria-label="Command history"></div>
       <div class="terminal-mount"></div>
       <div class="closed-overlay" hidden>
         <div class="closed-card">
@@ -541,7 +596,8 @@ async function openView(instance: TerminalInstance, { primary = false, thumbnail
   workspace.append(element);
   workspace.classList.remove("empty");
   const view: TerminalView = {
-    id, instance, element, controller: new AbortController(), phase: "connecting", stats: {}, text: "", transport
+    id, instance, element, controller: new AbortController(), phase: "connecting", stats: {}, text: "", transport,
+    commandMarks: []
   };
   views.set(id, view);
   selectView(view);
@@ -596,12 +652,15 @@ async function mountView(view: TerminalView, primary = false, failure = "", focu
   view.closure = undefined;
   view.stats = {};
   view.text = "";
+  view.commandMarks = [];
+  let previousMarkPhase: TerminalCommandMark["phase"] | null = null;
   const { element, instance, id, transport } = view;
   const current = () => !controller.signal.aborted && !view.controller.signal.aborted;
   element.dataset.phase = "connecting";
   element.dataset.connected = "false";
   elementAt(element, ".closed-overlay", HTMLElement).hidden = true;
   elementAt(element, ".terminal-mount", HTMLElement).inert = false;
+  elementAt(element, ".command-marks-rail", HTMLElement).replaceChildren();
   elementAt(element, ".view-role", HTMLElement).textContent = "Joining";
   elementAt(element, ".view-role", HTMLElement).title = "";
   updateViewControls(view);
@@ -644,6 +703,37 @@ async function mountView(view: TerminalView, primary = false, failure = "", focu
         element.dataset.shellPhase = shell.phase;
         elementAt(element, ".shell-status", HTMLElement).textContent = labels[shell.phase] +
           (shell.lastExitCode === null ? "" : ` / last exit ${shell.lastExitCode}`);
+      },
+      onWorkingDirectoryChange(workingDirectory) {
+        elementAt(element, ".cwd-status", HTMLElement).textContent =
+          workingDirectory.path === null ? "" : `cwd: ${workingDirectory.path}`;
+      },
+      onCommandMarkChange(mark) {
+        const status = elementAt(element, ".command-mark-status", HTMLElement);
+        if (mark === null) {
+          status.textContent = "";
+          previousMarkPhase = null;
+          return;
+        }
+        const cmdlineUrl = getCmdlineUrl(mark);
+        status.textContent = `mark: ${mark.phase}` +
+          (mark.exitCode === null ? "" : ` (exit ${mark.exitCode})`) +
+          (cmdlineUrl === null ? "" : ` / ${cmdlineUrl}`);
+        // A rising edge into "commandLine" starts a new logical command; every other phase update
+        // (executing, finished) refines the same trailing rail entry in place.
+        if (mark.phase === "commandLine" && previousMarkPhase !== "commandLine") {
+          const viewport = view.viewport;
+          const anchor = viewport?.available ? { generation: viewport.generation, top: viewport.top } : null;
+          view.commandMarks.push({ phase: mark.phase, exitCode: mark.exitCode, cmdlineUrl, anchor });
+          if (view.commandMarks.length > 20) view.commandMarks.shift();
+        } else if (view.commandMarks.length > 0) {
+          const entry = view.commandMarks[view.commandMarks.length - 1];
+          entry.phase = mark.phase;
+          entry.exitCode = mark.exitCode;
+          if (cmdlineUrl !== null) entry.cmdlineUrl = cmdlineUrl;
+        }
+        previousMarkPhase = mark.phase;
+        renderCommandMarksRail(view);
       },
       onStatus(message, level) {
         if (!current() || view.closure?.close) return;

--- a/samples/WebTerminalDemo/wwwroot/index.html
+++ b/samples/WebTerminalDemo/wwwroot/index.html
@@ -114,6 +114,16 @@
     [data-connected=false] .view-activity { visibility: hidden; }
     .terminal-stage { display: flex; position: relative; flex: 1 1 0; min-width: 0; min-height: 0; }
     .terminal-mount { flex: 1 1 0; min-width: 0; min-height: 0; contain: size; overflow: hidden; }
+    .command-marks-rail { display: flex; flex: 0 0 14px; flex-direction: column; align-items: center; gap: 4px; padding: 6px 0; overflow-y: auto; background: var(--cp-surface-soft); border-right: 1px solid var(--cp-border); }
+    .command-marks-rail:empty { border-right-color: transparent; }
+    .command-mark-dot { width: 8px; height: 8px; min-height: 0; flex: none; padding: 0; margin: 0; border: 1px solid var(--cp-border-strong); border-radius: 50%; background: var(--cp-text-muted); cursor: pointer; }
+    .command-mark-dot:hover { transform: scale(1.35); }
+    .command-mark-dot:focus-visible { outline: 2px solid var(--cp-link); outline-offset: 1px; }
+    .command-mark-dot:disabled { cursor: not-allowed; opacity: 0.4; transform: none; }
+    .command-mark-dot[data-phase=executing] { background: var(--cp-warning); border-color: var(--cp-warning); animation: command-mark-pulse 1.1s ease-in-out infinite; }
+    .command-mark-dot[data-exit=ok] { background: var(--cp-success); border-color: var(--cp-success); }
+    .command-mark-dot[data-exit=error] { background: var(--cp-danger); border-color: var(--cp-danger); }
+    @keyframes command-mark-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
     .closed-overlay { position: absolute; inset: 0; z-index: 1; display: flex; overflow: auto; padding: 12px; background: var(--cp-overlay); }
     .closed-overlay[hidden] { display: none; }
     .closed-card { margin: auto; width: 100%; max-width: 480px; padding: 16px; border: 1px solid var(--cp-border-strong); border-radius: 12px; background: var(--cp-surface); box-shadow: var(--cp-shadow); overflow-wrap: anywhere; }

--- a/src/Hex1b/Automation/Hex1bTerminalSnapshot.cs
+++ b/src/Hex1b/Automation/Hex1bTerminalSnapshot.cs
@@ -63,6 +63,8 @@ public sealed class Hex1bTerminalSnapshot : IHex1bTerminalRegion, IDisposable
         SavedTitles = state.SavedTitles;
         Progress = state.Progress;
         ShellIntegration = state.ShellIntegration;
+        WorkingDirectory = state.WorkingDirectory;
+        CommandMarks = state.CommandMarks;
 
         var scrollbackRows = state.ScrollbackRows;
         ScrollbackLineCount = scrollbackRows.Length;
@@ -170,6 +172,12 @@ public sealed class Hex1bTerminalSnapshot : IHex1bTerminalRegion, IDisposable
     /// <summary>Gets the immutable shell phase and latest result captured atomically with this snapshot.</summary>
     /// <remarks>This is current terminal activity even when the snapshot displays historical text.</remarks>
     public TerminalShellIntegration ShellIntegration { get; }
+
+    /// <summary>Gets the working directory last reported by OSC 7, captured atomically with this snapshot.</summary>
+    public TerminalWorkingDirectory WorkingDirectory { get; }
+
+    /// <summary>Gets the OSC 133 command-mark history captured atomically with this snapshot.</summary>
+    public IReadOnlyList<TerminalCommandMark> CommandMarks { get; }
 
     internal string IconName { get; }
 

--- a/src/Hex1b/Automation/Hex1bTerminalSnapshotState.cs
+++ b/src/Hex1b/Automation/Hex1bTerminalSnapshotState.cs
@@ -35,4 +35,6 @@ internal sealed record Hex1bTerminalSnapshotState(
     string IconName,
     IReadOnlyList<(string Title, string IconName)> SavedTitles,
     TerminalProgress Progress,
-    TerminalShellIntegration ShellIntegration);
+    TerminalShellIntegration ShellIntegration,
+    TerminalWorkingDirectory WorkingDirectory,
+    IReadOnlyList<TerminalCommandMark> CommandMarks);

--- a/src/Hex1b/Hex1bTerminal.Activity.cs
+++ b/src/Hex1b/Hex1bTerminal.Activity.cs
@@ -41,6 +41,61 @@ public sealed partial class Hex1bTerminal
     /// </remarks>
     public event Action<TerminalShellIntegration>? ShellIntegrationChanged;
 
+    /// <summary>Gets the working directory last reported by OSC 7.</summary>
+    /// <remarks>
+    /// Defaults to no reported directory. RIS clears it; soft reset, screen changes, and
+    /// process exit preserve it, matching <see cref="Progress"/> and
+    /// <see cref="ShellIntegration"/>.
+    /// </remarks>
+    public TerminalWorkingDirectory WorkingDirectory
+    {
+        get { lock (_bufferLock) return _activityState.WorkingDirectory; }
+    }
+
+    /// <summary>Occurs when the reported working directory changes to a distinct value.</summary>
+    /// <remarks>
+    /// Subscribing does not emit the baseline; read <see cref="WorkingDirectory"/> for
+    /// current state.
+    /// </remarks>
+    public event Action<TerminalWorkingDirectory>? WorkingDirectoryChanged;
+
+    private readonly List<TerminalCommandMark> _commandMarks = [];
+    private int _commandMarkHistoryCapacity = 200;
+
+    /// <summary>
+    /// Gets the bounded history of OSC 133 command marks, oldest first.
+    /// </summary>
+    /// <remarks>
+    /// Capacity is configured via <see cref="Hex1bTerminalOptions.CommandMarkHistoryCapacity"/>;
+    /// once exceeded, the oldest marks are evicted. RIS and reflow do not remove existing
+    /// entries, but their row anchors become unresolvable (see <see cref="TerminalCommandMark"/>).
+    /// </remarks>
+    public IReadOnlyList<TerminalCommandMark> CommandMarks
+    {
+        get { lock (_bufferLock) return [.. _commandMarks]; }
+    }
+
+    /// <summary>Occurs when a new OSC 133 command mark is recorded.</summary>
+    /// <remarks>Subscribing does not emit prior marks; read <see cref="CommandMarks"/> for
+    /// current history.</remarks>
+    public event Action<TerminalCommandMark>? CommandMarkAdded;
+
+    private void RecordCommandMarkIfPresent(string command, string parameters, string payload)
+    {
+        if (command != "133" || _commandMarkHistoryCapacity == 0)
+            return;
+        if (!TerminalActivityState.TryParseMarker(parameters, payload, out var phase, out var exitCode,
+                out var rawParameters))
+            return;
+
+        EnsureTextRows();
+        var mark = new TerminalCommandMark(phase, exitCode, rawParameters, _textGeneration, _textScreenRowIds[_cursorY]);
+        _commandMarks.Add(mark);
+        while (_commandMarks.Count > _commandMarkHistoryCapacity)
+            _commandMarks.RemoveAt(0);
+        CommandMarkAdded?.Invoke(mark);
+    }
+
     internal void SubscribeActivityStateChanged(Action<TerminalActivityState> handler)
     {
         lock (_bufferLock)
@@ -62,11 +117,12 @@ public sealed partial class Hex1bTerminal
         }
     }
 
-    internal void RestoreActivityState(TerminalProgress progress, TerminalShellIntegration shellIntegration)
+    internal void RestoreActivityState(TerminalProgress progress, TerminalShellIntegration shellIntegration,
+        TerminalWorkingDirectory workingDirectory)
     {
         lock (_bufferLock)
         {
-            SetActivityState(new TerminalActivityState(progress, shellIntegration));
+            SetActivityState(new TerminalActivityState(progress, shellIntegration, workingDirectory));
         }
         PresentationInvalidated?.Invoke();
     }
@@ -105,5 +161,7 @@ public sealed partial class Hex1bTerminal
             ProgressChanged?.Invoke(state.Progress);
         if (previous.ShellIntegration != state.ShellIntegration)
             ShellIntegrationChanged?.Invoke(state.ShellIntegration);
+        if (previous.WorkingDirectory != state.WorkingDirectory)
+            WorkingDirectoryChanged?.Invoke(state.WorkingDirectory);
     }
 }

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -389,6 +389,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 OnScrollbackRowPruned);
             _scrollbackCallback = options.ScrollbackCallback;
         }
+        _commandMarkHistoryCapacity = Math.Max(0, options.CommandMarkHistoryCapacity);
         
         _dcsByteStreamParser = new DcsByteStreamParser(sixelPolicy);
         _escapeTimeout = options.EscapeSequenceTimeout ?? TimeSpan.FromMilliseconds(50);
@@ -2174,7 +2175,9 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 _iconName,
                 includeSavedTitles ? Array.AsReadOnly(_titleStack.ToArray()) : [],
                 _activityState.Progress,
-                _activityState.ShellIntegration);
+                _activityState.ShellIntegration,
+                _activityState.WorkingDirectory,
+                [.. _commandMarks]);
         }
     }
 
@@ -6771,7 +6774,8 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
     }
 
     /// <summary>
-    /// Processes an OSC sequence, handling title sequences (0/1/2/22/23) and hyperlinks (8).
+    /// Processes an OSC sequence, handling title sequences (0/1/2/22/23), hyperlinks (8),
+    /// and shell integration (7/9/133).
     /// </summary>
     /// <remarks>
     /// <para>Supported OSC sequences:</para>
@@ -6779,9 +6783,12 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
     ///   <item>OSC 0 - Set icon name AND window title</item>
     ///   <item>OSC 1 - Set icon name only</item>
     ///   <item>OSC 2 - Set window title only</item>
+    ///   <item>OSC 7 - Report working directory</item>
     ///   <item>OSC 8 - Hyperlinks</item>
+    ///   <item>OSC 9;4 - Progress</item>
     ///   <item>OSC 22 - Push current title/icon onto stack, optionally set new values</item>
     ///   <item>OSC 23 - Pop title/icon from stack and restore</item>
+    ///   <item>OSC 133 - Shell integration markers and command marks</item>
     /// </list>
     /// <para>
     /// OSC 0/1/2 do NOT affect the title stack - they only modify current values.
@@ -6814,9 +6821,11 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 ProcessOsc8Hyperlink(parameters, payload);
                 break;
 
+            case "7":
             case "9":
             case "133":
                 SetActivityState(_activityState.ApplyOsc(command, parameters, payload));
+                RecordCommandMarkIfPresent(command, parameters, payload);
                 break;
                 
             case "22":

--- a/src/Hex1b/Hex1bTerminalOptions.cs
+++ b/src/Hex1b/Hex1bTerminalOptions.cs
@@ -108,6 +108,13 @@ public sealed class Hex1bTerminalOptions
     public int? ScrollbackCapacity { get; set; }
 
     /// <summary>
+    /// Maximum number of OSC 133 command marks to retain in <see cref="Hex1bTerminal.CommandMarks"/>.
+    /// Oldest marks are evicted first once the capacity is exceeded. Default is 200; set to 0
+    /// to disable command mark history entirely.
+    /// </summary>
+    public int CommandMarkHistoryCapacity { get; set; } = 200;
+
+    /// <summary>
     /// Optional callback invoked each time a row is scrolled off the top of the terminal
     /// into the scrollback buffer. Can be used for persistence or logging.
     /// </summary>

--- a/src/Hex1b/Hmp1/Hex1bTerminal.Hmp1Replay.cs
+++ b/src/Hex1b/Hmp1/Hex1bTerminal.Hmp1Replay.cs
@@ -93,7 +93,10 @@ public sealed partial class Hex1bTerminal
                 RestoreActivityState(
                     new TerminalProgress((TerminalProgressState)activity.Progress.State, activity.Progress.Percentage),
                     new TerminalShellIntegration((TerminalShellIntegrationPhase)activity.ShellIntegration.Phase,
-                        activity.ShellIntegration.LastExitCode));
+                        activity.ShellIntegration.LastExitCode),
+                    activity.WorkingDirectory.Uri is { } uri
+                        ? TerminalWorkingDirectory.TryCreate(uri) ?? TerminalWorkingDirectory.Default
+                        : TerminalWorkingDirectory.Default);
             }
             catch
             {

--- a/src/Hex1b/Hmp1/Hmp1ActivityState.cs
+++ b/src/Hex1b/Hmp1/Hmp1ActivityState.cs
@@ -13,11 +13,13 @@ internal sealed record Hmp1ActivityState
 
     public required Hmp1ProgressState Progress { get; init; }
     public required Hmp1ShellIntegrationState ShellIntegration { get; init; }
+    public required Hmp1WorkingDirectoryState WorkingDirectory { get; init; }
 
     internal static Hmp1ActivityState Default { get; } = new()
     {
         Progress = new() { State = 0, Percentage = null },
-        ShellIntegration = new() { Phase = 0, LastExitCode = null }
+        ShellIntegration = new() { Phase = 0, LastExitCode = null },
+        WorkingDirectory = new() { Uri = null }
     };
 
     internal static Hmp1ActivityState Capture(Hex1bTerminalSnapshot snapshot) => new()
@@ -27,7 +29,8 @@ internal sealed record Hmp1ActivityState
         {
             Phase = (int)snapshot.ShellIntegration.Phase,
             LastExitCode = snapshot.ShellIntegration.LastExitCode
-        }
+        },
+        WorkingDirectory = new() { Uri = snapshot.WorkingDirectory.Uri }
     };
 
     internal static Hmp1ActivityState Parse(ReadOnlyMemory<byte> payload)
@@ -43,7 +46,9 @@ internal sealed record Hmp1ActivityState
             if (state.Progress is not { State: >= 0 and <= 4 } progress ||
                 state.ShellIntegration is not { Phase: >= 0 and <= 4 } shell ||
                 (progress.State is 0 or 3 ? progress.Percentage is not null : progress.Percentage is not (>= 0 and <= 100)) ||
-                (shell.Phase == 0 && shell.LastExitCode is not null))
+                (shell.Phase == 0 && shell.LastExitCode is not null) ||
+                state.WorkingDirectory is not { } workingDirectory ||
+                (workingDirectory.Uri is not null && TerminalWorkingDirectory.TryCreate(workingDirectory.Uri) is null))
                 throw new InvalidDataException("Invalid HMP activity checkpoint state.");
             return state;
         }
@@ -83,4 +88,10 @@ internal sealed record Hmp1ShellIntegrationState
 {
     public required int Phase { get; init; }
     public required int? LastExitCode { get; init; }
+}
+
+[JsonUnmappedMemberHandling(JsonUnmappedMemberHandling.Disallow)]
+internal sealed record Hmp1WorkingDirectoryState
+{
+    public required string? Uri { get; init; }
 }

--- a/src/Hex1b/Hwt1/Hwt1CommandMark.cs
+++ b/src/Hex1b/Hwt1/Hwt1CommandMark.cs
@@ -1,0 +1,23 @@
+namespace Hex1b;
+
+/// <summary>
+/// Wire projection of the most recently recorded <see cref="TerminalCommandMark"/>, atomic with
+/// the rest of the frame. Unlike <see cref="TerminalCommandMark"/>'s server-side bounded history,
+/// HWT1 does not transport a mark history or event log — only the latest one, mirroring how
+/// <see cref="Hwt1ShellIntegration"/> exposes only the current phase. <c>rawParameters</c> is
+/// sent verbatim; parsing into individual keys (e.g. <c>cmdline_url</c>) is left to the client.
+/// </summary>
+internal sealed record Hwt1CommandMark(string Phase, int? ExitCode, string? RawParameters)
+{
+    internal static Hwt1CommandMark? From(TerminalCommandMark? mark) => mark is null
+        ? null
+        : new(mark.Phase switch
+        {
+            TerminalShellIntegrationPhase.Unknown => "unknown",
+            TerminalShellIntegrationPhase.Prompt => "prompt",
+            TerminalShellIntegrationPhase.CommandLine => "commandLine",
+            TerminalShellIntegrationPhase.Executing => "executing",
+            TerminalShellIntegrationPhase.Finished => "finished",
+            _ => throw new ArgumentOutOfRangeException(nameof(mark))
+        }, mark.ExitCode, mark.RawParameters);
+}

--- a/src/Hex1b/Hwt1/Hwt1FrameMetadata.cs
+++ b/src/Hex1b/Hwt1/Hwt1FrameMetadata.cs
@@ -7,4 +7,5 @@ internal sealed record Hwt1FrameMetadata(
     List<Hwt1RenderImage> Images, string[] RetainedImages, List<Hwt1RenderPlacement> Placements,
     Hwt1FrameStatistics Stats, List<string> Warnings, Hwt1Peer Peer, Hwt1History? History,
     List<Hwt1Hyperlink> Hyperlinks, string Title,
-    Hwt1Progress Progress, Hwt1ShellIntegration ShellIntegration);
+    Hwt1Progress Progress, Hwt1ShellIntegration ShellIntegration, Hwt1WorkingDirectory WorkingDirectory,
+    Hwt1CommandMark? CommandMark);

--- a/src/Hex1b/Hwt1/Hwt1RenderProjection.cs
+++ b/src/Hex1b/Hwt1/Hwt1RenderProjection.cs
@@ -172,7 +172,9 @@ internal sealed class Hwt1RenderProjection
             new(workloadBytes, outputBatches, elapsedMs,
                 snapshotMs + Stopwatch.GetElapsedTime(started).TotalMilliseconds),
             warnings, peer ?? Hwt1Peer.Standalone, history, hyperlinks, snapshot.WindowTitle,
-            Hwt1Progress.From(snapshot.Progress), Hwt1ShellIntegration.From(snapshot.ShellIntegration)),
+            Hwt1Progress.From(snapshot.Progress), Hwt1ShellIntegration.From(snapshot.ShellIntegration),
+            Hwt1WorkingDirectory.From(snapshot.WorkingDirectory),
+            Hwt1CommandMark.From(snapshot.CommandMarks.Count > 0 ? snapshot.CommandMarks[^1] : null)),
             Hwt1JsonSerializerContext.Default.Hwt1FrameMetadata);
         if (metadata.Length > 8 * 1024 * 1024)
             throw new InvalidDataException("Frame metadata exceeds the HWT1 8 MiB limit.");

--- a/src/Hex1b/Hwt1/Hwt1WorkingDirectory.cs
+++ b/src/Hex1b/Hwt1/Hwt1WorkingDirectory.cs
@@ -1,0 +1,7 @@
+namespace Hex1b;
+
+internal sealed record Hwt1WorkingDirectory(string? Uri, string? Host, string? Path)
+{
+    internal static Hwt1WorkingDirectory From(TerminalWorkingDirectory workingDirectory) =>
+        new(workingDirectory.Uri, workingDirectory.Host, workingDirectory.Path);
+}

--- a/src/Hex1b/TerminalActivityState.cs
+++ b/src/Hex1b/TerminalActivityState.cs
@@ -6,10 +6,11 @@ namespace Hex1b;
 /// <summary>Immutable activity pair and shared reducer for authoritative and standalone terminals.</summary>
 internal sealed record TerminalActivityState(
     TerminalProgress Progress,
-    TerminalShellIntegration ShellIntegration)
+    TerminalShellIntegration ShellIntegration,
+    TerminalWorkingDirectory WorkingDirectory)
 {
     internal static TerminalActivityState Default { get; } =
-        new(TerminalProgress.Default, TerminalShellIntegration.Default);
+        new(TerminalProgress.Default, TerminalShellIntegration.Default, TerminalWorkingDirectory.Default);
 
     internal TerminalActivityState Apply(AnsiToken token) => token switch
     {
@@ -20,6 +21,12 @@ internal sealed record TerminalActivityState(
 
     internal TerminalActivityState ApplyOsc(string command, string parameters, string payload)
     {
+        if (command == "7")
+        {
+            var directory = TerminalWorkingDirectory.TryCreate(payload);
+            return directory is null ? this : this with { WorkingDirectory = directory };
+        }
+
         if (command == "9" && parameters == "4")
         {
             var separator = payload.IndexOf(';');
@@ -45,42 +52,64 @@ internal sealed record TerminalActivityState(
 
         if (command == "133")
         {
-            // The tokenizer places a bare marker in Payload, but a marker with an
-            // argument in Parameters (including D with an explicitly empty argument).
-            var marker = parameters.Length == 0 ? payload : parameters;
-            if (marker == "D")
-            {
-                int? exitCode = null;
-                if (parameters.Length != 0 && payload.Length != 0)
-                {
-                    if (!IsAsciiDecimal(payload, allowSign: true) ||
-                        !int.TryParse(payload, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var value))
-                        return this;
-                    exitCode = value;
-                }
-                return this with
-                {
-                    ShellIntegration = new TerminalShellIntegration(TerminalShellIntegrationPhase.Finished, exitCode)
-                };
-            }
-
-            if (parameters.Length != 0)
+            if (!TryParseMarker(parameters, payload, out var phase, out var exitCode, out _))
                 return this;
-            var phase = marker switch
+
+            if (phase == TerminalShellIntegrationPhase.Finished)
+                return this with { ShellIntegration = new TerminalShellIntegration(phase, exitCode) };
+
+            return this with
             {
-                "A" => TerminalShellIntegrationPhase.Prompt,
-                "B" => TerminalShellIntegrationPhase.CommandLine,
-                "C" => TerminalShellIntegrationPhase.Executing,
-                _ => TerminalShellIntegrationPhase.Unknown
+                ShellIntegration = new TerminalShellIntegration(phase, ShellIntegration.LastExitCode)
             };
-            if (phase != TerminalShellIntegrationPhase.Unknown)
-                return this with
-                {
-                    ShellIntegration = new TerminalShellIntegration(phase, ShellIntegration.LastExitCode)
-                };
         }
 
         return this;
+    }
+
+    /// <summary>
+    /// Parses an OSC 133 marker and its optional trailing raw parameter string (e.g.
+    /// <c>cmdline_url=...</c>), which is captured verbatim and never interpreted here.
+    /// </summary>
+    internal static bool TryParseMarker(string parameters, string payload,
+        out TerminalShellIntegrationPhase phase, out int? exitCode, out string? rawParameters)
+    {
+        phase = TerminalShellIntegrationPhase.Unknown;
+        exitCode = null;
+        rawParameters = null;
+
+        // The tokenizer places a bare marker in Payload, but a marker with an
+        // argument in Parameters (including D with an explicitly empty argument).
+        var marker = parameters.Length == 0 ? payload : parameters;
+        var argument = parameters.Length == 0 ? "" : payload;
+
+        if (marker == "D")
+        {
+            phase = TerminalShellIntegrationPhase.Finished;
+            if (argument.Length == 0)
+                return true;
+
+            // Unlike A/B/C, D's argument is strictly an exit code — no trailing raw
+            // parameters are recognized here (no known extension uses them on D).
+            if (!IsAsciiDecimal(argument, allowSign: true) ||
+                !int.TryParse(argument, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var value))
+                return false;
+            exitCode = value;
+            return true;
+        }
+
+        phase = marker switch
+        {
+            "A" => TerminalShellIntegrationPhase.Prompt,
+            "B" => TerminalShellIntegrationPhase.CommandLine,
+            "C" => TerminalShellIntegrationPhase.Executing,
+            _ => TerminalShellIntegrationPhase.Unknown
+        };
+        if (phase == TerminalShellIntegrationPhase.Unknown)
+            return false;
+        if (argument.Length != 0)
+            rawParameters = argument;
+        return true;
     }
 
     private static bool IsAsciiDecimal(ReadOnlySpan<char> text, bool allowSign)

--- a/src/Hex1b/TerminalCommandMark.cs
+++ b/src/Hex1b/TerminalCommandMark.cs
@@ -1,0 +1,99 @@
+namespace Hex1b;
+
+/// <summary>
+/// Records a single OSC 133 shell-integration marker (prompt, command-line, executing, or
+/// finished) anchored to a specific row in the terminal's text history.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is history — a sequence of past markers — unlike <see cref="TerminalShellIntegration"/>,
+/// which reflects only the current phase. Marks are captured in a bounded, most-recent-first
+/// list; older marks are evicted as new ones arrive.
+/// </para>
+/// <para>
+/// A mark's row anchor (<see cref="TextGeneration"/>, <see cref="TextRowId"/>) becomes stale
+/// once the terminal's text-row identity space is invalidated (for example by <c>RIS</c> or a
+/// resize-driven reflow) — a mark whose <see cref="TextGeneration"/> no longer matches the
+/// terminal's current generation cannot be resolved back to a row.
+/// </para>
+/// </remarks>
+public sealed record TerminalCommandMark
+{
+    private IReadOnlyDictionary<string, string>? _parameters;
+
+    internal TerminalCommandMark(TerminalShellIntegrationPhase phase, int? exitCode, string? rawParameters,
+        long textGeneration, long textRowId)
+    {
+        Phase = phase;
+        ExitCode = exitCode;
+        RawParameters = rawParameters;
+        TextGeneration = textGeneration;
+        TextRowId = textRowId;
+    }
+
+    /// <summary>Gets the shell-integration phase this mark reports.</summary>
+    public TerminalShellIntegrationPhase Phase { get; }
+
+    /// <summary>Gets the reported exit code, or null when this mark is not a finished marker
+    /// with a reported code.</summary>
+    public int? ExitCode { get; }
+
+    /// <summary>
+    /// Gets the raw, verbatim <c>key=value[;key=value...]</c> string trailing the marker, or
+    /// null when none was present. This is captured as-is; it is the caller's responsibility
+    /// to sanitize it for whatever context it is rendered or logged in.
+    /// </summary>
+    public string? RawParameters { get; }
+
+    /// <summary>
+    /// Gets the text-history generation this mark was captured in. A mark can only be resolved
+    /// to a row while the terminal's current text generation still matches this value.
+    /// </summary>
+    public long TextGeneration { get; }
+
+    /// <summary>Gets the stable text-row identifier this mark is anchored to.</summary>
+    public long TextRowId { get; }
+
+    /// <summary>
+    /// Gets <see cref="RawParameters"/> split into key/value pairs, parsed and cached on first
+    /// access. Returns an empty dictionary when <see cref="RawParameters"/> is null.
+    /// </summary>
+    /// <remarks>
+    /// Parameter keys are whatever the shell or prompt integration emitted; this is not a
+    /// fixed vocabulary and unrecognized keys are preserved as-is. Values are not decoded
+    /// (e.g. percent-decoding is left to the consumer for keys that use it, such as
+    /// <c>cmdline_url</c>).
+    /// </remarks>
+    public IReadOnlyDictionary<string, string> Parameters => _parameters ??= ParseParameters(RawParameters);
+
+    /// <summary>Gets whether a <c>cmdline_url</c> parameter was present on this marker.</summary>
+    /// <remarks>
+    /// This is a Contour-originated, non-universal extension to OSC 133;C. Most terminals and
+    /// shell integrations do not emit it.
+    /// </remarks>
+    public bool HasCmdlineUrl => Parameters.ContainsKey("cmdline_url");
+
+    /// <summary>
+    /// Gets the raw (still percent-encoded) <c>cmdline_url</c> value, or null when not present.
+    /// </summary>
+    public string? CmdlineUrl => Parameters.TryGetValue("cmdline_url", out var value) ? value : null;
+
+    private static IReadOnlyDictionary<string, string> ParseParameters(string? rawParameters)
+    {
+        if (string.IsNullOrEmpty(rawParameters))
+            return EmptyParameters;
+
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var segment in rawParameters.Split(';'))
+        {
+            var separator = segment.IndexOf('=');
+            if (separator < 0)
+                continue;
+            result[segment[..separator]] = segment[(separator + 1)..];
+        }
+        return result;
+    }
+
+    private static readonly IReadOnlyDictionary<string, string> EmptyParameters =
+        new Dictionary<string, string>(0, StringComparer.Ordinal);
+}

--- a/src/Hex1b/TerminalWidgetHandle.cs
+++ b/src/Hex1b/TerminalWidgetHandle.cs
@@ -291,6 +291,18 @@ public sealed class TerminalWidgetHandle :
     /// This describes current state, not a history of command executions.
     /// </remarks>
     public event Action<TerminalShellIntegration>? ShellIntegrationChanged;
+
+    /// <summary>Gets the working directory last reported by OSC 7 from the child workload.</summary>
+    /// <remarks>Remains live while copy mode freezes displayed cells. Process exit and
+    /// disconnect retain the last reported directory; <see cref="Reset"/> clears it.</remarks>
+    public TerminalWorkingDirectory WorkingDirectory
+    {
+        get { lock (_bufferLock) return _activityState.WorkingDirectory; }
+    }
+
+    /// <summary>Occurs when the reported working directory changes to a distinct value.</summary>
+    /// <remarks>Subscribing does not emit a baseline; read <see cref="WorkingDirectory"/>.</remarks>
+    public event Action<TerminalWorkingDirectory>? WorkingDirectoryChanged;
     
     /// <summary>
     /// Event raised when the terminal state changes.
@@ -446,6 +458,10 @@ public sealed class TerminalWidgetHandle :
             return;
         if (previous.ShellIntegration != activity.ShellIntegration)
             ShellIntegrationChanged?.Invoke(activity.ShellIntegration);
+        if (_disposed)
+            return;
+        if (previous.WorkingDirectory != activity.WorkingDirectory)
+            WorkingDirectoryChanged?.Invoke(activity.WorkingDirectory);
         if (!_disposed)
             OutputReceived?.Invoke();
     }

--- a/src/Hex1b/TerminalWorkingDirectory.cs
+++ b/src/Hex1b/TerminalWorkingDirectory.cs
@@ -1,0 +1,45 @@
+namespace Hex1b;
+
+/// <summary>
+/// Contains the working directory last reported by a shell using OSC 7.
+/// </summary>
+/// <remarks>
+/// This reflects the most recently reported directory only, not a history of visited
+/// directories. No directory is inferred from output; it is only ever set from OSC 7.
+/// </remarks>
+public sealed record TerminalWorkingDirectory
+{
+    internal static TerminalWorkingDirectory Default { get; } = new(null, null, null);
+
+    internal TerminalWorkingDirectory(string? uri, string? host, string? path)
+    {
+        Uri = uri;
+        Host = host;
+        Path = path;
+    }
+
+    /// <summary>Gets the raw reported URI, or null if no directory has been reported.</summary>
+    public string? Uri { get; }
+
+    /// <summary>
+    /// Gets the reported host name, or null if none was present or no directory has been
+    /// reported. An empty host (as in <c>file:///path</c>) is reported as an empty string.
+    /// </summary>
+    public string? Host { get; }
+
+    /// <summary>
+    /// Gets the percent-decoded local path, or null if no directory has been reported.
+    /// </summary>
+    public string? Path { get; }
+
+    /// <summary>
+    /// Parses a raw OSC 7 <c>file://</c> URI, or returns null if it is not a well-formed
+    /// absolute file URI.
+    /// </summary>
+    internal static TerminalWorkingDirectory? TryCreate(string uri)
+    {
+        if (!System.Uri.TryCreate(uri, UriKind.Absolute, out var parsed) || !parsed.IsFile)
+            return null;
+        return new TerminalWorkingDirectory(uri, parsed.Host, parsed.LocalPath);
+    }
+}

--- a/src/web-terminal/README.md
+++ b/src/web-terminal/README.md
@@ -185,6 +185,7 @@ workers, fonts, and the intended WebSocket endpoint.
 | `onTitleChange` | Initial authoritative workload title, then distinct presented changes; see below. |
 | `onClose` | Native WebSocket close details, including pre-mount transport failure; not workload completion. |
 | `onProgressChange`, `onShellIntegrationChange` | Initial authoritative activity, then distinct presented changes for host-owned chrome. |
+| `onWorkingDirectoryChange`, `onCommandMarkChange` | Initial authoritative OSC 7 directory and latest OSC 133 marker, then distinct presented changes; see below. |
 | `inputBindings`, `onInput`, `actions` | Per-view input policy and custom actions. |
 | `onSelectionUI` | Synchronous, cancelable UI notification hook. |
 
@@ -195,7 +196,8 @@ Font size is an integer from 8–32, defaulting to 16. Import `MIN_FONT_SIZE` an
 ownership. `requestPrimary()` explicitly requests ownership; inspect `peer` or
 `onRoleChange` to observe the result.
 
-The handle exposes `geometry`, `peer`, `connected`, `readOnly`, `title`, `progress`, `shellIntegration`, `stats`, `screenText`,
+The handle exposes `geometry`, `peer`, `connected`, `readOnly`, `title`, `progress`, `shellIntegration`,
+`workingDirectory`, `commandMark`, `stats`, `screenText`,
 `sizing`, `viewport`, `selection`, `inputBindings`, and `inputContext`.
 Metrics start empty; check optional fields before using them. History may be
 unavailable, and selection can be unavailable, none, pending, valid, or
@@ -204,7 +206,8 @@ their state-specific values. `screenText` reflects the presented viewport, not
 an independently reconstructed ANSI buffer.
 
 Callbacks include `onGeometry`, `onRoleChange`, `onTitleChange`, `onSizingChange`, `onStats`,
-`onProgressChange`, `onShellIntegrationChange`, `onViewportChange`, `onSelectionChange`, `onStatus`, and `onInputError`.
+`onProgressChange`, `onShellIntegrationChange`, `onWorkingDirectoryChange`, `onCommandMarkChange`,
+`onViewportChange`, `onSelectionChange`, `onStatus`, and `onInputError`.
 
 ### Live read-only views
 
@@ -341,11 +344,28 @@ A/B/C preserve the last reported result, and D replaces it, including clearing
 it to null when the shell omits its status. No command text, history, or output
 locations are retained by these APIs.
 
-Both getters return defensive copies. Their callbacks receive the first
+`terminal.workingDirectory` exposes OSC 7 state as `{ uri, host, path }`, all
+`null` until the first report. `uri` is the raw reported `file://` URI; `host`
+and `path` are derived from it (`host` is `""` for a local/unqualified
+authority). A malformed or non-`file` URI leaves the previous value unchanged.
+
+`terminal.commandMark` exposes the single most-recently-reported OSC 133 marker
+as `{ phase, exitCode, rawParameters } | null` — `null` until the first marker.
+`phase` uses the same enum as `shellIntegration.phase`. `exitCode` is non-null
+only on a `finished` (D) marker. `rawParameters` is the verbatim
+`key=value[;key=value...]` text trailing the marker (for example a
+`cmdline_url` extension on marker C), or `null` when none was present; use the
+exported `parseCommandMarkParameters(rawParameters)` helper to parse it into a
+`Map`, or `getCmdlineUrl(mark)` as a shortcut for the `cmdline_url` entry. This
+is **not** a command-mark history — only the latest marker is exposed, mirroring
+`shellIntegration`. A host that wants its own history should accumulate
+distinct values from `onCommandMarkChange` itself.
+
+All four getters return defensive copies. Their callbacks receive the first
 authoritative presented state before mount resolves, then distinct presented
-changes. Both getters are updated before either activity callback. Callbacks
-use the same direct, synchronous host-callback convention as title changes;
-host exceptions are not swallowed or retried.
+changes. All four getters are updated before their corresponding activity
+callback. Callbacks use the same direct, synchronous host-callback convention
+as title changes; host exceptions are not swallowed or retried.
 
 Frames coalesce: the browser might see only Finished for a fast command, or
 miss an entire command whose final state is unchanged. These callbacks are
@@ -356,15 +376,16 @@ and a new mount receives its own baseline.
 This example creates optional chrome outside the terminal:
 
 ```ts
-import { WebTerminal } from "@hex1b/web-terminal";
+import { WebTerminal, getCmdlineUrl } from "@hex1b/web-terminal";
 
 const status = document.createElement("span");
+const cwd = document.createElement("span");
 const progress = document.createElement("progress");
 progress.max = 100;
 progress.hidden = true;
 const container = document.createElement("div");
 container.style.cssText = "width:800px;height:480px";
-document.body.append(status, progress, container);
+document.body.append(status, cwd, progress, container);
 
 const terminal = await WebTerminal.mount(container, {
   url: "/ws/terminal",
@@ -378,6 +399,13 @@ const terminal = await WebTerminal.mount(container, {
     status.textContent = value.phase +
       (value.lastExitCode === null ? "" : ` (last exit ${value.lastExitCode})`);
   },
+  onWorkingDirectoryChange(value) {
+    cwd.textContent = value.path ?? "";
+  },
+  onCommandMarkChange(value) {
+    const cmdlineUrl = getCmdlineUrl(value);
+    if (cmdlineUrl) console.log("Command link:", cmdlineUrl);
+  },
   onStats(stats) {
     if (!stats.connected) {
       progress.hidden = true;
@@ -385,7 +413,7 @@ const terminal = await WebTerminal.mount(container, {
     }
   }
 });
-console.log(terminal.progress, terminal.shellIntegration);
+console.log(terminal.progress, terminal.shellIntegration, terminal.workingDirectory, terminal.commandMark);
 ```
 
 No title, document chrome, or progress UI is changed automatically by the

--- a/src/web-terminal/src/command-mark.ts
+++ b/src/web-terminal/src/command-mark.ts
@@ -1,0 +1,26 @@
+import type { TerminalCommandMark } from "./types.js";
+
+/**
+ * Parses a {@link TerminalCommandMark.rawParameters} string into key/value pairs, mirroring the
+ * server's `TerminalCommandMark.Parameters`: segments are split on `;`, each split on the first
+ * `=`; segments without `=` are ignored. Values are not decoded (e.g. percent-decoding is left
+ * to the caller for keys that use it, such as `cmdline_url`). Returns an empty map for null/"".
+ */
+export function parseCommandMarkParameters(rawParameters: string | null): ReadonlyMap<string, string> {
+  const result = new Map<string, string>();
+  if (!rawParameters) return result;
+  for (const segment of rawParameters.split(";")) {
+    const separator = segment.indexOf("=");
+    if (separator < 0) continue;
+    result.set(segment.slice(0, separator), segment.slice(separator + 1));
+  }
+  return result;
+}
+
+/**
+ * Gets the raw (still percent-encoded) `cmdline_url` parameter from a command mark, or null when
+ * absent. This is a Contour-originated, non-universal extension to OSC 133;C.
+ */
+export function getCmdlineUrl(mark: TerminalCommandMark | null): string | null {
+  return mark ? parseCommandMarkParameters(mark.rawParameters).get("cmdline_url") ?? null : null;
+}

--- a/src/web-terminal/src/index.ts
+++ b/src/web-terminal/src/index.ts
@@ -1,4 +1,5 @@
 export { WebTerminal } from "./web-terminal.js";
 export { InputRoute, TerminalAction, defaultInputBindings } from "./input-policy.js";
 export { MIN_FONT_SIZE, MAX_FONT_SIZE } from "./terminal-sizing.js";
+export { parseCommandMarkParameters, getCmdlineUrl } from "./command-mark.js";
 export type * from "./types.js";

--- a/src/web-terminal/src/protocol.ts
+++ b/src/web-terminal/src/protocol.ts
@@ -7,6 +7,7 @@ export const LIMITS = Object.freeze({
   frameBytes: 96 * 1024 * 1024,
   metadataBytes: 8 * 1024 * 1024,
   titleUnits: 4096,
+  commandMarkParameterUnits: 8192,
   cells: 262144,
   images: 4096,
   placements: 16384,
@@ -121,6 +122,29 @@ function validateMetadata(metadata: unknown): asserts metadata is FrameMetadata 
     integer(shell.lastExitCode, "terminal shell exit code", -2147483648, 2147483647);
   if (shell.phase === "unknown" && shell.lastExitCode !== null)
     throw new Error("Unknown terminal shell phase has an exit code");
+  const workingDirectory = metadata.workingDirectory;
+  if (!isRecord(workingDirectory)) throw new Error("Invalid terminal working directory");
+  const wdFields = [workingDirectory.uri, workingDirectory.host, workingDirectory.path];
+  if (wdFields.every(field => field === null)) {
+    // No directory reported yet.
+  } else if (wdFields.some(field => typeof field !== "string" || field.length > LIMITS.metadataBytes)) {
+    throw new Error("Invalid terminal working directory");
+  }
+  const commandMark = metadata.commandMark;
+  if (commandMark !== null) {
+    if (!isRecord(commandMark) || typeof commandMark.phase !== "string" ||
+        !["unknown", "prompt", "commandLine", "executing", "finished"].includes(commandMark.phase)) {
+      throw new Error("Invalid terminal command mark");
+    }
+    if (commandMark.exitCode !== null) {
+      integer(commandMark.exitCode, "terminal command mark exit code", -2147483648, 2147483647);
+      if (commandMark.phase !== "finished") throw new Error("Non-finished terminal command mark has an exit code");
+    }
+    if (commandMark.rawParameters !== null &&
+        (typeof commandMark.rawParameters !== "string" || commandMark.rawParameters.length > LIMITS.commandMarkParameterUnits)) {
+      throw new Error("Invalid terminal command mark parameters");
+    }
+  }
   const columns = integer(metadata.columns, "columns", 1, 1024);
   const rows = integer(metadata.rows, "rows", 1, 512);
   if (typeof metadata.mouseTracking !== "number" || ![0, 9, 1000, 1002, 1003].includes(metadata.mouseTracking)) {

--- a/src/web-terminal/src/terminal-worker.ts
+++ b/src/web-terminal/src/terminal-worker.ts
@@ -138,6 +138,7 @@ async function drawFrame() {
         mouseTracking: metadata.mouseTracking, peer: metadata.peer,
         history: metadata.history, revision: frame.revision, title: metadata.title,
         progress: metadata.progress, shellIntegration: metadata.shellIntegration,
+        workingDirectory: metadata.workingDirectory, commandMark: metadata.commandMark,
         text, hyperlinks: metadata.hyperlinks
       });
       send({ type: "ack", revision: frame.revision });

--- a/src/web-terminal/src/types.ts
+++ b/src/web-terminal/src/types.ts
@@ -166,6 +166,28 @@ export interface TerminalShellIntegration {
   /** Null means no reported status, not success. Preserved across the next prompt/command. */
   readonly lastExitCode: number | null;
 }
+/** Last reported OSC 7 working directory, or all-null before any is reported. */
+export interface TerminalWorkingDirectory {
+  /** Raw URI as reported by the shell (typically `file://`), or null. */
+  readonly uri: string | null;
+  /** Authority from the URI; "" for a local/unqualified authority. Null when uri is null. */
+  readonly host: string | null;
+  /** Decoded filesystem path from the URI. Null when uri is null. */
+  readonly path: string | null;
+}
+/**
+ * Latest OSC 133 marker, distinct from {@link TerminalShellIntegration}: it additionally carries
+ * any raw trailing `key=value` parameters (e.g. a `cmdline_url` extension on marker C). This is
+ * the single most-recent marker only — the server does not transport a mark history or event
+ * log over this wire; consumers that want their own history should accumulate distinct values
+ * from {@link WebTerminalOptions.onCommandMarkChange} themselves.
+ */
+export interface TerminalCommandMark {
+  readonly phase: TerminalShellIntegrationPhase;
+  readonly exitCode: number | null;
+  /** Verbatim `key=value[;key=value...]` trailing the marker, or null when none was present. */
+  readonly rawParameters: string | null;
+}
 export interface WebTerminalOptions extends InputPolicyOptions {
   url: string | URL;
   /** Optional module-worker entry, resolved against the page URL. Defaults to the bundled worker. */
@@ -211,6 +233,18 @@ export interface WebTerminalOptions extends InputPolicyOptions {
    * occur between frames. Replays provide current state, never synthetic command executions.
    */
   onShellIntegrationChange?: (shellIntegration: TerminalShellIntegration) => void;
+  /**
+   * Receives the first authoritative presented working directory before mount resolves, then
+   * distinct presented changes. All-null means none reported yet; a malformed or non-`file` OSC 7
+   * report does not change presented state. No notifications after disposal.
+   */
+  onWorkingDirectoryChange?: (workingDirectory: TerminalWorkingDirectory) => void;
+  /**
+   * Receives the first authoritative presented command mark before mount resolves (null if none
+   * yet reported), then distinct presented changes. Only the latest marker is transmitted, not a
+   * history; entire commands may occur between frames. No notifications after disposal.
+   */
+  onCommandMarkChange?: (commandMark: TerminalCommandMark | null) => void;
   onStats?: (stats: TerminalStats, text: string | undefined) => void;
   onViewportChange?: (viewport: TerminalViewport) => void;
   onSelectionChange?: (selection: TerminalSelection) => void;
@@ -232,6 +266,10 @@ export interface WebTerminalHandle {
   readonly progress: TerminalProgress;
   /** Current presented shell state, initially unknown. Retained on disconnect/dispose. */
   readonly shellIntegration: TerminalShellIntegration;
+  /** Current presented working directory, all-null initially. Retained on disconnect/dispose. */
+  readonly workingDirectory: TerminalWorkingDirectory;
+  /** Latest presented command mark, or null if none reported yet. Retained on disconnect/dispose. */
+  readonly commandMark: TerminalCommandMark | null;
   readonly stats: TerminalStats;
   readonly screenText: string;
   readonly sizing: TerminalSizingState;

--- a/src/web-terminal/src/web-terminal.ts
+++ b/src/web-terminal/src/web-terminal.ts
@@ -12,7 +12,8 @@ import type { MouseCapture } from "./mouse-input.js";
 import type { CopySelectionOptions, InputActionHandler, InputDecision, InputBinding,
   TerminalActionName, TerminalGeometry, TerminalInput, TerminalInputContext, TerminalPeer,
   TerminalRendererPreference, TerminalSelection, TerminalSizing, TerminalSizingState, TerminalStats, TerminalViewport,
-  TerminalProgress, TerminalShellIntegration, WebTerminalHandle, WebTerminalOptions } from "./types.js";
+  TerminalProgress, TerminalShellIntegration, TerminalWorkingDirectory, TerminalCommandMark,
+  WebTerminalHandle, WebTerminalOptions } from "./types.js";
 import type { InputCommand, TerminalCommand, WorkerInputMessage, WorkerOutputMessage } from "./wire-types.js";
 import { errorMessage, isRecord } from "./validation.js";
 export { InputRoute, TerminalAction, defaultInputBindings } from "./input-policy.js";
@@ -60,6 +61,8 @@ export class WebTerminal implements WebTerminalHandle {
   #hasTitle = false;
   #progress: TerminalProgress = { state: "none", percentage: null };
   #shellIntegration: TerminalShellIntegration = { phase: "unknown", lastExitCode: null };
+  #workingDirectory: TerminalWorkingDirectory = { uri: null, host: null, path: null };
+  #commandMark: TerminalCommandMark | null = null;
   #hasActivity = false;
   #history: HistoryState;
   #highlights!: HTMLDivElement;
@@ -128,6 +131,8 @@ export class WebTerminal implements WebTerminalHandle {
   get title(): string { return this.#title; }
   get progress(): TerminalProgress { return { ...this.#progress }; }
   get shellIntegration(): TerminalShellIntegration { return { ...this.#shellIntegration }; }
+  get workingDirectory(): TerminalWorkingDirectory { return { ...this.#workingDirectory }; }
+  get commandMark(): TerminalCommandMark | null { return this.#commandMark ? { ...this.#commandMark } : null; }
   get stats(): TerminalStats { return { ...this.#stats }; }
   get screenText() { return this.#screenText; }
   get sizing(): TerminalSizingState { return { ...this.#sizing }; }
@@ -333,14 +338,23 @@ export class WebTerminal implements WebTerminalHandle {
           this.#progress.percentage !== message.progress.percentage;
         const shellChanged = !this.#hasActivity || this.#shellIntegration.phase !== message.shellIntegration.phase ||
           this.#shellIntegration.lastExitCode !== message.shellIntegration.lastExitCode;
+        const workingDirectoryChanged = !this.#hasActivity ||
+          this.#workingDirectory.uri !== message.workingDirectory.uri;
+        const commandMarkChanged = !this.#hasActivity || this.#commandMark?.phase !== message.commandMark?.phase ||
+          this.#commandMark?.exitCode !== message.commandMark?.exitCode ||
+          this.#commandMark?.rawParameters !== message.commandMark?.rawParameters;
         this.#title = message.title;
         this.#hasTitle = true;
         this.#progress = { ...message.progress };
         this.#shellIntegration = { ...message.shellIntegration };
+        this.#workingDirectory = { ...message.workingDirectory };
+        this.#commandMark = message.commandMark ? { ...message.commandMark } : null;
         this.#hasActivity = true;
         if (titleChanged) this.#options.onTitleChange?.(this.#title);
         if (!this.#disposed && progressChanged) this.#options.onProgressChange?.(this.progress);
         if (!this.#disposed && shellChanged) this.#options.onShellIntegrationChange?.(this.shellIntegration);
+        if (!this.#disposed && workingDirectoryChanged) this.#options.onWorkingDirectoryChange?.(this.workingDirectory);
+        if (!this.#disposed && commandMarkChanged) this.#options.onCommandMarkChange?.(this.commandMark);
       }
     } else if (message.type === "history") {
       this.#screenText = message.text;

--- a/src/web-terminal/src/wire-types.ts
+++ b/src/web-terminal/src/wire-types.ts
@@ -1,7 +1,7 @@
 import type { InputModifiers, PointerButton, SelectionMode, SelectionRange,
   TerminalBuffer, TerminalFont, TerminalGeometry, TerminalPeer, TerminalSize, TerminalStats,
   TerminalRendererPreference, TerminalStatusLevel, TerminalProgress, TerminalShellIntegration,
-  TerminalCloseDetails } from "./types.js";
+  TerminalWorkingDirectory, TerminalCommandMark, TerminalCloseDetails } from "./types.js";
 
 export type SelectionText =
   | { status: "valid"; text: string }
@@ -38,6 +38,8 @@ export interface FrameMetadata extends TerminalGeometry {
   title: string;
   progress: TerminalProgress;
   shellIntegration: TerminalShellIntegration;
+  workingDirectory: TerminalWorkingDirectory;
+  commandMark: TerminalCommandMark | null;
   defaultBackground?: number; defaultForeground?: number;
   cursor: { visible: boolean; x: number; y: number; shape: number };
   images: ImageMetadata[]; retainedImages: string[]; placements: ImagePlacement[]; warnings: string[];
@@ -87,6 +89,7 @@ export type WorkerOutputMessage =
   | { type: "status"; message: string; level: TerminalStatusLevel }
   | ({ type: "geometry"; peer: TerminalPeer; history: HistoryMetadata | null;
        revision: number; title: string; progress: TerminalProgress; shellIntegration: TerminalShellIntegration;
+       workingDirectory: TerminalWorkingDirectory; commandMark: TerminalCommandMark | null;
        text: string; hyperlinks: HyperlinkRange[] } & TerminalGeometry)
   | { type: "history"; history: HistoryMetadata | null; revision: number; text: string }
   | { type: "stats"; stats: WorkerStats; text?: string };

--- a/src/web-terminal/tests/fixtures/browser.mjs
+++ b/src/web-terminal/tests/fixtures/browser.mjs
@@ -151,6 +151,8 @@ export function frame({ title = "", revision = 1, full = revision === 1, baseRev
     version: 1, title, revision, full, baseRevision, peer,
     progress: { state: "none", percentage: null },
     shellIntegration: { phase: "unknown", lastExitCode: null },
+    workingDirectory: { uri: null, host: null, path: null },
+    commandMark: null,
     columns: 1, rows: 1, cellWidth: 10, cellHeight: 20, mouseTracking: 0,
     cursor: { visible: true, x: 0, y: 0, shape: 1 },
     history: null, images: [], retainedImages: [], placements: [], warnings: [], hyperlinks: [],

--- a/src/web-terminal/tests/package.test.mjs
+++ b/src/web-terminal/tests/package.test.mjs
@@ -11,7 +11,8 @@ const read = path => readFileSync(new URL(path, root), "utf8");
 
 test("Package entry exposes only the supported runtime API", () => {
   assert.deepEqual(Object.keys(entry).sort(), [
-    "InputRoute", "MAX_FONT_SIZE", "MIN_FONT_SIZE", "TerminalAction", "WebTerminal", "defaultInputBindings"
+    "InputRoute", "MAX_FONT_SIZE", "MIN_FONT_SIZE", "TerminalAction", "WebTerminal", "defaultInputBindings",
+    "getCmdlineUrl", "parseCommandMarkParameters"
   ]);
   assert.equal(entry.MIN_FONT_SIZE, 8);
   assert.equal(entry.MAX_FONT_SIZE, 32);

--- a/src/web-terminal/tests/protocol-validation.test.mjs
+++ b/src/web-terminal/tests/protocol-validation.test.mjs
@@ -8,6 +8,8 @@ function metadata() {
     title: "",
     progress: { state: "none", percentage: null },
     shellIntegration: { phase: "unknown", lastExitCode: null },
+    workingDirectory: { uri: null, host: null, path: null },
+    commandMark: null,
     columns: 1, rows: 1, cellWidth: 10, cellHeight: 20, mouseTracking: 0,
     peer: { id: null, primaryId: null, isPrimary: true },
     cursor: { x: 0, y: 0, visible: false, shape: "SteadyBlock" }, history: null,

--- a/src/web-terminal/tests/web-terminal.test.mjs
+++ b/src/web-terminal/tests/web-terminal.test.mjs
@@ -119,6 +119,8 @@ function frame(peer) {
     title: "",
     progress: { state: "none", percentage: null },
     shellIntegration: { phase: "unknown", lastExitCode: null },
+    workingDirectory: { uri: null, host: null, path: null },
+    commandMark: null,
     columns: 1, rows: 1, cellWidth: 10, cellHeight: 20, mouseTracking: 0, peer,
     cursor: { x: 0, y: 0, visible: false, shape: 0 }, history: null,
     images: [], retainedImages: [], placements: [], warnings: [], hyperlinks: [],

--- a/tests/Hex1b.Tests/Hmp1/Hmp1ActivityStateTests.cs
+++ b/tests/Hex1b.Tests/Hmp1/Hmp1ActivityStateTests.cs
@@ -760,7 +760,8 @@ public class Hmp1ActivityStateTests
     private static Hmp1ActivityState Activity(int state, int? percentage, int phase, int? exitCode) => new()
     {
         Progress = new() { State = state, Percentage = percentage },
-        ShellIntegration = new() { Phase = phase, LastExitCode = exitCode }
+        ShellIntegration = new() { Phase = phase, LastExitCode = exitCode },
+        WorkingDirectory = new() { Uri = null }
     };
 
     private static async Task<JsonElement> ReadActivityFrameAsync(

--- a/tests/Hex1b.Tests/OscShellIntegrationTests.cs
+++ b/tests/Hex1b.Tests/OscShellIntegrationTests.cs
@@ -57,10 +57,6 @@ public class OscShellIntegrationTests
     [DataRow(";D")]
     [DataRow(";D;0")]
     [DataRow(";D;")]
-    [DataRow("A;")]
-    [DataRow("A;prompt=1")]
-    [DataRow("B;")]
-    [DataRow("C;extra")]
     [DataRow("D; ")]
     [DataRow("D;0 ")]
     [DataRow("D; 0")]
@@ -194,7 +190,7 @@ public class OscShellIntegrationTests
         terminal.BeginActivityStateRestore();
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b" + "c\x1b]9;4;3\x07\x1b]133;D\x07"));
         terminal.BeginActivityStateRestore();
-        terminal.RestoreActivityState(progress, shell);
+        terminal.RestoreActivityState(progress, shell, TerminalWorkingDirectory.Default);
         terminal.EndActivityStateRestore();
         Assert.AreEqual(0, progressEvents.Count);
         Assert.AreEqual(0, shellEvents.Count);
@@ -204,7 +200,7 @@ public class OscShellIntegrationTests
 
         terminal.BeginActivityStateRestore();
         terminal.ApplyTokens([RisToken.Instance]);
-        terminal.RestoreActivityState(progress, shell);
+        terminal.RestoreActivityState(progress, shell, TerminalWorkingDirectory.Default);
         terminal.EndActivityStateRestore();
         Assert.AreEqual(1, progressEvents.Count);
         Assert.AreEqual(1, shellEvents.Count);
@@ -225,7 +221,8 @@ public class OscShellIntegrationTests
                 var value = i % 2;
                 terminal.RestoreActivityState(
                     new TerminalProgress(TerminalProgressState.Normal, value),
-                    new TerminalShellIntegration(TerminalShellIntegrationPhase.Finished, value));
+                    new TerminalShellIntegration(TerminalShellIntegrationPhase.Finished, value),
+                    TerminalWorkingDirectory.Default);
             }
         }, TestContext.Current.CancellationToken);
         started.SetResult();

--- a/tests/Hex1b.Tests/OscWorkingDirectoryAndCommandMarkTests.cs
+++ b/tests/Hex1b.Tests/OscWorkingDirectoryAndCommandMarkTests.cs
@@ -1,0 +1,216 @@
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests;
+
+/// <summary>
+/// Tests for OSC 7 (working directory) terminal state and events.
+/// </summary>
+[TestClass]
+public class OscWorkingDirectoryTests
+{
+    [TestMethod]
+    public async Task Osc7_ValidFileUri_UpdatesWorkingDirectoryAndFiresEvent()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+        Assert.AreEqual(TerminalWorkingDirectory.Default, terminal.WorkingDirectory);
+
+        var changes = new List<TerminalWorkingDirectory>();
+        terminal.WorkingDirectoryChanged += changes.Add;
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]7;file:///home/user/project\x07"));
+
+        Assert.AreEqual("file:///home/user/project", terminal.WorkingDirectory.Uri);
+        Assert.AreEqual("", terminal.WorkingDirectory.Host);
+        Assert.AreEqual("/home/user/project", terminal.WorkingDirectory.Path);
+        Assert.AreEqual(1, changes.Count);
+
+        using var snapshot = terminal.CreateSnapshot();
+        Assert.AreEqual(terminal.WorkingDirectory, snapshot.WorkingDirectory);
+    }
+
+    [TestMethod]
+    public async Task Osc7_WithHostname_ReportsHost()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]7;file://myhost/home/user\x07"));
+
+        Assert.AreEqual("myhost", terminal.WorkingDirectory.Host);
+        Assert.AreEqual("myhost/home/user", terminal.WorkingDirectory.Uri!["file://".Length..]);
+    }
+
+    [TestMethod]
+    public async Task Osc7_PercentEncodedPath_IsDecoded()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]7;file:///home/user/my%20project\x07"));
+
+        Assert.AreEqual("/home/user/my project", terminal.WorkingDirectory.Path);
+    }
+
+    [TestMethod]
+    [DataRow("not-a-uri")]
+    [DataRow("http://example.com/path")]
+    [DataRow("")]
+    public async Task Osc7_MalformedOrNonFileUri_DoesNotMutateState(string payload)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+        var changes = 0;
+        terminal.WorkingDirectoryChanged += _ => changes++;
+        terminal.ApplyTokens([new OscToken("7", "", payload)]);
+
+        Assert.AreEqual(TerminalWorkingDirectory.Default, terminal.WorkingDirectory);
+        Assert.AreEqual(0, changes);
+    }
+
+    [TestMethod]
+    public async Task Osc7_RIS_ClearsWorkingDirectory()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]7;file:///tmp\x07"));
+        Assert.AreNotEqual(TerminalWorkingDirectory.Default, terminal.WorkingDirectory);
+
+        terminal.ApplyTokens([RisToken.Instance]);
+        Assert.AreEqual(TerminalWorkingDirectory.Default, terminal.WorkingDirectory);
+    }
+}
+
+/// <summary>
+/// Tests for OSC 133 command marks: history entries anchored to text rows, distinct from the
+/// current-phase-only <see cref="TerminalShellIntegration"/> state.
+/// </summary>
+[TestClass]
+public class OscCommandMarkTests
+{
+    [TestMethod]
+    public async Task Osc133_BareMarkers_RecordMarksWithoutRawParameters()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+        var added = new List<TerminalCommandMark>();
+        terminal.CommandMarkAdded += added.Add;
+
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]133;A\x07\x1b]133;B\x07\x1b]133;C\x07\x1b]133;D;3\x07"));
+
+        Assert.AreEqual(4, added.Count);
+        Assert.AreEqual(TerminalShellIntegrationPhase.Prompt, added[0].Phase);
+        Assert.AreEqual(TerminalShellIntegrationPhase.CommandLine, added[1].Phase);
+        Assert.AreEqual(TerminalShellIntegrationPhase.Executing, added[2].Phase);
+        Assert.AreEqual(TerminalShellIntegrationPhase.Finished, added[3].Phase);
+        Assert.AreEqual(3, added[3].ExitCode);
+        foreach (var mark in added)
+        {
+            Assert.IsNull(mark.RawParameters);
+            Assert.AreEqual(0, mark.Parameters.Count);
+            Assert.IsFalse(mark.HasCmdlineUrl);
+            Assert.IsNull(mark.CmdlineUrl);
+        }
+        TestSeq.AreEqual(added, terminal.CommandMarks);
+    }
+
+    [TestMethod]
+    public async Task Osc133_MarkerCWithCmdlineUrl_CapturesRawAndParsedValueVerbatim()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]133;C;cmdline_url=ls%20-la\x07"));
+
+        var mark = TestSeq.Single(terminal.CommandMarks);
+        Assert.AreEqual(TerminalShellIntegrationPhase.Executing, mark.Phase);
+        Assert.AreEqual("cmdline_url=ls%20-la", mark.RawParameters);
+        Assert.IsTrue(mark.HasCmdlineUrl);
+        Assert.AreEqual("ls%20-la", mark.CmdlineUrl);
+        Assert.AreEqual(1, mark.Parameters.Count);
+        Assert.AreEqual("ls%20-la", mark.Parameters["cmdline_url"]);
+    }
+
+    [TestMethod]
+    public async Task Osc133_MarkerCWithMultipleParameters_ParsesAllKeys()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]133;C;foo=bar;baz=qux\x07"));
+
+        var mark = TestSeq.Single(terminal.CommandMarks);
+        Assert.AreEqual("foo=bar;baz=qux", mark.RawParameters);
+        Assert.AreEqual(2, mark.Parameters.Count);
+        Assert.AreEqual("bar", mark.Parameters["foo"]);
+        Assert.AreEqual("qux", mark.Parameters["baz"]);
+        Assert.IsFalse(mark.HasCmdlineUrl);
+    }
+
+    [TestMethod]
+    public async Task Osc133_ParametersDictionary_IsLazyAndCached()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]133;C;a=1\x07"));
+        var mark = TestSeq.Single(terminal.CommandMarks);
+
+        // Accessing Parameters twice must return the same cached instance, not re-parse.
+        Assert.AreSame(mark.Parameters, mark.Parameters);
+    }
+
+    [TestMethod]
+    public async Task Osc133_MarkerDWithTrailingContent_IsRejectedAndNoMarkIsRecorded()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+        var added = 0;
+        terminal.CommandMarkAdded += _ => added++;
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]133;D;0;foo=bar\x07"));
+
+        Assert.AreEqual(0, added);
+        Assert.AreEqual(0, terminal.CommandMarks.Count);
+        Assert.AreEqual(TerminalShellIntegrationPhase.Unknown, terminal.ShellIntegration.Phase);
+    }
+
+    [TestMethod]
+    public async Task CommandMarks_ExceedingCapacity_EvictsOldestFirst()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithHeadless().WithDimensions(20, 5)
+            .Build();
+        for (var i = 0; i < 205; i++)
+            terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]133;A\x07"));
+
+        Assert.AreEqual(200, terminal.CommandMarks.Count);
+    }
+
+    [TestMethod]
+    public async Task CommandMarks_AnchorsAreStableUntilTextGenerationChanges()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]133;A\x07"));
+        var first = TestSeq.Single(terminal.CommandMarks);
+
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]133;B\x07"));
+        var second = terminal.CommandMarks[1];
+
+        // Same row (cursor hasn't moved), same generation: identical anchor.
+        Assert.AreEqual(first.TextGeneration, second.TextGeneration);
+        Assert.AreEqual(first.TextRowId, second.TextRowId);
+
+        // RIS invalidates the text-row identity space (bumps the generation).
+        terminal.ApplyTokens([RisToken.Instance]);
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]133;C\x07"));
+        var third = terminal.CommandMarks[2];
+        Assert.AreNotEqual(first.TextGeneration, third.TextGeneration);
+    }
+}

--- a/tests/Hex1b.Tests/TerminalWidgetHandleActivityTests.cs
+++ b/tests/Hex1b.Tests/TerminalWidgetHandleActivityTests.cs
@@ -107,7 +107,7 @@ public class TerminalWidgetHandleActivityTests
 
         var progress = new TerminalProgress(TerminalProgressState.Indeterminate, null);
         var shell = new TerminalShellIntegration(TerminalShellIntegrationPhase.Executing, -4);
-        terminal.RestoreActivityState(progress, shell);
+        terminal.RestoreActivityState(progress, shell, TerminalWorkingDirectory.Default);
         var changes = 0;
         handle.ProgressChanged += _ => changes++;
         handle.ShellIntegrationChanged += _ => changes++;
@@ -178,7 +178,7 @@ public class TerminalWidgetHandleActivityTests
         {
             terminal.BeginActivityStateRestore();
             terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b" + "c\x1b]133;C\x07"));
-            terminal.RestoreActivityState(progress, shell);
+            terminal.RestoreActivityState(progress, shell, TerminalWorkingDirectory.Default);
             terminal.EndActivityStateRestore();
         }
         Assert.AreEqual(2, changes);


### PR DESCRIPTION
## Summary
- retain OSC 7 working-directory and OSC 133 command-mark state in terminal snapshots and HMP1/HWT1 projections
- expose working-directory and command-mark getters/events through `@hex1b/web-terminal`
- add a shell-integration tape and command-history rail to WebTerminalDemo

## Validation
- full `Hex1b.Tests` suite passed (11,426 tests)
- `@hex1b/web-terminal` typecheck, build, and tests passed (196 tests)
- WebTerminalDemo typecheck and build passed