### PR TITLE
Fix ProteinView FullHD with bounded compressed Kitty graphics

### DIFF
--- a/samples/WebTerminalDemo/README.md
+++ b/samples/WebTerminalDemo/README.md
@@ -134,6 +134,7 @@ origin:
 | `graphics.browser.js` | Sixel and KGP in mixed WebGPU/WebGL2 views, renderer controls/diagnostics, cached-image movement, and late attachment to silent server-driven animation. |
 | `graphics-stream.browser.js` | Reviewed HWT1 capture replay through the actual decoder and WebGPU/WebGL2 renderer, with pixel readback and a screenshot-ready canvas. This is offline frame replay, not a live WebSocket/worker check. |
 | `graphics-worker-stream.browser.js` | A reviewed full HWT1 frame through the mounted client, actual worker and GPU. Only WebSocket transport is replaced; the mounted canvas stays available for screenshots until navigation. |
+| `proteinview-live.browser.js` | An explicitly supplied ProteinView binary/model through this sample's actual shell scene, socket, mounted client and worker. Checks changing image presentations, viewport pixels and bounded browser image ownership. |
 | `relay.browser.js` | Direct/relay transport selection, mixed peers, input and resize authority, primary closure, fresh reconnect/navigation-return replicas, retained KGP movement, and silent animation. |
 | `titles.browser.js` | Real POSIX shell title output through direct HWT1 and HMP1 relay, initial/late/reconnect notifications, safe header text and fallback, reset retention, duplicate/resync suppression, and disposal. |
 | `activity.browser.js` | Host-owned progress/severity and shell-phase chrome, direct and relayed current state, paused late attachment, resync, and fresh reconnect. No shell hooks required. |
@@ -168,10 +169,9 @@ are not substitutes for this transcript. A PTY can split/coalesce application
 writes, and an input write completing does not prove application consumption.
 
 The ordinary `ProteinViewGraphicsStreamTests` exercise fragmented raw input,
-picker replies, uncompressed RGBA, PNG, and Unicode virtual placements. The
-opt-in comparison records compressed and otherwise equivalent uncompressed
-streams without encoding a currently missing image as permanent correct
-behavior:
+picker replies, raw and zlib-compressed RGBA, PNG, and Unicode virtual placements.
+The opt-in comparison records compressed and otherwise equivalent uncompressed
+streams and checks that both retain the same exact pixels:
 
 ```sh
 HEX1B_GRAPHICS_EVIDENCE=/absolute/new/private/evidence-directory \
@@ -244,6 +244,95 @@ The replay runner limits input to 8 MiB, rechunks to 997 bytes to exercise raw
 framing, and appends a last-row processing marker. It saves retained-image hashes
 and an HWT1 frame. Preserve the original capture and a transformation manifest
 separately: replay rechunking and the marker are not original application bytes.
+
+## ProteinView live and sustained validation
+
+After starting this sample, the live fixture can run a reviewed, already-built
+ProteinView executable through its normal shell scene. It does not download or
+modify the application. Use an isolated browser and a task-owned sample process
+with a clean POSIX shell (`SHELL=/bin/sh`); the fixture uses POSIX argument quoting.
+Supply URL-encoded absolute paths where necessary:
+
+```sh
+playwright-cli -s=proteinview-validation open \
+  'http://localhost:5290/health?executable=/absolute/ProteinView/target/release/proteinview&model=/absolute/ProteinView/examples/4HHB.pdb&backend=webgpu'
+playwright-cli -s=proteinview-validation run-code \
+  "$(< samples/WebTerminalDemo/tests/proteinview-live.browser.js)"
+```
+
+The fixture creates its own terminal, runs `--fullhd`, toggles auto-rotation and
+waits for 50 observed image-upload/presentation changes. It reads actual
+compositor pixels rather than a renderer-only mock. The result includes peak
+texture/image/atlas counters. These browser counters are not the producer's
+retained-memory counters. Use `backend=webgl2` for the other renderer.
+
+On success the application stays paused for screenshots or reconnect checks.
+Run the lifecycle fixture in that same browser to check FullHD/HD/Braille mode
+switching and 20 reconnects alternating direct HWT1 and HMP1-replica views:
+
+```sh
+playwright-cli -s=proteinview-validation run-code \
+  "$(< samples/WebTerminalDemo/tests/proteinview-lifecycle.browser.js)"
+```
+
+It checks one 800x400 RGBA texture after each reconnect and zero image textures
+in text modes. These dimensions belong to the pinned application/model and
+80x24 test geometry, not a general meaning of "FullHD". To save screenshots,
+set `window.proteinViewEvidenceDirectory` to an existing private absolute
+directory before invoking it. The fixture preserves the workload on completion
+or failure for inspection.
+
+The caller must dispose `window.proteinViewAcceptance.terminal` and end the
+owned instance with `DELETE /api/terminals/{instanceId}` from the same origin,
+then close the isolated browser. Closing the browser alone does not terminate
+the sample's shared workload.
+
+For bounded **server-side** actual-application ownership measurements, run the
+opt-in sustained capture separately:
+
+```sh
+HEX1B_PROTEINVIEW_EXECUTABLE=/absolute/ProteinView/target/release/proteinview \
+HEX1B_PROTEINVIEW_MODEL=/absolute/ProteinView/examples/4HHB.pdb \
+HEX1B_GRAPHICS_SUSTAINED_EVIDENCE=/absolute/new/private/sustained-directory \
+  dotnet test tests/Hex1b.Tests/Hex1b.Tests.csproj --no-progress \
+  --filter "FullyQualifiedName~Capture_ExplicitSustainedRun"
+```
+
+This run requires 200 distinct accepted image generations within 60 seconds and
+a 64 MiB/100,000-event raw duplex budget. It records physical encoded retention,
+decoded-capacity reservations and acknowledged HWT1 frames independently.
+It deliberately retains an initial snapshot and one caller-owned decoded array.
+Reported allocation churn includes capture and projection overhead; it is not a
+benchmark or a process-wide memory bound. Ordinary snapshot/image references
+remain valid after live eviction or disposal, so retaining them extends their
+lifetime outside the terminal's current-screen accounting.
+
+Set `HEX1B_GRAPHICS_ACK_INTERVAL_MS=16` for a separate, explicitly paced HWT1
+acknowledgement comparison. The default is immediate acknowledgement. Pacing
+changes capture/projection frequency and allocation overhead; it does not
+simulate or replace measurements from the actual browser connection.
+
+### Compressed image ownership
+
+Kitty zlib uploads are validated completely before publication. The terminal
+retains their compressed backing in the existing `KgpImageData`, so snapshots
+and non-web consumers see authoritative image data too. Each `Data` access on a
+compressed image returns a fresh caller-owned array in its declared format
+(RGB, RGBA, or PNG bytes). Read it once per operation; the terminal does not keep
+a decoded-array cache. Existing uncompressed image behavior is unchanged.
+
+The live-screen budget charges actual compressed storage plus a conservative
+decoded-capacity reservation. That is not a process-memory limit: chunk assembly,
+validation, transport projection and caller-owned arrays have separate transient
+costs, and retaining old snapshots keeps their ordinary image references alive.
+Snapshot disposal does not invalidate those references. HWT1 drops obsolete KGP
+generations from its current projection cache while preserving resources still
+used by current placements; already emitted frames own their payloads separately.
+
+Malformed checksums, truncation, invalid output sizes and exceeded limits reject
+the upload rather than publishing a partially decoded image. One complete zlib
+member is interpreted; bounded trailing input is ignored but retained and charged,
+not interpreted as another image.
 
 ## Shared instances and floating views
 

--- a/samples/WebTerminalDemo/README.md
+++ b/samples/WebTerminalDemo/README.md
@@ -132,6 +132,8 @@ origin:
 | `bindings.browser.js` | Per-view input overrides, named actions, Windows-style right-click copy/paste, clipboard failures/races, capture ownership, and native text/paste/IME paths. Clipboard access is mocked. |
 | `selection-ui.browser.js` | Default, augmented, and replaced selection controls; host CSS, highlight parts, canvas alignment, focus/input isolation, action reuse, UI errors, and disposal. |
 | `graphics.browser.js` | Sixel and KGP in mixed WebGPU/WebGL2 views, renderer controls/diagnostics, cached-image movement, and late attachment to silent server-driven animation. |
+| `graphics-stream.browser.js` | Reviewed HWT1 capture replay through the actual decoder and WebGPU/WebGL2 renderer, with pixel readback and a screenshot-ready canvas. This is offline frame replay, not a live WebSocket/worker check. |
+| `graphics-worker-stream.browser.js` | A reviewed full HWT1 frame through the mounted client, actual worker and GPU. Only WebSocket transport is replaced; the mounted canvas stays available for screenshots until navigation. |
 | `relay.browser.js` | Direct/relay transport selection, mixed peers, input and resize authority, primary closure, fresh reconnect/navigation-return replicas, retained KGP movement, and silent animation. |
 | `titles.browser.js` | Real POSIX shell title output through direct HWT1 and HMP1 relay, initial/late/reconnect notifications, safe header text and fallback, reset retention, duplicate/resync suppression, and disposal. |
 | `activity.browser.js` | Host-owned progress/severity and shell-phase chrome, direct and relayed current state, paused late attachment, resync, and fresh reconnect. No shell hooks required. |
@@ -156,6 +158,92 @@ loopback-only access policy.
 The package's Node regressions and TypeScript builds run in CI. The browser
 fixtures remain focused, explicitly invoked checks; they are not a claim of
 broad HMP graphics/performance stability or a browser/device compatibility matrix.
+
+### Opt-in raw graphics investigations
+
+`tests/Hex1b.Tests/Diagnostics/` contains an internal duplex workload recorder and
+exact-chunk replay adapter. These record original byte arrays at the PTY adapter
+boundary, including terminal replies; Tape, Asciinema, and HWT1 frame recordings
+are not substitutes for this transcript. A PTY can split/coalesce application
+writes, and an input write completing does not prove application consumption.
+
+The ordinary `ProteinViewGraphicsStreamTests` exercise fragmented raw input,
+picker replies, uncompressed RGBA, PNG, and Unicode virtual placements. The
+opt-in comparison records compressed and otherwise equivalent uncompressed
+streams without encoding a currently missing image as permanent correct
+behavior:
+
+```sh
+HEX1B_GRAPHICS_EVIDENCE=/absolute/new/private/evidence-directory \
+  dotnet test tests/Hex1b.Tests/Hex1b.Tests.csproj --no-progress \
+  --filter "FullyQualifiedName~ProteinViewGraphicsStreamTests"
+```
+
+To capture the real application, first build a reviewed ProteinView checkout
+locally. The investigation baseline is upstream commit
+`9b9a0790bc78f1d2a7c0923905049d27c67c05e2`; the test never downloads or installs it.
+Supply an absolute binary path and the bundled model:
+
+```sh
+HEX1B_PROTEINVIEW_EXECUTABLE=/absolute/ProteinView/target/release/proteinview \
+HEX1B_PROTEINVIEW_MODEL=/absolute/ProteinView/examples/4HHB.pdb \
+HEX1B_GRAPHICS_EVIDENCE=/absolute/new/private/application-evidence \
+  dotnet test tests/Hex1b.Tests/Hex1b.Tests.csproj --no-progress \
+  --filter "FullyQualifiedName~ProteinViewInvestigationTests"
+```
+
+This Unix-only runner launches the binary directly, not a shell. Each case uses
+80x24 cells, a 20-second deadline, a 64 MiB/100,000-event capture budget, and
+four-second sampling windows. Cases cover plain/Braille/FullHD, uppercase `M`,
+safe observed terminal hints versus a separate normalized environment, and
+HMP1 producer-backed versus direct HWT1 projection. It records binary/model
+hashes, picker logs, byte transcripts and sampled HWT1 frames. It does not
+reproduce arbitrary inherited environments or a native Ghostty session.
+SSH/session identifier values are never copied; only their presence is retained.
+Do not run under tmux, where upstream may change passthrough configuration.
+Without the explicit environment variables these investigation cases are skipped.
+
+Keep captures private and review them before sharing. The binary runs with your
+privileges; supply only a reviewed executable and local input. An interrupted,
+failed, or budget-exceeded transcript is not a successful reproduction.
+
+For browser readback, use a loopback-only static test host serving the matching
+built client at `/web-terminal/` and **only reviewed `.hwt` files** at `/evidence/`.
+Do not expose raw transcripts, environment metadata, arbitrary files, or a
+production host. Navigate to
+`/?frame=rgba-control.hwt&backend=webgpu`, then run:
+
+```sh
+playwright-cli run-code "$(< samples/WebTerminalDemo/tests/graphics-stream.browser.js)"
+```
+
+Use `backend=webgl2` for that renderer. Repeat `frame` parameters in recorded
+order when replaying deltas (for example, before/after `M`). The optional
+`minimum` asserts a red-pixel lower bound for the synthetic red image. Without it,
+the fixture reports pixel counts for investigation; zero images or pixels do not
+constitute success. Real FullHD acceptance requires visible molecular output in
+the viewport, not just an ACK, texture allocation, or colored header text.
+
+For the mounted-worker check, navigate to a full-frame artifact with `?frame=...`
+and invoke `graphics-worker-stream.browser.js` instead. It runs the real client
+and worker with only the socket replaced, so it can distinguish renderer-only
+fixture effects from actual client behavior. It does not establish live network
+transport behavior. Navigate away or close the isolated browser to dispose it.
+
+To inspect an already reviewed reduced raw-output file (without launching an
+application), use:
+
+```sh
+HEX1B_GRAPHICS_STREAM=/absolute/reduced-output.bin \
+HEX1B_GRAPHICS_REPLAY_OUTPUT=/absolute/new/private/replay-directory \
+  dotnet test tests/Hex1b.Tests/Hex1b.Tests.csproj --no-progress \
+  --filter "FullyQualifiedName~GraphicsStreamReplayTests"
+```
+
+The replay runner limits input to 8 MiB, rechunks to 997 bytes to exercise raw
+framing, and appends a last-row processing marker. It saves retained-image hashes
+and an HWT1 frame. Preserve the original capture and a transformation manifest
+separately: replay rechunking and the marker are not original application bytes.
 
 ## Shared instances and floating views
 

--- a/samples/WebTerminalDemo/tests/graphics-placeholders.browser.js
+++ b/samples/WebTerminalDemo/tests/graphics-placeholders.browser.js
@@ -1,0 +1,342 @@
+// Run against WebTerminalDemo with:
+// playwright-cli -s=<session> run-code "$(cat samples/WebTerminalDemo/tests/graphics-placeholders.browser.js)"
+async page => {
+  const origin = page.url().match(/^https?:\/\/[^/]+/)?.[0] || "http://localhost:5290";
+  const context = await page.context().browser().newContext({ deviceScaleFactor: 1 });
+  const test = await context.newPage();
+  const errors = [];
+  test.on("pageerror", error => errors.push(error.message));
+  try {
+    await test.goto(`${origin}/health`);
+    const results = await test.evaluate(async () => {
+      const { TerminalRenderer } = await import("/web-terminal/renderer.js");
+      const check = (condition, message) => { if (!condition) throw new Error(message); };
+      // Same native framebuffer readback as renderers.browser.js; never infer
+      // image coverage from quad counts or screenshots of a scaled DOM canvas.
+      async function pixels(renderer) {
+        const { backend, canvas } = renderer;
+        const result = new Uint8Array(canvas.width * canvas.height * 4);
+        if (backend.kind === "webgl2") {
+          const raw = new Uint8Array(result.length);
+          const gl = backend.gl;
+          gl.readPixels(0, 0, canvas.width, canvas.height, gl.RGBA, gl.UNSIGNED_BYTE, raw);
+          check(gl.getError() === gl.NO_ERROR, "WebGL2 readback failed");
+          for (let y = 0; y < canvas.height; y++) {
+            result.set(raw.subarray((canvas.height - 1 - y) * canvas.width * 4,
+              (canvas.height - y) * canvas.width * 4), y * canvas.width * 4);
+          }
+        } else {
+          const { device, context, format } = backend;
+          const bytesPerRow = Math.ceil(canvas.width * 4 / 256) * 256;
+          const buffer = device.createBuffer({ size: bytesPerRow * canvas.height,
+            usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ });
+          try {
+            const encoder = device.createCommandEncoder();
+            encoder.copyTextureToBuffer({ texture: context.getCurrentTexture() },
+              { buffer, bytesPerRow }, [canvas.width, canvas.height]);
+            device.queue.submit([encoder.finish()]);
+            await buffer.mapAsync(GPUMapMode.READ);
+            const raw = new Uint8Array(buffer.getMappedRange());
+            const red = format.startsWith("bgra") ? 2 : 0;
+            for (let y = 0; y < canvas.height; y++) for (let x = 0; x < canvas.width; x++) {
+              const source = y * bytesPerRow + x * 4, target = (y * canvas.width + x) * 4;
+              result.set([raw[source + red], raw[source + 1], raw[source + 2 - red], 255], target);
+            }
+          } finally { buffer.destroy(); }
+        }
+        await renderer.idle();
+        return result;
+      }
+      const red = [255, 0, 0, 255], black = [0, 0, 0, 255];
+      const blue = [0, 0, 255, 255], green = [0, 255, 0, 255], white = [255, 255, 255, 255];
+      const cells = Object.freeze(["\u0305", "\u030d", "\u030e", "\u0310"].map((column, index) =>
+        Object.freeze({
+          index, text: `\u{10eeee}\u0305${column}`, width: 1,
+          // Packed RGBA: RGB 0,0,1 encodes Kitty image ID 1.
+          foreground: 0xff010000, background: 0xff000000,
+          underlineColor: 0xff00ff00, attributes: 0, underlineStyle: 0
+        })));
+      const originalCells = JSON.stringify(cells);
+      const rgba = new Uint8Array(40 * 20 * 4);
+      for (let i = 0; i < rgba.length; i += 4) rgba.set(red, i);
+      const image = { key: "red", width: 40, height: 20, format: "rgba", bytes: rgba, byteLength: rgba.length };
+      // HWT's projected destination for a 4-column, 1-row virtual placement.
+      const placement = Object.freeze({
+        key: "red", kind: "kgp", x: 0, y: 0, width: 40, height: 20,
+        sourceX: 0, sourceY: 0, sourceWidth: 40, sourceHeight: 20,
+        clipX: 0, clipY: 0, clipWidth: 40, clipHeight: 20, z: -1
+      });
+      const metadata = Object.freeze({
+        defaultBackground: 0xff000000, cursor: Object.freeze({ visible: false, shape: 0, x: 0, y: 0 }),
+        placements: Object.freeze([placement])
+      });
+      const originalMetadata = JSON.stringify(metadata);
+      const reports = [];
+      for (const kind of ["webgpu", "webgl2"]) {
+        const canvas = document.createElement("canvas");
+        document.body.append(canvas);
+        const failures = [];
+        let renderer;
+        try {
+          renderer = await TerminalRenderer.create(canvas, 1, error => failures.push(error.message), undefined, kind);
+          check(renderer.backend.kind === kind && !renderer.fallbackReason, `${kind}: forced renderer ignored`);
+          renderer.resize(4, 1);
+          if (kind === "webgpu") {
+            const { device, context, format } = renderer.backend;
+            context.configure({ device, format, alphaMode: "opaque",
+              usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC });
+          }
+          await renderer.updateImages([image], ["red"]);
+          const capture = async (frameCells = cells, frameMetadata = metadata, blink = true) => {
+            renderer.prepareGlyphs(frameCells);
+            renderer.render(frameCells, frameMetadata, blink);
+            return pixels(renderer);
+          };
+          const assertPixels = (actual, expected, label) => {
+            check(actual.length === 800 * 4, `${kind}/${label}: framebuffer must be 40x20`);
+            for (let i = 0; i < 800; i++) {
+              const color = expected(i % 40, Math.floor(i / 40));
+              check(color.every((value, channel) => actual[i * 4 + channel] === value),
+                `${kind}/${label}: wrong pixel (${i % 40},${Math.floor(i / 40)}): ` +
+                `${[...actual.subarray(i * 4, i * 4 + 4)]}, expected ${color}`);
+            }
+          };
+          const initial = await capture();
+          assertPixels(initial, () => red, "all 800 red pixels");
+          check(renderer.metrics().atlasGlyphs === 0 && renderer.metrics().glyphUploadBytes === 0,
+            `${kind}: placeholders entered the glyph atlas`);
+
+          const ordinary = cells.map(cell => ({ ...cell, text: "A", foreground: 0xffffffff }));
+          const ordinaryPixels = await capture(ordinary);
+          const ordinaryRedPixels = Array.from({ length: 800 }, (_, i) =>
+            red.every((value, channel) => ordinaryPixels[i * 4 + channel] === value)).filter(Boolean).length;
+          check(ordinaryRedPixels > 0 && ordinaryRedPixels < 800, `${kind}: ordinary glyphs no longer paint above images`);
+          check(renderer.metrics().atlasGlyphs === 1, `${kind}: ordinary glyph was not prepared`);
+
+          // Seed a cached glyph deliberately: a preparation-only fix must not
+          // accidentally pass without an independent paint-time guard.
+          const ordinaryGlyph = renderer.glyphs.get("0/1/A");
+          for (const cell of cells) renderer.glyphs.set(`0/1/${cell.text}`, ordinaryGlyph);
+          try {
+            assertPixels(await capture(), () => red, "cached placeholder glyph suppression");
+          } finally {
+            for (const cell of cells) renderer.glyphs.delete(`0/1/${cell.text}`);
+          }
+
+          const bare = cells.map(cell => ({ ...cell, text: "\u{10eeee}" }));
+          assertPixels(await capture(bare), () => red, "bare reserved scalar");
+          check(renderer.metrics().atlasGlyphs === 1, `${kind}: bare placeholder entered the atlas`);
+          const neighbors = ["\u{10eeed}", "\u{10eeef}", "A\u0305", "\u0305"].map((text, index) =>
+            ({ ...ordinary[index], text }));
+          renderer.prepareGlyphs(neighbors);
+          for (const cell of neighbors) check(renderer.glyphs.has(`0/1/${cell.text}`),
+            `${kind}: non-placeholder text was suppressed: ${cell.text}`);
+
+          assertPixels(await capture(cells, { ...metadata, placements: [{ ...placement, clipX: 10, clipWidth: 20 }] }),
+            x => x >= 10 && x < 30 ? red : black, "placement clipping");
+          assertPixels(await capture(cells, { ...metadata, placements: [{ ...placement, sourceX: -10 }] }),
+            x => x >= 10 ? red : black, "source cropping");
+          assertPixels(await capture(cells, { ...metadata, placements: [{ ...placement, z: -2147483648 }] }),
+            () => black, "image below opaque backgrounds");
+          assertPixels(await capture(cells.map(cell => ({ ...cell, background: 0 })), {
+            ...metadata, placements: [{ ...placement, z: -2147483648 }]
+          }), () => red, "image below transparent backgrounds");
+          assertPixels(await capture(ordinary, { ...metadata, placements: [{ ...placement, z: 0 }] }),
+            () => red, "image above ordinary glyphs");
+          assertPixels(await capture(cells.map(cell => ({ ...cell, underlineStyle: 1 }))),
+            (_x, y) => y === 18 ? green : red, "placeholder decorations preserved");
+          assertPixels(await capture(ordinary.map(cell => ({ ...cell, attributes: 64 }))),
+            () => red, "concealed ordinary glyphs");
+          assertPixels(await capture(ordinary.map(cell => ({ ...cell, attributes: 16 })), metadata, false),
+            () => red, "blinking ordinary glyphs");
+          assertPixels(await capture(cells.map(cell => ({ ...cell, foreground: 0xffffffff })), {
+            ...metadata, cursor: { visible: true, shape: 4, x: 0, y: 0 }
+          }), (x, y) => x < 10 && y >= 18 ? white : red, "cursor over placeholders");
+
+          await renderer.updateImages([], []);
+          assertPixels(await capture(cells.map(cell => ({ ...cell, background: 0xffff0000 })), {
+            ...metadata, placements: []
+          }), () => blue, "missing image leaves placeholder background without tofu");
+          check(renderer.metrics().textureBytes === 0, `${kind}: deleted image texture retained`);
+          let missingPlacementError;
+          try { renderer.render(cells, metadata, true); }
+          catch (error) { missingPlacementError = error.message; }
+          check(missingPlacementError === "Placement texture is missing: red",
+            `${kind}: invalid missing-texture placement no longer fails`);
+          check(JSON.stringify(cells) === originalCells && JSON.stringify(metadata) === originalMetadata,
+            `${kind}: authoritative cell text/colors or placement metadata changed`);
+          check(failures.length === 0, `${kind}: ${failures.join("; ")}`);
+
+          // Observe calls to the native GPU objects, not just RenderTexture.destroy.
+          // These bounded test-held references are deliberately not a GC/working-set probe.
+          const backend = renderer.backend;
+          const textures = new Map();
+          const bufferDeletes = new Map();
+          const restores = [];
+          const prematureDeletes = [];
+          let inFlight = false;
+          const intercept = (owner, name, observe) => {
+            const original = owner[name];
+            const own = Object.getOwnPropertyDescriptor(owner, name);
+            owner[name] = function (...args) {
+              const result = original.apply(this, args);
+              observe(...args);
+              return result;
+            };
+            restores.push(() => {
+              if (own) Object.defineProperty(owner, name, own);
+              else delete owner[name];
+            });
+          };
+          const deleted = texture => {
+            const entry = textures.get(texture);
+            if (!entry) return;
+            entry.deletes++;
+            if (inFlight) prematureDeletes.push(entry.label);
+          };
+          const watchTexture = (resource, label) => {
+            textures.set(resource.texture, { label, deletes: 0 });
+            if (kind === "webgpu") intercept(resource.texture, "destroy", () => deleted(resource.texture));
+            return resource;
+          };
+          const deletedBuffer = buffer => bufferDeletes.set(buffer, (bufferDeletes.get(buffer) || 0) + 1);
+          let deviceDeletes = 0;
+          try {
+            if (kind === "webgl2") {
+              intercept(backend.gl, "deleteTexture", deleted);
+              intercept(backend.gl, "deleteBuffer", deletedBuffer);
+            } else {
+              intercept(backend.instanceBuffer, "destroy", () => deletedBuffer(backend.instanceBuffer));
+              intercept(backend.uniform, "destroy", () => deletedBuffer(backend.uniform));
+              intercept(backend.device, "destroy", () => { deviceDeletes++; });
+            }
+            watchTexture(renderer.atlas, "atlas");
+            const originalCreate = backend.createTexture;
+            backend.createTexture = function (width, height, label) {
+              return watchTexture(originalCreate.call(this, width, height, label), label);
+            };
+            restores.push(() => { backend.createTexture = originalCreate; });
+            const imageEntries = () => [...textures.values()].filter(entry => entry.label !== "atlas");
+            const assertCurrent = key => {
+              check(renderer.images.size === 1 && renderer.images.has(key) &&
+                renderer.metrics().imageCount === 1 && renderer.metrics().textureBytes === 3200,
+              `${kind}/${key}: CPU image ownership did not stay at one 3200-byte texture`);
+              const current = renderer.images.get(key).texture;
+              for (const [texture, entry] of textures) {
+                check(entry.deletes === (texture === current || entry.label === "atlas" ? 0 : 1),
+                  `${kind}/${key}: incorrect native texture lifetime for ${entry.label}: ${entry.deletes}`);
+                if (kind === "webgl2") check(backend.gl.isTexture(texture) === (entry.deletes === 0),
+                  `${kind}/${key}: native WebGL texture liveness disagrees with deletion`);
+              }
+              check(backend.instanceBufferBytes > 0, `${kind}/${key}: live instance buffer disappeared`);
+            };
+            const generationPixels = new Uint8Array(rgba.length);
+            const presentCurrent = async (key, color) => {
+              const frameMetadata = { ...metadata, placements: [{ ...placement, key }] };
+              renderer.prepareGlyphs(cells);
+              inFlight = true;
+              try {
+                renderer.render(cells, frameMetadata, true);
+                // Retaining an in-flight image without replacing it must not free it.
+                await renderer.updateImages([], [key]);
+                assertCurrent(key);
+                assertPixels(await pixels(renderer), () => color, `generation ${key}`);
+              } finally { inFlight = false; }
+            };
+            const uploadsBefore = renderer.metrics().imageUploadBytes;
+            for (let generation = 0; generation < 65; generation++) {
+              const key = `generation-${generation}`;
+              const color = generation % 2 ? blue : red;
+              for (let offset = 0; offset < generationPixels.length; offset += 4) generationPixels.set(color, offset);
+              await renderer.updateImages([{ ...image, key, bytes: generationPixels }], [key]);
+              assertCurrent(key);
+              await presentCurrent(key, color);
+            }
+            check(imageEntries().length === 65 && imageEntries().filter(entry => entry.deletes === 1).length === 64,
+              `${kind}: 65 image generations did not delete exactly 64 superseded native textures`);
+            check(renderer.metrics().imageUploadBytes - uploadsBefore === 65 * 3200,
+              `${kind}: retain-only updates retransmitted image pixels`);
+
+            // Replacing a resource under the same key follows the same release path.
+            await renderer.updateImages([{ ...image, key: "generation-64" }], ["generation-64"]);
+            assertCurrent("generation-64");
+            await presentCurrent("generation-64", red);
+
+            // A still-placed shared image must survive pruning of other generations.
+            const sharedKey = "generation-64";
+            const sharedTexture = renderer.images.get(sharedKey).texture;
+            for (let offset = 0; offset < generationPixels.length; offset += 4) generationPixels.set(blue, offset);
+            for (let generation = 0; generation < 4; generation++) {
+              const key = `shared-current-${generation}`;
+              await renderer.updateImages([{ ...image, key, bytes: generationPixels }], [sharedKey, key]);
+              check(renderer.images.size === 2 && renderer.textureBytes === 6400 &&
+                renderer.images.get(sharedKey).texture === sharedTexture && textures.get(sharedTexture).deletes === 0,
+              `${kind}/${key}: pruning released or replaced a shared still-referenced image`);
+              const currentTexture = renderer.images.get(key).texture;
+              for (const [texture, entry] of textures) {
+                check(entry.deletes === (texture === currentTexture || texture === sharedTexture || entry.label === "atlas" ? 0 : 1),
+                  `${kind}/${key}: shared retention leaked an obsolete generation`);
+              }
+              inFlight = true;
+              try {
+                renderer.render(cells, { ...metadata, placements: [
+                  { ...placement, key, clipWidth: 20 },
+                  { ...placement, key: sharedKey, clipX: 20, clipWidth: 20 }
+                ] }, true);
+                await renderer.updateImages([], [sharedKey, key]);
+                assertPixels(await pixels(renderer), x => x < 20 ? blue : red, `shared retention ${generation}`);
+              } finally { inFlight = false; }
+            }
+            const lastSharedCurrent = renderer.images.get("shared-current-3");
+            await renderer.updateImages([], ["shared-current-3"]);
+            check(renderer.images.get("shared-current-3") === lastSharedCurrent &&
+              textures.get(sharedTexture).deletes === 1, `${kind}: releasing shared key disturbed retained current image`);
+            assertCurrent("shared-current-3");
+            await presentCurrent("shared-current-3", blue);
+            await renderer.updateImages([], []);
+            check(renderer.images.size === 0 && renderer.metrics().textureBytes === 0 &&
+              imageEntries().every(entry => entry.deletes === 1), `${kind}: empty retention leaked a native image`);
+            assertPixels(await capture(cells, { ...metadata, placements: [] }), () => black, "empty retention clears images");
+
+            // Dispose with a live image and a submitted frame's batches still retained.
+            await renderer.updateImages([{ ...image, key: "dispose-current" }], ["dispose-current"]);
+            await presentCurrent("dispose-current", red);
+            renderer.dispose();
+            renderer.dispose();
+            check(renderer.images.size === 0 && renderer.textureBytes === 0 &&
+              renderer.glyphs.size === 0 && renderer.glyphKeyUnits === 0 && renderer.batches.length === 0 &&
+              renderer.quadCount === 0 && renderer.instances.byteLength === 0 && renderer.fontMetrics.size === 0,
+            `${kind}: disposed renderer retained CPU resources or active byte counts`);
+            check([...textures.values()].every(entry => entry.deletes === 1),
+              `${kind}: dispose did not delete every native image and atlas exactly once`);
+            check(bufferDeletes.size === (kind === "webgpu" ? 2 : 1) &&
+              [...bufferDeletes.values()].every(count => count === 1),
+            `${kind}: dispose did not delete its native buffers exactly once`);
+            check(kind !== "webgpu" || deviceDeletes === 1, "WebGPU device was not destroyed exactly once");
+            check(kind !== "webgl2" || backend.textures.size === 0, "WebGL2 retained destroyed texture wrappers");
+            check(prematureDeletes.length === 0, `${kind}: resources deleted in flight: ${prematureDeletes}`);
+            check(failures.length === 0, `${kind}: ${failures.join("; ")}`);
+            reports.push({
+              renderer: kind, redPixels: 800, expectedRedPixels: 800, ordinaryRedPixels,
+              lifetime: { successiveKeys: 65, singleKeyImageCount: 1, singleKeyImageBytes: 3200,
+                sharedGenerations: 4, sharedImageCount: 2, sharedImageBytes: 6400,
+                nativeImageDeletes: imageEntries().reduce((sum, entry) => sum + entry.deletes, 0),
+                nativeAtlasDeletes: textures.get(renderer.atlas.texture).deletes,
+                nativeBufferDeletes: [...bufferDeletes.values()].reduce((sum, count) => sum + count, 0),
+                prematureDeletes: prematureDeletes.length, disposedImageBytes: renderer.textureBytes }
+            });
+          } finally {
+            renderer.dispose();
+            for (const restore of restores.reverse()) restore();
+          }
+        } finally {
+          renderer?.dispose();
+          canvas.remove();
+        }
+      }
+      return reports;
+    });
+    if (errors.length) throw new Error(errors.join("; "));
+    return { passed: true, results };
+  } finally { await context.close(); }
+}

--- a/samples/WebTerminalDemo/tests/graphics-stream.browser.js
+++ b/samples/WebTerminalDemo/tests/graphics-stream.browser.js
@@ -1,0 +1,94 @@
+async page => {
+  // Serve only reviewed HWT1 artifacts at /evidence/ and the matching built client at /web-terminal/.
+  // Example query: ?frame=rgba-control.hwt&backend=webgpu
+  const { frames, backend, minimum } = await page.evaluate(() => {
+    const query = new URL(location.href).searchParams;
+    return { frames: query.getAll("frame"), backend: query.get("backend") || "webgpu",
+      minimum: query.has("minimum") ? Number(query.get("minimum")) : null };
+  });
+  if (!frames.length) throw new Error("At least one frame query parameter is required");
+  await page.setContent('<canvas id="capture"></canvas>');
+  return await page.evaluate(async ({ frames, backend, minimum }) => {
+    const { decodeFrame } = await import("/web-terminal/protocol.js");
+    const { TerminalRenderer } = await import("/web-terminal/renderer.js");
+    const canvas = document.querySelector("#capture");
+    const errors = [];
+    const renderer = await TerminalRenderer.create(canvas, 1, error => errors.push(error.message), undefined, backend);
+    const cells = [];
+    let metadata;
+    try {
+      for (const name of frames) {
+        if (name.startsWith("/") || name.split("/").some(part => part === ".."))
+          throw new Error("Use a relative reviewed evidence path");
+        const response = await fetch(`/evidence/${name}`);
+        if (!response.ok) throw new Error(`Frame fetch failed: ${response.status}`);
+        const frame = decodeFrame(await response.arrayBuffer());
+        metadata = frame.metadata;
+        if (metadata.full) cells.length = metadata.columns * metadata.rows;
+        for (const cell of frame.cells) cells[cell.index] = cell;
+        renderer.resize(metadata.columns, metadata.rows);
+        await renderer.updateImages(frame.images, metadata.retainedImages);
+        renderer.prepareGlyphs(cells);
+      }
+      let pixels, stride, redIndex, flipY = false;
+      const { device, context, format, gl } = renderer.backend;
+      let readback;
+      if (backend === "webgpu") {
+        context.configure({ device, format, alphaMode: "opaque",
+          usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC });
+        renderer.render(cells, metadata, true);
+        stride = Math.ceil(canvas.width * 4 / 256) * 256;
+        readback = device.createBuffer({ size: stride * canvas.height,
+          usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ });
+        const copy = device.createCommandEncoder();
+        copy.copyTextureToBuffer({ texture: context.getCurrentTexture() },
+          { buffer: readback, bytesPerRow: stride }, [canvas.width, canvas.height]);
+        device.queue.submit([copy.finish()]);
+        await readback.mapAsync(GPUMapMode.READ);
+        pixels = new Uint8Array(readback.getMappedRange()).slice();
+        readback.unmap();
+        readback.destroy();
+        redIndex = format.startsWith("bgra") ? 2 : 0;
+      } else {
+        renderer.render(cells, metadata, true);
+        stride = canvas.width * 4;
+        pixels = new Uint8Array(stride * canvas.height);
+        gl.readPixels(0, 0, canvas.width, canvas.height, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+        redIndex = 0;
+        flipY = true;
+      }
+      let redPixels = 0, coloredViewportPixels = 0;
+      for (let y = 0; y < canvas.height; y++) for (let x = 0; x < canvas.width; x++) {
+        const offset = (flipY ? canvas.height - 1 - y : y) * stride + x * 4;
+        const r = pixels[offset + redIndex], g = pixels[offset + 1], b = pixels[offset + (redIndex === 2 ? 0 : 2)];
+        if (r > 240 && g < 10 && b < 10) redPixels++;
+        if (x >= 50 && x < canvas.width - 50 && y >= 60 && y < canvas.height - 60 &&
+            Math.max(r, g, b) > 70 && Math.max(r, g, b) - Math.min(r, g, b) > 40)
+          coloredViewportPixels++;
+      }
+      if (errors.length) throw new Error(errors.join("; "));
+      if (minimum !== null && redPixels < minimum)
+        throw new Error(`Expected at least ${minimum} red pixels, found ${redPixels}`);
+      // Keep a 2D copy for screenshots after GPU resource cleanup.
+      const rgba = new Uint8ClampedArray(canvas.width * canvas.height * 4);
+      for (let y = 0; y < canvas.height; y++) for (let x = 0; x < canvas.width; x++) {
+        const source = (flipY ? canvas.height - 1 - y : y) * stride + x * 4;
+        const destination = (y * canvas.width + x) * 4;
+        rgba[destination] = pixels[source + redIndex];
+        rgba[destination + 1] = pixels[source + 1];
+        rgba[destination + 2] = pixels[source + (redIndex === 2 ? 0 : 2)];
+        rgba[destination + 3] = 255;
+      }
+      const image = document.createElement("canvas");
+      image.width = canvas.width;
+      image.height = canvas.height;
+      image.getContext("2d").putImageData(new ImageData(rgba, image.width, image.height), 0, 0);
+      canvas.replaceWith(image);
+      return { backend, frames, redPixels, coloredViewportPixels,
+        images: metadata.retainedImages.length, placements: metadata.placements.length,
+        width: image.width, height: image.height, warnings: metadata.warnings, errors };
+    } finally {
+      renderer.dispose();
+    }
+  }, { frames, backend, minimum });
+}

--- a/samples/WebTerminalDemo/tests/graphics-worker-stream.browser.js
+++ b/samples/WebTerminalDemo/tests/graphics-worker-stream.browser.js
@@ -1,0 +1,57 @@
+async page => {
+  await page.setContent('<div id="terminal" style="width:800px;height:480px"></div>');
+  return await page.evaluate(async () => {
+    const name = new URL(location.href).searchParams.get("frame");
+    if (!name || name.startsWith("/") || name.split("/").some(part => part === ".."))
+      throw new Error("A reviewed relative frame path is required");
+    const frameUrl = new URL(`/evidence/${name}`, location.href).href;
+    const workerModule = new URL("/web-terminal/terminal-worker.js", location.href).href;
+    const source = `
+      const pending = [];
+      const capture = event => pending.push(event.data);
+      self.addEventListener("message", capture);
+      const response = await fetch(${JSON.stringify(frameUrl)});
+      if (!response.ok) throw new Error("Captured frame fetch failed");
+      const frame = await response.arrayBuffer();
+      self.WebSocket = class extends EventTarget {
+        static OPEN = 1;
+        readyState = 0;
+        constructor() {
+          super();
+          queueMicrotask(() => {
+            this.readyState = 1;
+            this.dispatchEvent(new Event("open"));
+            this.dispatchEvent(new MessageEvent("message", { data: frame }));
+          });
+        }
+        send(message) {
+          if (JSON.parse(message).type === "ack")
+            self.postMessage({ type: "status", message: "Captured frame acknowledged", level: "info" });
+        }
+        close() { this.readyState = 3; }
+      };
+      await import(${JSON.stringify(workerModule)});
+      self.removeEventListener("message", capture);
+      for (const data of pending) self.dispatchEvent(new MessageEvent("message", { data }));
+    `;
+    const { WebTerminal } = await import("/web-terminal/index.js");
+    const workerUrl = URL.createObjectURL(new Blob([source], { type: "text/javascript" }));
+    const status = [];
+    try {
+      const terminal = await WebTerminal.mount(document.querySelector("#terminal"), {
+        url: "/ws", workerUrl, renderer: "webgpu", onStatus: message => status.push(message)
+      });
+      // Retain the actual mounted client for screenshots; navigating away closes this fixture.
+      window.graphicsCapture = { terminal, workerUrl };
+      window.addEventListener("pagehide", () => {
+        terminal.dispose();
+        URL.revokeObjectURL(workerUrl);
+      }, { once: true });
+      return { provenance: "actual mounted client/worker/GPU; only WebSocket replaced with one captured HWT1 frame",
+        status, stats: terminal.stats, placeholderTextPresent: terminal.screenText.includes("\u{10eeee}") };
+    } catch (error) {
+      URL.revokeObjectURL(workerUrl);
+      throw error;
+    }
+  });
+}

--- a/samples/WebTerminalDemo/tests/proteinview-lifecycle.browser.js
+++ b/samples/WebTerminalDemo/tests/proteinview-lifecycle.browser.js
@@ -1,0 +1,73 @@
+async page => {
+  // Run after proteinview-live.browser.js. Optional screenshots go to the caller's private directory.
+  const directory = await page.evaluate(() => window.proteinViewEvidenceDirectory);
+  const backend = await page.evaluate(() => window.proteinViewAcceptance.terminal.stats.renderer);
+  await page.evaluate(() => window.proteinViewAcceptance.terminal.focus());
+  await page.keyboard.press("M");
+  await page.waitForFunction(() => {
+    const terminal = window.proteinViewAcceptance.terminal;
+    return terminal.stats.imageCount === 0 && terminal.stats.textureBytes === 0
+      && terminal.screenText.includes("\u2502 HD");
+  }, null, { timeout: 10000 });
+  await page.keyboard.press("m");
+  await page.waitForFunction(() => {
+    const terminal = window.proteinViewAcceptance.terminal;
+    return terminal.stats.imageCount === 0 && terminal.screenText.includes("Braille")
+      && /[\u2801-\u28ff]/u.test(terminal.screenText);
+  }, null, { timeout: 10000 });
+  if (directory)
+    await page.screenshot({ path: `${directory}/live-${backend}-braille.png` });
+  await page.keyboard.press("M");
+  await page.waitForFunction(() => {
+    const terminal = window.proteinViewAcceptance.terminal;
+    return terminal.stats.imageCount === 1 && terminal.screenText.includes("FullHD");
+  }, null, { timeout: 10000 });
+
+  const cycles = [];
+  for (let cycle = 0; cycle < 20; cycle++) {
+    await page.evaluate(() => window.proteinViewAcceptance.terminal.dispose());
+    await page.waitForFunction(async () => {
+      const response = await fetch("/api/terminals");
+      if (!response.ok) throw new Error(`Instance status failed: ${response.status}`);
+      const instances = await response.json();
+      const instance = instances.find(value => value.id === window.proteinViewAcceptance.instanceId);
+      if (!instance) throw new Error("Closing a view unexpectedly ended the shared workload");
+      return instance.peerCount === 0;
+    }, null, { timeout: 10000 });
+    const transport = cycle % 2 === 0 ? "direct" : "hmp1";
+    await page.evaluate(async transport => {
+      const { WebTerminal } = await import("/web-terminal/index.js");
+      const state = window.proteinViewAcceptance;
+      state.reconnectErrors = [];
+      state.terminal = await WebTerminal.mount(document.querySelector("#terminal"), {
+        url: `/ws?instance=${encodeURIComponent(state.instanceId)}&transport=${transport}`,
+        renderer: new URL(location.href).searchParams.get("backend") || "webgpu",
+        onStatus: (message, level) => { if (level === "error") state.reconnectErrors.push(message); }
+      });
+    }, transport);
+    await page.waitForFunction(() => {
+      const state = window.proteinViewAcceptance;
+      if (state.reconnectErrors.length) throw new Error(state.reconnectErrors.join("; "));
+      return state.terminal.stats.imageCount > 0;
+    }, null, { timeout: 10000 });
+    cycles.push(await page.evaluate(({ cycle, transport }) => {
+      const terminal = window.proteinViewAcceptance.terminal;
+      const stats = terminal.stats;
+      if (stats.imageCount !== 1 || stats.textureBytes !== 1280000)
+        throw new Error(`Reconnect retained incorrect graphics: ${JSON.stringify(stats)}`);
+      if (!terminal.screenText.includes("FullHD"))
+        throw new Error("Reconnect lost application text/state");
+      return { cycle, transport, imageCount: stats.imageCount, textureBytes: stats.textureBytes,
+        initialImagePayloadBytes: stats.imagePayloadBytes, frames: stats.frames };
+    }, { cycle, transport }));
+  }
+  if (directory)
+    await page.screenshot({ path: `${directory}/live-${backend}-reconnected.png` });
+  await page.evaluate(() => {
+    const terminal = window.proteinViewAcceptance.terminal;
+    terminal.requestPrimary();
+    terminal.focus();
+  });
+  return { modes: ["FullHD", "HalfBlock", "Braille", "FullHD"],
+    reconnectCycles: cycles, note: "Application remains owned and paused; caller must end the terminal." };
+}

--- a/samples/WebTerminalDemo/tests/proteinview-live.browser.js
+++ b/samples/WebTerminalDemo/tests/proteinview-live.browser.js
@@ -1,0 +1,126 @@
+async page => {
+  // Run on this demo's loopback /health URL with explicit executable/model query parameters.
+  const configuration = await page.evaluate(() => {
+    const query = new URL(location.href).searchParams;
+    return { executable: query.get("executable"), model: query.get("model"),
+      backend: query.get("backend") || "webgpu" };
+  });
+  if (!configuration.executable || !configuration.model)
+    throw new Error("Explicit reviewed ProteinView executable and local model paths are required");
+  await page.setContent('<div id="terminal" style="width:800px;height:480px"></div>');
+  await page.evaluate(async configuration => {
+    const response = await fetch("/api/terminals", {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ scene: "shell", columns: 80, rows: 24, name: "ProteinView acceptance" })
+    });
+    if (!response.ok) throw new Error(`Terminal creation failed: ${response.status}`);
+    const instance = await response.json();
+    const { WebTerminal } = await import("/web-terminal/index.js");
+    const state = window.proteinViewAcceptance = {
+      instanceId: instance.id, changes: [], statuses: [], errors: [],
+      peakTextureBytes: 0, peakImageCount: 0, peakAtlasBytes: 0, lastImageUploadBytes: 0
+    };
+    try {
+      state.terminal = await WebTerminal.mount(document.querySelector("#terminal"), {
+        url: `/ws?instance=${encodeURIComponent(instance.id)}`,
+        renderer: configuration.backend,
+        onStatus: (message, level) => {
+          state.statuses.push({ message, level });
+          if (level === "error") state.errors.push(message);
+        },
+        onStats: stats => {
+          state.peakTextureBytes = Math.max(state.peakTextureBytes, stats.textureBytes);
+          state.peakImageCount = Math.max(state.peakImageCount, stats.imageCount);
+          state.peakAtlasBytes = Math.max(state.peakAtlasBytes, stats.atlasBytes);
+          if (stats.imageCount && stats.imageUploadBytes > state.lastImageUploadBytes) {
+            state.lastImageUploadBytes = stats.imageUploadBytes;
+            if (state.changes.length < 256)
+              state.changes.push({ frame: stats.frames, textureBytes: stats.textureBytes,
+                imageCount: stats.imageCount, imageUploadBytes: stats.imageUploadBytes });
+          }
+        }
+      });
+      state.terminal.requestPrimary();
+      state.terminal.focus();
+      const quote = value => `'${value.replaceAll("'", "'\\''")}'`;
+      state.command = `exec ${quote(configuration.executable)} ${quote(configuration.model)} --fullhd`;
+    } catch (error) {
+      await fetch(`/api/terminals/${instance.id}`, { method: "DELETE" });
+      throw error;
+    }
+  }, configuration);
+  try {
+    await page.waitForFunction(() => window.proteinViewAcceptance.terminal.peer.isPrimary, null, { timeout: 10000 });
+    await page.evaluate(() => {
+      const state = window.proteinViewAcceptance;
+      state.startedAt = Date.now();
+      state.terminal.paste(state.command);
+    });
+    await page.keyboard.press("Enter");
+    const runDeadline = Date.now() + 60000;
+    const remaining = () => Math.max(1, runDeadline - Date.now());
+    await page.waitForFunction(() => {
+      const state = window.proteinViewAcceptance;
+      if (state.errors.length) throw new Error(state.errors.join("; "));
+      return state.terminal.stats.imageCount === 1 && state.terminal.screenText.includes("ProteinView");
+    }, null, { timeout: Math.min(10000, remaining()) });
+    await page.keyboard.press("Space");
+    await page.waitForFunction(() => {
+      const state = window.proteinViewAcceptance;
+      if (state.errors.length) throw new Error(state.errors.join("; "));
+      return state.changes.length >= 50;
+    }, null, { timeout: remaining() });
+    const beforeReset = await page.evaluate(() => window.proteinViewAcceptance.terminal.stats.imageUploadBytes);
+    await page.keyboard.press("Space");
+    await page.keyboard.press("r");
+    await page.waitForFunction(before => window.proteinViewAcceptance.terminal.stats.imageUploadBytes > before,
+      beforeReset, { timeout: Math.min(10000, remaining()) });
+
+    // Read the actual compositor screenshot rather than a renderer-only test canvas.
+    const screenshot = await page.screenshot();
+    const result = await page.evaluate(async png => {
+      const bitmap = await createImageBitmap(new Blob([new Uint8Array(png)], { type: "image/png" }));
+      const canvas = document.createElement("canvas");
+      canvas.width = bitmap.width;
+      canvas.height = bitmap.height;
+      const context = canvas.getContext("2d");
+      context.drawImage(bitmap, 0, 0);
+      bitmap.close();
+      const data = context.getImageData(0, 0, canvas.width, canvas.height).data;
+      const state = window.proteinViewAcceptance;
+      const bounds = state.terminal.element.getBoundingClientRect();
+      const scale = canvas.width / window.innerWidth;
+      let coloredViewportPixels = 0;
+      for (let y = Math.ceil((bounds.top + 60) * scale); y < (bounds.bottom - 60) * scale; y++) {
+        for (let x = Math.ceil((bounds.left + 50) * scale); x < (bounds.right - 50) * scale; x++) {
+          const offset = (y * canvas.width + x) * 4;
+          const r = data[offset], g = data[offset + 1], b = data[offset + 2];
+          if (Math.max(r, g, b) > 70 && Math.max(r, g, b) - Math.min(r, g, b) > 40)
+            coloredViewportPixels++;
+        }
+      }
+      if (coloredViewportPixels < 1000)
+        throw new Error(`Insufficient visible molecular output: ${coloredViewportPixels} colored viewport pixels`);
+      if (state.peakImageCount > 1)
+        throw new Error(`Same-ID rotation retained ${state.peakImageCount} browser images`);
+      if (state.peakTextureBytes > 80 * 24 * 10 * 20 * 4)
+        throw new Error(`Texture ownership exceeded the full logical viewport: ${state.peakTextureBytes}`);
+      return { instanceId: state.instanceId, startedAt: state.startedAt, completedAt: Date.now(), coloredViewportPixels,
+        changingImagePresentationsObserved: state.changes.length,
+        peakTextureBytes: state.peakTextureBytes, peakImageCount: state.peakImageCount,
+        peakAtlasBytes: state.peakAtlasBytes, stats: state.terminal.stats,
+        changes: state.changes, errors: state.errors,
+        note: "Real sample socket/client/worker and unmodified app. Left paused for screenshots/reconnect checks; caller must end the owned terminal." };
+    }, [...screenshot]);
+    return result;
+  } catch (error) {
+    await page.evaluate(async () => {
+      const state = window.proteinViewAcceptance;
+      state.terminal?.dispose();
+      const response = await fetch(`/api/terminals/${state.instanceId}`, { method: "DELETE" });
+      if (!response.ok && response.status !== 404)
+        console.error(`Cleanup failed: ${response.status}`);
+    });
+    throw error;
+  }
+}

--- a/src/Hex1b/Automation/TerminalRegionSvgExtensions.cs
+++ b/src/Hex1b/Automation/TerminalRegionSvgExtensions.cs
@@ -253,6 +253,13 @@ public static class TerminalRegionSvgExtensions
                 .ToList();
             var placeholderImageDefinitions =
                 new Dictionary<uint, (string ElementId, string DataUri)>();
+            var imageFormatData = new Dictionary<uint, byte[]>();
+            byte[] GetImageFormatData(KgpImageData image)
+            {
+                if (!imageFormatData.TryGetValue(image.ImageId, out var data))
+                    imageFormatData.Add(image.ImageId, data = image.CurrentFrameData);
+                return data;
+            }
             foreach (var placement in sortedPlacements)
             {
                 if (placeholderImageDefinitions.ContainsKey(placement.ImageId) ||
@@ -264,7 +271,7 @@ public static class TerminalRegionSvgExtensions
                 }
 
                 var dataUri = EncodeKgpImageToDataUri(
-                    image.CurrentFrameData,
+                    GetImageFormatData(image),
                     image.Width,
                     image.Height,
                     image.CurrentFrameFormat);
@@ -360,7 +367,7 @@ public static class TerminalRegionSvgExtensions
                         var (imgX, imgY, imgWidth, imgHeight) =
                             GetKgpDestinationBounds(placement, imageData, snapshot2, cellWidth, cellHeight);
                         var dataUri = EncodeKgpImageToDataUri(
-                            imageData.CurrentFrameData,
+                            GetImageFormatData(imageData),
                             imageData.Width,
                             imageData.Height,
                             imageData.CurrentFrameFormat,

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -342,7 +342,9 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         _metrics = options.Metrics ?? Diagnostics.Hex1bMetrics.Default;
         var sixelPolicy = options.CreateSixelPolicy();
         var graphicsBudgets = new TerminalGraphicsRetainedBudgetSet(
-            options.Graphics.MaximumRetainedBytesPerScreen);
+            options.Graphics.MaximumRetainedBytesPerScreen,
+            options.Graphics.MaximumRetainedInputBytesPerImage,
+            options.Graphics.MaximumRasterPixelsPerImage);
         _kgpGraphicsState = new KgpTerminalGraphicsState(graphicsBudgets);
         _sixelColorRegisters = new Sixel.SixelColorRegisters(sixelPolicy);
         _sixelGraphicsState = new SixelGraphicsState(
@@ -2825,6 +2827,11 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
 
     internal long GraphicsRetainedByteCount =>
         checked(ActiveKgpImageStore.TotalSize + SixelRetainedByteCount);
+
+    internal long GraphicsReservedDecodedByteCount => ActiveKgpImageStore.ReservedDecodedBytes;
+
+    internal long GraphicsChargedByteCount =>
+        checked(ActiveKgpImageStore.ChargedSize + SixelRetainedByteCount);
 
     internal Diagnostics.Hex1bMetrics DiagnosticsMetrics => _metrics;
 
@@ -7862,7 +7869,10 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             return;
         }
 
-        const int maximumEncodedLength = KgpMaximumEncodedChunkLength;
+        var maximumEncodedLength = pending.Transmission.Compression == KgpParsedCommand.CompressionMode.Zlib
+            ? Math.Min(KgpMaximumEncodedChunkLength,
+                GetMaximumKgpEncodedPayloadLength(ActiveKgpImageStore.RemainingPendingUploadBytes))
+            : KgpMaximumEncodedChunkLength;
         if (!TryDecodeKgpPayload(
                 base64Payload,
                 transmission.MoreData,
@@ -7977,6 +7987,9 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         var maximumEncodedLength = command.Transmission.MoreData
             ? KgpMaximumEncodedChunkLength
             : GetMaximumKgpEncodedPayloadLength();
+        if (command.Transmission.Compression == KgpParsedCommand.CompressionMode.Zlib)
+            maximumEncodedLength = Math.Min(maximumEncodedLength,
+                GetMaximumKgpEncodedPayloadLength(ActiveKgpImageStore.MaximumCompressedUploadBytes));
         if (!TryDecodeKgpPayload(
                 base64Payload,
                 command.Transmission.MoreData,
@@ -7998,7 +8011,9 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             var result = ActiveKgpImageStore.ProcessChunk(
                 command,
                 decodedData,
-                info.ExpectedDataLength);
+                command.Transmission.Compression == KgpParsedCommand.CompressionMode.Zlib
+                    ? ActiveKgpImageStore.MaximumCompressedUploadBytes
+                    : info.ExpectedDataLength);
             switch (result.Status)
             {
                 case KgpImageStore.ChunkStatus.Incomplete:
@@ -8044,6 +8059,9 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         var maximumEncodedLength = transmission.MoreData
             ? KgpMaximumEncodedChunkLength
             : GetMaximumKgpEncodedPayloadLength();
+        if (transmission.Compression == KgpParsedCommand.CompressionMode.Zlib)
+            maximumEncodedLength = Math.Min(maximumEncodedLength,
+                GetMaximumKgpEncodedPayloadLength(ActiveKgpImageStore.MaximumCompressedUploadBytes));
         byte[]? decodedData = null;
         if (!transmission.MoreData)
         {
@@ -8162,7 +8180,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         var message = result.Info.Status ==
             KgpImageStore.AnimationFrameStatus.Success
                 ? "OK"
-                : FormatKgpAnimationFrameError(
+                : result.Error ?? FormatKgpAnimationFrameError(
                     result.Info,
                     decodedData.LongLength);
         SendKgpFrameResponse(
@@ -8179,8 +8197,9 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         out string error)
     {
         maximumBytes = ActiveKgpImageStore.MaximumPendingUploadBytes;
-        if (transmission.Compression != KgpParsedCommand.CompressionMode.None ||
-            !TryGetExpectedKgpDataSize(transmission, out var expectedSize) ||
+        if (transmission.Compression == KgpParsedCommand.CompressionMode.Zlib)
+            return ActiveKgpImageStore.TryGetCompressedUploadLimit(transmission, out maximumBytes, out error);
+        if (!TryGetExpectedKgpDataSize(transmission, out var expectedSize) ||
             expectedSize == 0)
         {
             error = "";
@@ -8211,7 +8230,12 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 nameof(command));
         }
 
-        if (!TryValidateKgpData(transmission, decodedData, out var validationError))
+        KgpImageData? validatedImage = null;
+        var valid = transmission.Compression == KgpParsedCommand.CompressionMode.Zlib
+            ? ActiveKgpImageStore.TryCreateCompressedImage(transmission, decodedData,
+                out validatedImage, out var validationError)
+            : TryValidateKgpData(transmission, decodedData, out validationError);
+        if (!valid)
         {
             SendKgpTransmissionResponse(
                 transmission,
@@ -8221,7 +8245,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             return;
         }
 
-        var stored = ActiveKgpImageStore.StoreImage(transmission, decodedData);
+        var stored = ActiveKgpImageStore.StoreImage(transmission, decodedData, validatedImage);
         if (stored.Relocation is { } relocation)
             ApplyKgpImageRelocation(relocation);
         if (!stored.Stored)
@@ -8427,8 +8451,8 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 => "ENOENT:Image not found",
             KgpImageStore.AnimationFrameStatus.UnsupportedMedium
                 => "EINVAL:Animation frame transmission requires direct data",
-            KgpImageStore.AnimationFrameStatus.UnsupportedCompression
-                => "EINVAL:Animation frame compression is not supported",
+            KgpImageStore.AnimationFrameStatus.InvalidCompressedData
+                => "EINVAL:Invalid or incomplete zlib frame data",
             KgpImageStore.AnimationFrameStatus.UnsupportedFormat
                 => "EINVAL:Animation frames require RGB or RGBA data",
             KgpImageStore.AnimationFrameStatus.UnsupportedBaseFormat
@@ -8460,6 +8484,26 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         KgpParsedCommand.QuietMode quiet,
         string base64Payload)
     {
+        if (command.Compression == KgpParsedCommand.CompressionMode.Zlib)
+        {
+            var maximumLength = GetMaximumKgpEncodedPayloadLength(ActiveKgpImageStore.MaximumCompressedUploadBytes);
+            if (!ActiveKgpImageStore.TryGetCompressedUploadLimit(command, out _, out var error))
+            {
+                SendKgpResponse(command.ImageId, command.ImageNumber, error, (int)quiet);
+                return;
+            }
+            if (!TryDecodeKgpPayload(base64Payload, command.MoreData, maximumLength,
+                    out var compressed, out var payloadError))
+            {
+                SendKgpResponse(command.ImageId, command.ImageNumber,
+                    FormatKgpPayloadError(payloadError, maximumLength), (int)quiet);
+                return;
+            }
+            var valid = ActiveKgpImageStore.TryCreateCompressedImage(command, compressed, out _, out error);
+            SendKgpResponse(command.ImageId, command.ImageNumber, valid ? "OK" : error, (int)quiet);
+            return;
+        }
+
         var decodedData = DecodeKgpPayload(base64Payload);
 
         if (TryGetExpectedKgpDataSize(command, out var expectedSize) &&
@@ -8955,8 +8999,10 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
     }
 
     private int GetMaximumKgpEncodedPayloadLength()
+        => GetMaximumKgpEncodedPayloadLength(ActiveKgpImageStore.MaximumPendingUploadBytes);
+
+    private static int GetMaximumKgpEncodedPayloadLength(long maximumDecodedLength)
     {
-        var maximumDecodedLength = ActiveKgpImageStore.MaximumPendingUploadBytes;
         var maximumEncodedLength = (maximumDecodedLength + 2) / 3 * 4;
         return checked((int)Math.Min(maximumEncodedLength, int.MaxValue));
     }

--- a/src/Hex1b/Hex1bTerminalGraphicsOptions.cs
+++ b/src/Hex1b/Hex1bTerminalGraphicsOptions.cs
@@ -41,6 +41,9 @@ public sealed class Hex1bTerminalGraphicsOptions
     /// Framing may continue after this limit is reached so the terminal can
     /// recover at the protocol terminator. This limit is separate from decoded
     /// raster work and aggregate retained-memory budgets.
+    /// For zlib-compressed KGP uploads this bounds Base64-decoded compressed
+    /// input, including uninterpreted bytes after the first complete zlib member.
+    /// Legacy uncompressed KGP admission is unchanged.
     /// </remarks>
     public int MaximumRetainedInputBytesPerImage { get; set; } = 1024 * 1024;
 
@@ -48,6 +51,7 @@ public sealed class Hex1bTerminalGraphicsOptions
     /// Gets or sets the maximum logical pixel area rasterized for one graphic.
     /// The default is 16,777,216 pixels.
     /// </summary>
+    /// <remarks>Also bounds the dimensions of zlib-compressed KGP images.</remarks>
     public long MaximumRasterPixelsPerImage { get; set; } = 16L * 1024 * 1024;
 
     /// <summary>
@@ -92,6 +96,10 @@ public sealed class Hex1bTerminalGraphicsOptions
     /// <remarks>
     /// The main and alternate screens each receive one shared budget across all
     /// graphics protocols. KGP counts encoded image and animation-frame bytes.
+    /// A zlib-backed static KGP image also reserves its validated decoded-format
+    /// length, without retaining a decoded array. Materialized animation frames
+    /// count actual bytes only. This reservation bounds live admission, not
+    /// caller-owned arrays returned by <see cref="KgpImageData.Data"/> or old snapshots.
     /// Sixel counts each distinct image once, including retained payload, parsed
     /// metadata, sparse raster tiles, and a cached dense pixel buffer. Each
     /// protocol applies its established oldest-first eviction order to its own

--- a/src/Hex1b/Hmp1/Hmp1KgpStateReplay.cs
+++ b/src/Hex1b/Hmp1/Hmp1KgpStateReplay.cs
@@ -38,7 +38,8 @@ internal static class Hmp1KgpStateReplay
         foreach (var image in images.Values.OrderBy(image => image.ImageNumber > 0)
             .ThenBy(image => image.ImageNumber == 0 ? image.ImageId : 0))
         {
-            await AppendPixelsAsync(image, image.Data, image.Format, animationGap: null).ConfigureAwait(false);
+            await AppendPixelsAsync(image, image.IsZlibCompressed ? image.EncodedData : image.Data,
+                image.Format, animationGap: null, compressed: image.IsZlibCompressed).ConfigureAwait(false);
             KgpAnimationPlaybackSnapshot? playback = null;
             if (image.AnimationState is { } animation)
             {
@@ -127,7 +128,8 @@ internal static class Hmp1KgpStateReplay
         }
 
         async ValueTask AppendPixelsAsync(
-            KgpImageData image, byte[] data, KgpFormat format, int? animationGap)
+            KgpImageData image, ReadOnlyMemory<byte> data, KgpFormat format, int? animationGap,
+            bool compressed = false)
         {
             var action = animationGap.HasValue ? 'f' : 't';
             var offset = 0;
@@ -138,12 +140,14 @@ internal static class Hmp1KgpStateReplay
                 var isLast = offset + count >= data.Length;
                 var payload = count == 0
                     ? string.Empty
-                    : Convert.ToBase64String(data, offset, count);
+                    : Convert.ToBase64String(data.Span.Slice(offset, count));
                 string controls;
                 if (first)
                 {
                     controls = FormattableString.Invariant(
                         $"a={action},f={(int)format},s={image.Width},v={image.Height},{BuildImageIdentity(image)},t=d,q=2");
+                    if (compressed)
+                        controls += ",o=z";
                     if (animationGap is { } gap)
                         controls += FormattableString.Invariant($",X=1,z={(gap == 0 ? -1 : gap)}");
                     if (!isLast)

--- a/src/Hex1b/Hmp1/Hmp1PresentationAdapter.cs
+++ b/src/Hex1b/Hmp1/Hmp1PresentationAdapter.cs
@@ -73,7 +73,7 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
             new BoundedChannelOptions(1000)
             {
                 FullMode = BoundedChannelFullMode.DropOldest,
-                SingleReader = true,
+                SingleReader = false,
                 SingleWriter = false
             });
     }
@@ -777,6 +777,7 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
         {
             snapshot = [.. _sessions];
             _sessions.Clear();
+            _terminal = null;
         }
 
         foreach (var session in snapshot)
@@ -785,7 +786,16 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
         }
 
         _inputChannel.Writer.TryComplete();
-        Disconnected?.Invoke();
+        while (_inputChannel.Reader.TryRead(out _)) { }
+        try
+        {
+            Disconnected?.Invoke();
+        }
+        finally
+        {
+            Disconnected = null;
+            Resized = null;
+        }
     }
 
     /// <summary>
@@ -799,22 +809,25 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
     {
         try
         {
-            await foreach (var work in session.OutputChannel.Reader.ReadAllAsync(session.Cts.Token)
-                .ConfigureAwait(false))
+            while (await session.OutputChannel.Reader.WaitToReadAsync(session.Cts.Token).ConfigureAwait(false))
             {
-                if (work.ControlWriter is { } writer)
+                while (session.OutputChannel.Reader.TryRead(out var work))
                 {
-                    await writer(session.Stream).ConfigureAwait(false);
-                }
-                else if (!work.Output.IsEmpty)
-                {
-                    await Hmp1Protocol.WriteFrameAsync(
-                        session.Stream, Hmp1FrameType.Output, work.Output, session.Cts.Token).ConfigureAwait(false);
-                }
-                // Flush periodically (after draining available items)
-                if (session.OutputChannel.Reader.Count == 0)
-                {
-                    await session.Stream.FlushAsync(session.Cts.Token).ConfigureAwait(false);
+                    try
+                    {
+                        session.Cts.Token.ThrowIfCancellationRequested();
+                        if (work.ControlWriter is not null)
+                            await work.ControlWriter(session.Stream).ConfigureAwait(false);
+                        else if (!work.Output.IsEmpty)
+                            await Hmp1Protocol.WriteFrameAsync(
+                                session.Stream, Hmp1FrameType.Output, work.Output, session.Cts.Token).ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        work = default;
+                    }
+                    if (session.OutputChannel.Reader.Count == 0)
+                        await session.Stream.FlushAsync(session.Cts.Token).ConfigureAwait(false);
                 }
             }
         }
@@ -1124,6 +1137,9 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
         if (session.BrowserView is { } view)
             await view.DisposeAsync().ConfigureAwait(false);
         session.OutputChannel.Writer.TryComplete();
+        // Completion/cancellation does not discard buffered output or replay
+        // delegates, which can own an entire graphics snapshot.
+        while (session.OutputChannel.Reader.TryRead(out _)) { }
 
         try
         {
@@ -1193,7 +1209,7 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
             OutputChannel = Channel.CreateBounded<Hmp1OutboundWork>(new BoundedChannelOptions(1000)
             {
                 FullMode = BoundedChannelFullMode.Wait,
-                SingleReader = true,
+                SingleReader = false,
                 SingleWriter = false
             });
         }

--- a/src/Hex1b/Hmp1/Hmp1WorkloadAdapter.cs
+++ b/src/Hex1b/Hmp1/Hmp1WorkloadAdapter.cs
@@ -104,7 +104,7 @@ public sealed class Hmp1WorkloadAdapter : IHex1bTerminalWorkloadAdapter, IHmp1Co
             new BoundedChannelOptions(1000)
             {
                 FullMode = BoundedChannelFullMode.Wait,
-                SingleReader = true,
+                SingleReader = false,
                 SingleWriter = true
             });
 
@@ -277,6 +277,7 @@ public sealed class Hmp1WorkloadAdapter : IHex1bTerminalWorkloadAdapter, IHmp1Co
         {
             _initialHandshake.TrySetResult(error);
             _outputChannel.Writer.TryComplete();
+            while (_outputChannel.Reader.TryRead(out _)) { }
             _disconnectedTcs.TrySetResult();
             throw;
         }
@@ -792,6 +793,9 @@ public sealed class Hmp1WorkloadAdapter : IHex1bTerminalWorkloadAdapter, IHmp1Co
         }
 
         _outputChannel.Writer.TryComplete();
+        // Ordinary EOF leaves the final output available to the terminal. Explicit
+        // disposal ends that contract and must release unread replay/pixel payloads.
+        while (_outputChannel.Reader.TryRead(out _)) { }
     }
 }
 

--- a/src/Hex1b/Hwt1/Hwt1PresentationAdapter.cs
+++ b/src/Hex1b/Hwt1/Hwt1PresentationAdapter.cs
@@ -55,6 +55,7 @@ public sealed class Hwt1PresentationAdapter :
     private readonly Channel<bool> _dirty = Channel.CreateBounded<bool>(
         new BoundedChannelOptions(1) { FullMode = BoundedChannelFullMode.DropWrite });
     private readonly Hwt1RenderProjection _projection = new();
+    private readonly object _projectionLock = new();
     private readonly object _ackLock = new();
     private readonly CancellationTokenSource _disposedCancellation = new();
     private readonly TimeProvider _timeProvider;
@@ -237,9 +238,14 @@ public sealed class Hwt1PresentationAdapter :
             }
             using var capturedSnapshot = snapshot;
             var snapshotMs = Stopwatch.GetElapsedTime(snapshotStarted).TotalMilliseconds;
-            var bytes = _projection.Encode(snapshot, Capabilities, terminal.OutputBytesRead,
-                Interlocked.Read(ref _outputBatches), Stopwatch.GetElapsedTime(_started).TotalMilliseconds,
-                Interlocked.Exchange(ref _forceFull, 0) != 0, snapshotMs, peer, history);
+            byte[] bytes;
+            lock (_projectionLock)
+            {
+                linked.Token.ThrowIfCancellationRequested();
+                bytes = _projection.Encode(snapshot, Capabilities, terminal.OutputBytesRead,
+                    Interlocked.Read(ref _outputBatches), Stopwatch.GetElapsedTime(_started).TotalMilliseconds,
+                    Interlocked.Exchange(ref _forceFull, 0) != 0, snapshotMs, peer, history);
+            }
             lock (_ackLock)
             {
                 _awaitedRevision = _projection.Revision;
@@ -457,13 +463,33 @@ public sealed class Hwt1PresentationAdapter :
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
             return;
         if (_terminal is { } terminal)
+        {
+            _width = terminal.Width;
+            _height = terminal.Height;
             terminal.PresentationInvalidated -= InvalidatePresentation;
+        }
         _disposedCancellation.Cancel();
         _dirty.Writer.TryComplete();
-        Disconnected?.Invoke();
-        if (_muxer is not null)
-            await _muxer.RemoveSessionAsync(_session!).ConfigureAwait(false);
-        _disposedCancellation.Dispose();
+        lock (_projectionLock)
+            _projection.Clear();
+        var muxer = _muxer;
+        var session = _session;
+        _terminal = null;
+        _hmp1OutputSource = null;
+        _muxer = null;
+        _session = null;
+        try
+        {
+            Disconnected?.Invoke();
+        }
+        finally
+        {
+            Disconnected = null;
+            Resized = null;
+            if (muxer is not null)
+                await muxer.RemoveSessionAsync(session!).ConfigureAwait(false);
+            _disposedCancellation.Dispose();
+        }
     }
 
     private static int ReadBounded(JsonElement command, string name, int min, int max)

--- a/src/Hex1b/Hwt1/Hwt1RenderProjection.cs
+++ b/src/Hex1b/Hwt1/Hwt1RenderProjection.cs
@@ -13,13 +13,24 @@ internal sealed class Hwt1RenderProjection
 {
     internal const uint Magic = 0x31545748;
     internal const int MaxImageCount = 4096;
+    private const long MaxImageBytes = 32 * 1024 * 1024;
     private const long ImageBudget = 64 * 1024 * 1024;
-    private readonly Dictionary<string, (Hwt1RenderImage Image, uint LastUsed)> _images = [];
+    private readonly Dictionary<string, (Hwt1RenderImage Image, uint LastUsed, long BudgetBytes)> _images = [];
     private readonly ConditionalWeakTable<byte[], ImageIdentity> _identities = new();
     private Hwt1RenderCell[] _previous = [];
     private int _columns;
     private int _rows;
     public uint Revision { get; private set; }
+    internal int KgpMaterializationCount { get; private set; }
+    internal int RetainedImageCount => _images.Count;
+    internal long RetainedImageBytes => _images.Values.Sum(entry => (long)entry.Image.Bytes.Length);
+
+    internal void Clear()
+    {
+        _images.Clear();
+        _identities.Clear();
+        _previous = [];
+    }
 
     public byte[] Encode(Hex1bTerminalSnapshot snapshot, TerminalCapabilities capabilities,
         long workloadBytes, long outputBatches, double elapsedMs, bool forceFull = false,
@@ -32,9 +43,7 @@ internal sealed class Hwt1RenderProjection
         var started = Stopwatch.GetTimestamp();
         var full = forceFull || _previous.Length == 0 || _columns != snapshot.Width || _rows != snapshot.Height;
         var plannedImages = PreflightImages(snapshot, out var sixelKeys);
-        if (full)
-            _images.Clear();
-        TrimImages(plannedImages);
+        TrimImages(plannedImages, full);
         var baseRevision = full ? 0 : Revision;
         Revision = checked(Revision + 1);
         _columns = snapshot.Width;
@@ -80,7 +89,7 @@ internal sealed class Hwt1RenderProjection
             if (!snapshot.KgpImages.TryGetValue(p.ImageId, out var image))
                 throw new InvalidDataException("Snapshot placement references a missing KGP image.");
             var resource = ProjectKgpImage(image);
-            Retain(resource, active, newImages, full);
+            Retain(resource, active, newImages, full, plannedImages[resource.Key]);
             var sx = (double)p.SourceX;
             var sy = (double)p.SourceY;
             var sw = p.SourceWidth == 0 ? resource.Width - sx : Math.Min(p.SourceWidth, resource.Width - sx);
@@ -154,7 +163,7 @@ internal sealed class Hwt1RenderProjection
                 }
                 resource = new(key, pixels.Width, pixels.Height, "rgba", rgba);
             }
-            Retain(resource, active, newImages, full);
+            Retain(resource, active, newImages, full, plannedImages[resource.Key]);
             var px = p.PaintedLeft * cw;
             var py = p.PaintedTop * ch;
             var width = resource.Width * cw / p.Image.CellMetrics.SafeWidth;
@@ -241,24 +250,36 @@ internal sealed class Hwt1RenderProjection
 
     private Hwt1RenderImage ProjectKgpImage(KgpImageData image, bool dimensionsOnly = false)
     {
-        var data = image.CurrentFrameData;
-        var identity = _identities.GetValue(data, bytes => new(Convert.ToHexString(SHA256.HashData(bytes))));
+        // Validated compressed roots already carry their format-byte identity and
+        // dimensions. Do not inflate them during preflight or cache lookups.
+        byte[]? data = null;
+        var hash = image.CurrentFrameDataHash;
+        if (hash is null)
+        {
+            data = image.CurrentFrameData;
+            hash = _identities.GetValue(data, bytes => new(Convert.ToHexString(SHA256.HashData(bytes)))).Hash;
+        }
         var format = image.CurrentFrameFormat;
         var width = checked((int)image.Width);
         var height = checked((int)image.Height);
         if (format == KgpFormat.Png && (width == 0 || height == 0))
         {
-            if (data.Length < 24 || !data.AsSpan(0, 8).SequenceEqual(new byte[] { 137, 80, 78, 71, 13, 10, 26, 10 }))
+            if (data is null || data.Length < 24 || !data.AsSpan(0, 8).SequenceEqual(new byte[] { 137, 80, 78, 71, 13, 10, 26, 10 }))
                 throw new InvalidDataException("KGP PNG does not contain an IHDR.");
             width = BinaryPrimitives.ReadInt32BigEndian(data.AsSpan(16, 4));
             height = BinaryPrimitives.ReadInt32BigEndian(data.AsSpan(20, 4));
         }
         EnsureImageSize(width, height);
-        var key = $"k:{identity.Hash}:{width}:{height}:{format}";
+        var key = $"k:{hash}:{width}:{height}:{format}";
         if (dimensionsOnly)
             return new(key, width, height, format == KgpFormat.Png ? "png" : "rgba", []);
         if (_images.TryGetValue(key, out var cached))
             return cached.Image;
+        if (data is null)
+        {
+            data = image.CurrentFrameData;
+            KgpMaterializationCount++;
+        }
         if (format == KgpFormat.Png)
             return new(key, width, height, "png", data);
         var pixelCount = checked(width * height);
@@ -283,17 +304,18 @@ internal sealed class Hwt1RenderProjection
 
     private static void EnsureImageSize(int width, int height)
     {
-        if (width <= 0 || height <= 0 || width > 4096 || height > 4096 || (long)width * height * 4 > 32 * 1024 * 1024)
+        if (width <= 0 || height <= 0 || width > 4096 || height > 4096 || (long)width * height * 4 > MaxImageBytes)
             throw new InvalidDataException("Image exceeds the HWT1 limit (4096 per axis, 32 MiB decoded).");
     }
 
-    private void Retain(Hwt1RenderImage resource, HashSet<string> active, List<Hwt1RenderImage> added, bool full)
+    private void Retain(Hwt1RenderImage resource, HashSet<string> active, List<Hwt1RenderImage> added, bool full,
+        long budgetBytes)
     {
         if (!active.Add(resource.Key))
             return;
         if (full || !_images.ContainsKey(resource.Key))
             added.Add(resource);
-        _images[resource.Key] = (resource, Revision);
+        _images[resource.Key] = (resource, Revision, budgetBytes);
     }
 
     private Dictionary<string, long> PreflightImages(
@@ -306,8 +328,12 @@ internal sealed class Hwt1RenderProjection
         {
             if (!snapshot.KgpImages.TryGetValue(placement.ImageId, out var image))
                 throw new InvalidDataException("Snapshot placement references a missing KGP image.");
+            var payloadBytes = image.IsZlibCompressed && image.CurrentFrameFormat == KgpFormat.Png
+                ? image.ReservedDecodedBytes : 0;
+            if (payloadBytes > MaxImageBytes)
+                throw new InvalidDataException("Image exceeds the HWT1 32 MiB PNG payload limit.");
             var resource = ProjectKgpImage(image, dimensionsOnly: true);
-            Reserve(resource.Key, resource.Width, resource.Height);
+            Reserve(resource.Key, resource.Width, resource.Height, payloadBytes);
         }
         foreach (var placement in snapshot.SixelPlacements)
         {
@@ -325,15 +351,20 @@ internal sealed class Hwt1RenderProjection
         }
         return planned;
 
-        void Reserve(string key, int width, int height)
+        void Reserve(string key, int width, int height, long payloadBytes = 0)
         {
             EnsureImageSize(width, height);
-            var size = (long)width * height * 4;
-            if (!planned.TryAdd(key, size))
+            // Compressed PNG format bytes can dwarf their raster (for example,
+            // ancillary metadata). Bound both payload retention and texture cost.
+            var size = Math.Max((long)width * height * 4, payloadBytes);
+            if (_images.TryGetValue(key, out var cached))
+                size = Math.Max(size, cached.BudgetBytes);
+            if (planned.TryGetValue(key, out var previous) && previous >= size)
                 return;
-            bytes += size;
+            planned[key] = size;
+            bytes += size - previous;
             if (bytes > ImageBudget)
-                throw new InvalidDataException("Visible graphics exceed the HWT1 64 MiB decoded-image budget.");
+                throw new InvalidDataException("Visible graphics exceed the HWT1 64 MiB image-resource budget.");
             if (planned.Count > MaxImageCount)
                 throw new InvalidDataException($"Visible graphics exceed the HWT1 {MaxImageCount}-image resource limit.");
         }
@@ -351,17 +382,24 @@ internal sealed class Hwt1RenderProjection
         return "s:" + Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(identity.ToString())));
     }
 
-    private void TrimImages(Dictionary<string, long> planned)
+    private void TrimImages(Dictionary<string, long> planned, bool full)
     {
+        // KGP uploads replace image generations, often on every animation frame.
+        // Retaining obsolete hashes also keeps the browser's corresponding GPU
+        // resources alive. Shared hashes remain while any current placement uses them.
+        foreach (var key in _images.Keys.Where(key => key.StartsWith("k:", StringComparison.Ordinal) &&
+                     !planned.ContainsKey(key)).ToArray())
+            _images.Remove(key);
+
         // Reserve the complete next frame and evict inactive entries before allocating replacements.
         var inactive = _images.Where(p => !planned.ContainsKey(p.Key)).OrderBy(p => p.Value.LastUsed).ToArray();
-        var bytes = planned.Values.Sum() + inactive.Sum(p => (long)p.Value.Image.Width * p.Value.Image.Height * 4);
+        var bytes = planned.Values.Sum() + inactive.Sum(p => p.Value.BudgetBytes);
         var count = planned.Count + inactive.Length;
         foreach (var entry in inactive)
         {
-            if (bytes <= ImageBudget && count <= MaxImageCount)
+            if (!full && bytes <= ImageBudget && count <= MaxImageCount)
                 break;
-            bytes -= (long)entry.Value.Image.Width * entry.Value.Image.Height * 4;
+            bytes -= entry.Value.BudgetBytes;
             count--;
             _images.Remove(entry.Key);
         }

--- a/src/Hex1b/Kgp/KgpImageData.cs
+++ b/src/Hex1b/Kgp/KgpImageData.cs
@@ -9,6 +9,11 @@ namespace Hex1b;
 public sealed class KgpImageData
 {
     private readonly KgpAnimationState? _animation;
+    private readonly byte[] _data;
+    private readonly byte[]? _encodedData;
+    private readonly int _decodedLength;
+    private readonly string? _formatDataHash;
+    private long _materializationCount;
 
     /// <summary>
     /// The image ID assigned by the client or allocated by the terminal.
@@ -21,13 +26,27 @@ public sealed class KgpImageData
     public uint ImageNumber { get; }
 
     /// <summary>
-    /// The decoded pixel data for the root frame.
+    /// The root-frame data in <see cref="Format"/> representation, including PNG bytes.
     /// </summary>
     /// <remarks>
     /// When animation frame operations materialize an image, the root frame is
     /// stored as RGBA data even if the image was originally transmitted as RGB.
+    /// For zlib-backed images each access decompresses into a fresh caller-owned
+    /// array; read this property once per operation. These arrays and the image
+    /// remain usable after live-image eviction or snapshot disposal. Other images
+    /// retain their existing shared-array behavior.
     /// </remarks>
-    public byte[] Data { get; }
+    public byte[] Data
+    {
+        get
+        {
+            if (_encodedData is null)
+                return _data;
+            var data = KgpZlibData.Materialize(_encodedData, _decodedLength);
+            Interlocked.Increment(ref _materializationCount);
+            return data;
+        }
+    }
 
     /// <summary>
     /// Image width in pixels.
@@ -82,17 +101,42 @@ public sealed class KgpImageData
         uint height,
         KgpFormat format,
         byte[] contentHash,
-        KgpAnimationState? animation = null)
+        KgpAnimationState? animation = null,
+        byte[]? encodedData = null,
+        int decodedLength = 0,
+        string? formatDataHash = null)
     {
         ImageId = imageId;
         ImageNumber = imageNumber;
-        Data = data;
+        _data = data;
         Width = width;
         Height = height;
         Format = format;
         ContentHash = contentHash;
         _animation = animation;
+        _encodedData = encodedData;
+        _decodedLength = decodedLength;
+        _formatDataHash = formatDataHash;
     }
+
+    internal static KgpImageData CreateCompressed(
+        uint imageId,
+        uint imageNumber,
+        byte[] encodedData,
+        KgpFormat format,
+        KgpZlibData.Validation validation)
+        => new(imageId, imageNumber, [], validation.Width, validation.Height,
+            format, validation.Hash, encodedData: encodedData,
+            decodedLength: validation.Length,
+            formatDataHash: Convert.ToHexString(validation.Hash));
+
+    internal bool IsZlibCompressed => _encodedData is not null;
+    internal ReadOnlyMemory<byte> EncodedData => _encodedData ?? ReadOnlyMemory<byte>.Empty;
+    internal string? CurrentFrameDataHash => _formatDataHash;
+    internal long ReservedDecodedBytes => _encodedData is null ? 0 : _decodedLength;
+    internal long ChargedSize => checked(StorageSize + ReservedDecodedBytes);
+    internal long MaterializationCount => Interlocked.Read(ref _materializationCount);
+    internal long MaterializedBytes => checked(MaterializationCount * _decodedLength);
 
     /// <summary>
     /// Validates that the data size matches the expected size for the given format and dimensions.
@@ -100,11 +144,11 @@ public sealed class KgpImageData
     public bool IsDataSizeValid()
     {
         if (Format == KgpFormat.Png)
-            return Data.Length > 0;
+            return (_encodedData is null ? _data.Length : _decodedLength) > 0;
 
         var bytesPerPixel = Format == KgpFormat.Rgb24 ? 3 : 4;
         var expectedSize = (long)Width * Height * bytesPerPixel;
-        return Data.Length == expectedSize;
+        return (_encodedData is null ? _data.Length : _decodedLength) == expectedSize;
     }
 
     /// <summary>
@@ -118,7 +162,7 @@ public sealed class KgpImageData
 
     internal int CurrentFrameNumber => CurrentFrameIndex + 1;
 
-    internal long StorageSize => _animation?.StorageSize ?? Data.LongLength;
+    internal long StorageSize => _animation?.StorageSize ?? (_encodedData ?? _data).LongLength;
 
     internal IReadOnlyList<KgpAnimationFrame>? AnimationFrames
         => _animation?.Frames;
@@ -164,7 +208,7 @@ public sealed class KgpImageData
     {
         ArgumentNullException.ThrowIfNull(animation);
         var root = animation.GetFrame(0);
-        var contentHash = ReferenceEquals(root.Data, Data) &&
+        var contentHash = ReferenceEquals(root.Data, _data) &&
             Format == root.Format
                 ? ContentHash
                 : SHA256.HashData(root.Data);
@@ -183,10 +227,13 @@ public sealed class KgpImageData
         => new(
             imageId,
             ImageNumber,
-            Data,
+            _data,
             Width,
             Height,
             Format,
             ContentHash,
-            _animation);
+            _animation,
+            _encodedData,
+            _decodedLength,
+            _formatDataHash);
 }

--- a/src/Hex1b/Kgp/KgpImageStore.cs
+++ b/src/Hex1b/Kgp/KgpImageStore.cs
@@ -55,7 +55,7 @@ public sealed class KgpImageStore
         InvalidIdentity,
         ImageNotFound,
         UnsupportedMedium,
-        UnsupportedCompression,
+        InvalidCompressedData,
         UnsupportedFormat,
         UnsupportedBaseFormat,
         InvalidBaseData,
@@ -80,7 +80,8 @@ public sealed class KgpImageStore
 
     internal readonly record struct AnimationFrameResult(
         AnimationFrameInfo Info,
-        KgpImageData? Image);
+        KgpImageData? Image,
+        string? Error = null);
 
     internal enum AnimationFrameDeleteStatus
     {
@@ -122,6 +123,7 @@ public sealed class KgpImageStore
     private readonly HashSet<uint> _unaddressableImageIds = new();
     private uint _nextId = 1;
     private long _totalSize;
+    private long _reservedDecodedBytes;
     private readonly long _quotaBytes;
     private readonly TerminalGraphicsRetainedBudget? _sharedBudget;
 
@@ -189,6 +191,78 @@ public sealed class KgpImageStore
         get { lock (_lock) return _totalSize; }
     }
 
+    internal long ReservedDecodedBytes
+    {
+        get { lock (_lock) return _reservedDecodedBytes; }
+    }
+
+    internal long ChargedSize
+    {
+        get { lock (_lock) return checked(_totalSize + _reservedDecodedBytes); }
+    }
+
+    private long ChargedSizeUnsafe => checked(_totalSize + _reservedDecodedBytes);
+
+    internal long MaximumCompressedUploadBytes =>
+        Math.Min(MaximumPendingUploadBytes, _sharedBudget?.MaximumInputBytes ?? 1024 * 1024);
+
+    private long MaximumCompressedRasterPixels =>
+        _sharedBudget?.MaximumRasterPixels ?? 16L * 1024 * 1024;
+
+    internal bool TryGetCompressedUploadLimit(
+        KgpParsedCommand.TransmissionData transmission,
+        out long maximumBytes,
+        out string error)
+    {
+        maximumBytes = MaximumCompressedUploadBytes;
+        error = "";
+        if (transmission.Format is not (KgpFormat.Rgb24 or KgpFormat.Rgba32 or KgpFormat.Png) ||
+            transmission.Medium != KgpTransmissionMedium.Direct)
+        {
+            error = "EINVAL:Compressed images require direct RGB, RGBA or PNG data";
+            return false;
+        }
+        if (transmission.Format == KgpFormat.Png)
+            return true;
+        if (!KgpZlibData.ValidDimensions(transmission.Width, transmission.Height, MaximumCompressedRasterPixels))
+        {
+            error = "EFBIG:Image dimensions exceed the raster limit";
+            return false;
+        }
+        var length = checked((long)transmission.Width * transmission.Height *
+            (transmission.Format == KgpFormat.Rgb24 ? 3 : 4));
+        if (length > Array.MaxLength || length > EffectiveQuotaBytes)
+        {
+            error = "ENOSPC:Decoded image exceeds storage capacity";
+            return false;
+        }
+        return true;
+    }
+
+    internal bool TryCreateCompressedImage(
+        KgpParsedCommand.TransmissionData transmission,
+        byte[] data,
+        out KgpImageData? image,
+        out string error)
+    {
+        image = null;
+        if (!TryGetCompressedUploadLimit(transmission, out var maximumBytes, out error))
+            return false;
+        if (data.LongLength > maximumBytes)
+        {
+            error = "EFBIG:Compressed image input exceeds upload limit";
+            return false;
+        }
+        if (!KgpZlibData.TryValidate(data, transmission.Format,
+                transmission.Width, transmission.Height, MaximumCompressedRasterPixels,
+                EffectiveQuotaBytes - data.LongLength, out var validation, out error))
+            return false;
+
+        image = KgpImageData.CreateCompressed(transmission.ImageId, transmission.ImageNumber,
+            data, transmission.Format, validation);
+        return true;
+    }
+
     /// <summary>
     /// Whether a chunked transfer is in progress.
     /// </summary>
@@ -199,6 +273,21 @@ public sealed class KgpImageStore
 
     internal long MaximumPendingUploadBytes
         => Math.Min(Math.Max(0, EffectiveQuotaBytes), Array.MaxLength);
+
+    internal long PendingUploadBytes
+    {
+        get { lock (_lock) return _pendingUpload?.Length ?? 0; }
+    }
+
+    internal long PendingUploadCapacity
+    {
+        get { lock (_lock) return _pendingUpload?.Capacity ?? 0; }
+    }
+
+    internal long RemainingPendingUploadBytes
+    {
+        get { lock (_lock) return _pendingUpload is { } pending ? pending.MaximumBytes - pending.Length : 0; }
+    }
 
     /// <summary>
     /// Allocates a currently unused, non-zero image ID.
@@ -231,11 +320,12 @@ public sealed class KgpImageStore
 
     internal StoreResult StoreImage(
         KgpParsedCommand.TransmissionData transmission,
-        byte[] data)
+        byte[] data,
+        KgpImageData? validatedImage = null)
     {
         lock (_lock)
         {
-            return StoreTransmissionUnsafe(transmission, data);
+            return StoreTransmissionUnsafe(transmission, data, validatedImage);
         }
     }
 
@@ -442,32 +532,58 @@ public sealed class KgpImageStore
             if (info.Status != AnimationFrameStatus.Success)
                 return new AnimationFrameResult(info, Image: null);
 
-            if (data.Length < info.ExpectedDataLength)
+            if (command.Transmission.Compression == KgpParsedCommand.CompressionMode.None &&
+                data.Length != info.ExpectedDataLength)
             {
                 return new AnimationFrameResult(
-                    info with { Status = AnimationFrameStatus.InsufficientData },
-                    Image: null);
-            }
-
-            if (data.Length > info.ExpectedDataLength)
-            {
-                return new AnimationFrameResult(
-                    info with { Status = AnimationFrameStatus.TooMuchData },
-                    Image: null);
-            }
-
-            if (info.RequiredStorageBytes > 0 &&
-                WouldExceedQuota(
-                    _totalSize,
-                    info.RequiredStorageBytes,
-                    EffectiveQuotaBytes))
-            {
-                return new AnimationFrameResult(
-                    info with { Status = AnimationFrameStatus.NoSpace },
+                    info with
+                    {
+                        Status = data.Length < info.ExpectedDataLength
+                            ? AnimationFrameStatus.InsufficientData
+                            : AnimationFrameStatus.TooMuchData,
+                    },
                     Image: null);
             }
 
             var image = _imagesById[info.ImageId];
+            var quotaDelta = checked(info.RequiredStorageBytes - image.ReservedDecodedBytes);
+            if (quotaDelta > 0 &&
+                WouldExceedQuota(ChargedSizeUnsafe, quotaDelta, EffectiveQuotaBytes))
+            {
+                return new AnimationFrameResult(
+                    info with { Status = AnimationFrameStatus.NoSpace }, Image: null);
+            }
+
+            if (command.Transmission.Compression == KgpParsedCommand.CompressionMode.Zlib)
+            {
+                if (data.LongLength > MaximumCompressedUploadBytes)
+                    return new AnimationFrameResult(
+                        info with { Status = AnimationFrameStatus.TooMuchData }, Image: null,
+                        Error: "EFBIG:Compressed frame input exceeds upload limit");
+                if (!KgpZlibData.TryValidate(data, command.Transmission.Format,
+                        info.SourceWidth, info.SourceHeight, MaximumCompressedRasterPixels,
+                        info.ExpectedDataLength, out var validation, out var error))
+                {
+                    var status = error.StartsWith("ENODATA:", StringComparison.Ordinal)
+                        ? AnimationFrameStatus.InsufficientData
+                        : error.StartsWith("EFBIG:", StringComparison.Ordinal)
+                            ? AnimationFrameStatus.TooMuchData
+                            : error.StartsWith("ENOMEM:", StringComparison.Ordinal)
+                                ? AnimationFrameStatus.OutOfMemory
+                                : AnimationFrameStatus.InvalidCompressedData;
+                    return new AnimationFrameResult(info with { Status = status }, Image: null, Error: error);
+                }
+                try
+                {
+                    data = KgpZlibData.Materialize(data, validation.Length);
+                }
+                catch (OutOfMemoryException)
+                {
+                    return new AnimationFrameResult(
+                        info with { Status = AnimationFrameStatus.OutOfMemory }, Image: null);
+                }
+            }
+
             try
             {
                 var animation = CreateNormalizedAnimation(image);
@@ -535,8 +651,9 @@ public sealed class KgpImageStore
                         "KGP animation frame storage accounting changed during a locked transaction.");
                 }
 
+                SetSizesUnsafe(checked(_totalSize + storageDelta),
+                    checked(_reservedDecodedBytes - image.ReservedDecodedBytes));
                 _imagesById[image.ImageId] = updatedImage;
-                SetTotalSizeUnsafe(checked(_totalSize + storageDelta));
                 return new AnimationFrameResult(info, updatedImage);
             }
             catch (OutOfMemoryException)
@@ -621,9 +738,10 @@ public sealed class KgpImageStore
                     removedIndex,
                     currentFrameIndex);
                 var updatedImage = image.WithAnimation(updatedAnimation);
+                SetSizesUnsafe(checked(
+                    _totalSize - (image.StorageSize - updatedImage.StorageSize)),
+                    checked(_reservedDecodedBytes - image.ReservedDecodedBytes + updatedImage.ReservedDecodedBytes));
                 _imagesById[image.ImageId] = updatedImage;
-                SetTotalSizeUnsafe(checked(
-                    _totalSize - (image.StorageSize - updatedImage.StorageSize)));
                 return new AnimationFrameDeleteResult(
                     AnimationFrameDeleteStatus.Deleted,
                     image.ImageId,
@@ -700,7 +818,11 @@ public sealed class KgpImageStore
                 if (control.LoopCount > 0)
                     animation = animation.SetMaximumLoops(control.LoopCount);
 
-                _imagesById[image.ImageId] = image.WithAnimation(animation);
+                var updatedImage = image.WithAnimation(animation);
+                SetSizesUnsafe(
+                    checked(_totalSize - image.StorageSize + updatedImage.StorageSize),
+                    checked(_reservedDecodedBytes - image.ReservedDecodedBytes));
+                _imagesById[image.ImageId] = updatedImage;
                 return new AnimationControlResult(
                     AnimationControlStatus.Success,
                     image.ImageId,
@@ -823,7 +945,7 @@ public sealed class KgpImageStore
             _imagesById.Clear();
             _imagesByNumber.Clear();
             _unaddressableImageIds.Clear();
-            SetTotalSizeUnsafe(0);
+            SetSizesUnsafe(0, 0);
             AbortChunkedTransferUnsafe();
         }
     }
@@ -873,7 +995,9 @@ public sealed class KgpImageStore
     /// <param name="decodedData">The base64-decoded payload data for this chunk.</param>
     /// <returns>
     /// The completed <see cref="KgpImageData"/> when the final chunk (m=0) is received,
-    /// or null if more chunks are expected.
+    /// or null if more chunks are expected or a compressed upload is invalid or
+    /// exceeds its limits. Compressed uploads validate one complete zlib member;
+    /// bounded trailing bytes are retained and charged, but not interpreted.
     /// </returns>
     public KgpImageData? ProcessChunk(KgpCommand command, byte[] decodedData)
     {
@@ -883,19 +1007,31 @@ public sealed class KgpImageStore
         lock (_lock)
         {
             var transmission = command.ToTransmissionData();
+            if (_pendingUpload is null &&
+                transmission.Compression == KgpParsedCommand.CompressionMode.Zlib &&
+                !TryGetCompressedUploadLimit(transmission, out _, out _))
+                return null;
             var result = ProcessChunkUnsafe(
                 initialCommand: null,
                 transmission,
                 ToQuietMode(command.Quiet),
                 quietWasSpecified: command.Quiet != 0,
                 decodedData,
-                Array.MaxLength);
+                transmission.Compression == KgpParsedCommand.CompressionMode.Zlib
+                    ? MaximumCompressedUploadBytes
+                    : Array.MaxLength);
             if (result.Status != ChunkStatus.Complete)
                 return null;
 
             var imageId = result.Transmission.ImageId > 0
                 ? result.Transmission.ImageId
                 : AllocateIdUnsafe();
+            if (result.Transmission.Compression == KgpParsedCommand.CompressionMode.Zlib)
+            {
+                return TryCreateCompressedImage(result.Transmission, result.Data!, out var compressed, out _)
+                    ? compressed!.WithImageId(imageId)
+                    : null;
+            }
             return CreateImage(imageId, result.Transmission, result.Data!);
         }
     }
@@ -1042,7 +1178,8 @@ public sealed class KgpImageStore
 
     private StoreResult StoreTransmissionUnsafe(
         KgpParsedCommand.TransmissionData transmission,
-        byte[] data)
+        byte[] data,
+        KgpImageData? validatedImage = null)
     {
         if (transmission.ImageId > 0 && transmission.ImageNumber > 0)
         {
@@ -1053,8 +1190,19 @@ public sealed class KgpImageStore
         var imageId = transmission.ImageId > 0
             ? transmission.ImageId
             : AllocateIdUnsafe();
-        var image = CreateImage(imageId, transmission, data);
-        if (_sharedBudget is not null && image.StorageSize > EffectiveQuotaBytes)
+        KgpImageData image;
+        if (transmission.Compression == KgpParsedCommand.CompressionMode.Zlib)
+        {
+            if (validatedImage is null &&
+                !TryCreateCompressedImage(transmission, data, out validatedImage, out var error))
+                throw new InvalidDataException(error);
+            image = validatedImage!.WithImageId(imageId);
+        }
+        else
+        {
+            image = CreateImage(imageId, transmission, data);
+        }
+        if ((_sharedBudget is not null || image.IsZlibCompressed) && image.ChargedSize > EffectiveQuotaBytes)
             return new StoreResult(image, Replaced: false, Stored: false);
 
         ImageRelocation? relocation = null;
@@ -1076,32 +1224,34 @@ public sealed class KgpImageStore
         KgpImageData image,
         bool addressable = true)
     {
-        if (_sharedBudget is not null && image.StorageSize > EffectiveQuotaBytes)
+        if ((_sharedBudget is not null || image.IsZlibCompressed) && image.ChargedSize > EffectiveQuotaBytes)
             return new StoreResult(image, Replaced: false, Stored: false);
 
         var replaced = _imagesById.TryGetValue(image.ImageId, out var existing);
         if (existing is not null)
         {
-            SetTotalSizeUnsafe(checked(_totalSize - existing.StorageSize));
+            SetSizesUnsafe(checked(_totalSize - existing.StorageSize),
+                checked(_reservedDecodedBytes - existing.ReservedDecodedBytes));
             _imagesById.Remove(existing.ImageId);
             _unaddressableImageIds.Remove(existing.ImageId);
             RemoveFromNumberIndex(existing);
         }
 
         while (WouldExceedQuota(
-                   _totalSize,
-                   image.StorageSize,
+                   ChargedSizeUnsafe,
+                   image.ChargedSize,
                    EffectiveQuotaBytes) &&
                _imagesById.Count > 0)
         {
             EvictOldest();
         }
 
-        if (_sharedBudget is not null &&
-            WouldExceedQuota(_totalSize, image.StorageSize, EffectiveQuotaBytes))
+        if ((_sharedBudget is not null || image.IsZlibCompressed) &&
+            WouldExceedQuota(ChargedSizeUnsafe, image.ChargedSize, EffectiveQuotaBytes))
             return new StoreResult(image, replaced, Stored: false);
 
-        SetTotalSizeUnsafe(checked(_totalSize + image.StorageSize));
+        SetSizesUnsafe(checked(_totalSize + image.StorageSize),
+            checked(_reservedDecodedBytes + image.ReservedDecodedBytes));
         _imagesById[image.ImageId] = image;
         if (addressable)
             _unaddressableImageIds.Remove(image.ImageId);
@@ -1126,7 +1276,8 @@ public sealed class KgpImageStore
         if (!_imagesById.TryGetValue(imageId, out var image))
             return false;
 
-        SetTotalSizeUnsafe(checked(_totalSize - image.StorageSize));
+        SetSizesUnsafe(checked(_totalSize - image.StorageSize),
+            checked(_reservedDecodedBytes - image.ReservedDecodedBytes));
         _imagesById.Remove(imageId);
         _unaddressableImageIds.Remove(imageId);
         RemoveFromNumberIndex(image);
@@ -1183,11 +1334,15 @@ public sealed class KgpImageStore
     private long EffectiveQuotaBytes =>
         _sharedBudget?.MaximumKgpBytes ?? _quotaBytes;
 
-    private void SetTotalSizeUnsafe(long totalSize)
+    private void SetSizesUnsafe(long totalSize, long reservedDecodedBytes)
     {
+        ArgumentOutOfRangeException.ThrowIfNegative(totalSize);
+        ArgumentOutOfRangeException.ThrowIfNegative(reservedDecodedBytes);
+        _ = checked(totalSize + reservedDecodedBytes);
         if (_sharedBudget is not null)
-            _sharedBudget.SetKgpBytes(totalSize);
+            _sharedBudget.SetKgpBytes(totalSize, reservedDecodedBytes);
         _totalSize = totalSize;
+        _reservedDecodedBytes = reservedDecodedBytes;
     }
 
     private static KgpImageData CreateImage(
@@ -1195,6 +1350,8 @@ public sealed class KgpImageStore
         KgpParsedCommand.TransmissionData transmission,
         byte[] data)
     {
+        if (transmission.Compression != KgpParsedCommand.CompressionMode.None)
+            throw new InvalidOperationException("Compressed images require validated backing.");
         var width = transmission.Width;
         var height = transmission.Height;
         if (transmission.Format == KgpFormat.Png)
@@ -1233,13 +1390,6 @@ public sealed class KgpImageStore
         {
             return CreateAnimationFrameFailure(
                 AnimationFrameStatus.UnsupportedMedium,
-                transmission);
-        }
-
-        if (transmission.Compression != KgpParsedCommand.CompressionMode.None)
-        {
-            return CreateAnimationFrameFailure(
-                AnimationFrameStatus.UnsupportedCompression,
                 transmission);
         }
 
@@ -1285,7 +1435,9 @@ public sealed class KgpImageStore
         if (sourceWidth == 0 ||
             sourceHeight == 0 ||
             sourceWidth > image.Width ||
-            sourceHeight > image.Height)
+            sourceHeight > image.Height ||
+            (transmission.Compression == KgpParsedCommand.CompressionMode.Zlib &&
+             !KgpZlibData.ValidDimensions(sourceWidth, sourceHeight, MaximumCompressedRasterPixels)))
         {
             return CreateAnimationFrameFailure(
                 AnimationFrameStatus.InvalidDimensions,
@@ -1398,6 +1550,8 @@ public sealed class KgpImageStore
         var root = image.AnimationState?.GetFrame(0);
         var rootData = root?.Format == KgpFormat.Rgba32
             ? root.Data
+            : image.IsZlibCompressed && image.Format == KgpFormat.Rgba32
+                ? image.Data
             : KgpAnimationFrameComposer.ConvertToRgba(
                 root?.Data ?? image.Data,
                 image.Width,

--- a/src/Hex1b/Kgp/KgpPendingUpload.cs
+++ b/src/Hex1b/Kgp/KgpPendingUpload.cs
@@ -26,6 +26,7 @@ internal sealed class KgpPendingUpload : IDisposable
     internal long MaximumBytes { get; }
 
     internal long Length => _length;
+    internal long Capacity => _buffer?.LongLength ?? 0;
 
     internal void ApplyQuiet(KgpParsedCommand.QuietMode quiet)
     {

--- a/src/Hex1b/Kgp/KgpZlibData.cs
+++ b/src/Hex1b/Kgp/KgpZlibData.cs
@@ -1,0 +1,154 @@
+using System.IO.Compression;
+using System.Security.Cryptography;
+
+namespace Hex1b;
+
+internal static class KgpZlibData
+{
+    internal readonly record struct Validation(
+        int Length, uint Width, uint Height, byte[] Hash);
+
+    internal static bool TryValidate(
+        byte[] encoded,
+        KgpFormat format,
+        uint width,
+        uint height,
+        long maximumPixels,
+        long maximumDecodedBytes,
+        out Validation validation,
+        out string error)
+    {
+        validation = default;
+        error = "";
+        var limit = Math.Min(Array.MaxLength, maximumDecodedBytes);
+        long expectedLength = 0;
+        if (format != KgpFormat.Png)
+        {
+            if (!ValidDimensions(width, height, maximumPixels))
+            {
+                error = "EFBIG:Image dimensions exceed the raster limit";
+                return false;
+            }
+            expectedLength = checked((long)width * height *
+                (format == KgpFormat.Rgb24 ? 3 : 4));
+            if (expectedLength > limit)
+            {
+                error = "ENOSPC:Decoded image exceeds storage capacity";
+                return false;
+            }
+            limit = expectedLength;
+        }
+
+        try
+        {
+            using var input = new CompleteInputStream(encoded);
+            using var inflater = new ZLibStream(input, CompressionMode.Decompress);
+            using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+            Span<byte> scratch = stackalloc byte[8192];
+            Span<byte> pngHeader = stackalloc byte[33];
+            var headerLength = 0;
+            long length = 0;
+            while (true)
+            {
+                // Read one byte beyond the bound, including after the expected
+                // output, so completion and the zlib checksum are validated.
+                var requested = (int)Math.Min(scratch.Length, Math.Max(1, limit - length + 1));
+                var count = inflater.Read(scratch[..requested]);
+                if (count == 0)
+                    break;
+                length = checked(length + count);
+                if (length > limit)
+                {
+                    error = "EFBIG:Too much decoded image data";
+                    return false;
+                }
+                hash.AppendData(scratch[..count]);
+                if (format == KgpFormat.Png && headerLength < pngHeader.Length)
+                {
+                    var copied = Math.Min(count, pngHeader.Length - headerLength);
+                    scratch[..copied].CopyTo(pngHeader[headerLength..]);
+                    headerLength += copied;
+                    if (headerLength == pngHeader.Length &&
+                        (!KgpPngMetadata.TryReadDimensions(pngHeader, out width, out height) ||
+                         !ValidDimensions(width, height, maximumPixels)))
+                    {
+                        error = "EINVAL:Invalid or oversized PNG dimensions";
+                        return false;
+                    }
+                }
+            }
+
+            if (format == KgpFormat.Png ? headerLength < pngHeader.Length : length != expectedLength)
+            {
+                error = "ENODATA:Insufficient decoded image data";
+                return false;
+            }
+            validation = new Validation(checked((int)length), width, height, hash.GetHashAndReset());
+            return true;
+        }
+        catch (InvalidDataException)
+        {
+            error = "EINVAL:Invalid or incomplete zlib image data";
+            return false;
+        }
+        catch (IOException)
+        {
+            // The in-memory inflater reports unsupported preset dictionaries as
+            // an internal ZLibException (IOException), not InvalidDataException.
+            error = "EINVAL:Invalid or unsupported zlib image data";
+            return false;
+        }
+        catch (OutOfMemoryException)
+        {
+            error = "ENOMEM:Out of memory";
+            return false;
+        }
+    }
+
+    internal static bool ValidDimensions(uint width, uint height, long maximumPixels)
+        => width > 0 && height > 0 &&
+           (ulong)width * height <= (ulong)maximumPixels;
+
+    internal static byte[] Materialize(byte[] encoded, int length)
+    {
+        var result = new byte[length];
+        using var input = new CompleteInputStream(encoded);
+        using var inflater = new ZLibStream(input, CompressionMode.Decompress);
+        inflater.ReadExactly(result);
+        return result;
+    }
+
+    // ZLibStream may accept a truncated checksum when its source returns EOF.
+    // Completed uploads must instead fail if the inflater needs missing input.
+    // A completed first member may leave bounded trailing bytes uninterpreted.
+    private sealed class CompleteInputStream(byte[] data) : Stream
+    {
+        private int _position;
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => data.Length;
+        public override long Position
+        {
+            get => _position;
+            set => throw new NotSupportedException();
+        }
+        public override int Read(byte[] buffer, int offset, int count)
+            => Read(buffer.AsSpan(offset, count));
+        public override int Read(Span<byte> buffer)
+        {
+            if (buffer.IsEmpty)
+                return 0;
+            if (_position == data.Length)
+                throw new InvalidDataException("Incomplete zlib member.");
+            var count = Math.Min(buffer.Length, data.Length - _position);
+            data.AsSpan(_position, count).CopyTo(buffer);
+            _position += count;
+            return count;
+        }
+        public override void Flush() => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}

--- a/src/Hex1b/TerminalGraphicsRetainedBudget.cs
+++ b/src/Hex1b/TerminalGraphicsRetainedBudget.cs
@@ -7,15 +7,23 @@ internal sealed class TerminalGraphicsRetainedBudget
 {
     private readonly object _lock = new();
     private long _kgpBytes;
+    private long _kgpReservedBytes;
     private long _sixelBytes;
 
-    internal TerminalGraphicsRetainedBudget(long maximumBytes)
+    internal TerminalGraphicsRetainedBudget(
+        long maximumBytes,
+        int maximumInputBytes = 1024 * 1024,
+        long maximumRasterPixels = 16L * 1024 * 1024)
     {
         ArgumentOutOfRangeException.ThrowIfNegative(maximumBytes);
         MaximumBytes = maximumBytes;
+        MaximumInputBytes = maximumInputBytes;
+        MaximumRasterPixels = maximumRasterPixels;
     }
 
     internal long MaximumBytes { get; }
+    internal int MaximumInputBytes { get; }
+    internal long MaximumRasterPixels { get; }
 
     internal long KgpBytes
     {
@@ -49,7 +57,7 @@ internal sealed class TerminalGraphicsRetainedBudget
         get
         {
             lock (_lock)
-                return Math.Max(0, MaximumBytes - _kgpBytes);
+                return Math.Max(0, MaximumBytes - _kgpBytes - _kgpReservedBytes);
         }
     }
 
@@ -57,17 +65,19 @@ internal sealed class TerminalGraphicsRetainedBudget
     {
         ArgumentOutOfRangeException.ThrowIfNegative(bytes);
         lock (_lock)
-            return bytes <= MaximumBytes - _kgpBytes;
+            return bytes <= MaximumBytes - _kgpBytes - _kgpReservedBytes;
     }
 
-    internal void SetKgpBytes(long bytes)
+    internal void SetKgpBytes(long bytes, long reservedBytes = 0)
     {
         ArgumentOutOfRangeException.ThrowIfNegative(bytes);
+        ArgumentOutOfRangeException.ThrowIfNegative(reservedBytes);
         lock (_lock)
         {
-            if (bytes > MaximumBytes - _sixelBytes)
+            if (checked(bytes + reservedBytes) > MaximumBytes - _sixelBytes)
                 throw new InvalidOperationException("KGP retained bytes exceed the shared screen budget.");
             _kgpBytes = bytes;
+            _kgpReservedBytes = reservedBytes;
         }
     }
 
@@ -76,7 +86,7 @@ internal sealed class TerminalGraphicsRetainedBudget
         ArgumentOutOfRangeException.ThrowIfNegative(bytes);
         lock (_lock)
         {
-            if (bytes > MaximumBytes - _kgpBytes)
+            if (bytes > MaximumBytes - _kgpBytes - _kgpReservedBytes)
                 throw new InvalidOperationException("Sixel retained bytes exceed the shared screen budget.");
             _sixelBytes = bytes;
         }
@@ -85,10 +95,13 @@ internal sealed class TerminalGraphicsRetainedBudget
 
 internal sealed class TerminalGraphicsRetainedBudgetSet
 {
-    internal TerminalGraphicsRetainedBudgetSet(long maximumBytesPerScreen)
+    internal TerminalGraphicsRetainedBudgetSet(
+        long maximumBytesPerScreen,
+        int maximumInputBytes = 1024 * 1024,
+        long maximumRasterPixels = 16L * 1024 * 1024)
     {
-        Main = new TerminalGraphicsRetainedBudget(maximumBytesPerScreen);
-        Alternate = new TerminalGraphicsRetainedBudget(maximumBytesPerScreen);
+        Main = new TerminalGraphicsRetainedBudget(maximumBytesPerScreen, maximumInputBytes, maximumRasterPixels);
+        Alternate = new TerminalGraphicsRetainedBudget(maximumBytesPerScreen, maximumInputBytes, maximumRasterPixels);
     }
 
     internal TerminalGraphicsRetainedBudget Main { get; }

--- a/src/web-terminal/src/renderer.ts
+++ b/src/web-terminal/src/renderer.ts
@@ -35,6 +35,12 @@ function glyphKey(cell: TerminalCell): string {
   return `${cell.attributes & 5}/${cell.width}/${cell.text}`;
 }
 
+function isKgpPlaceholder(cell: TerminalCell): boolean {
+  // The base scalar and following diacritics encode an image reference, not a glyph.
+  // Keep the authoritative text and colors intact even when no image is placed.
+  return cell.text.codePointAt(0) === 0x10eeee;
+}
+
 /** Shelf packer. Plans are computed before mutating the atlas used by a submitted frame. */
 function packGlyphs(glyphs: ReadonlyMap<string, TerminalCell>, size: number, scale: number,
   initial: Shelf = { x: 0, y: 0, rowHeight: 0 }): { placements: GlyphPlacement[]; shelf: Shelf } | null {
@@ -219,7 +225,7 @@ export class TerminalRenderer {
   prepareGlyphs(cells: readonly (TerminalCell | undefined)[]): void {
     const visible = new Map<string, TerminalCell>();
     for (const cell of cells) {
-      if (!cell || !cell.width || !cell.text.trim() || (cell.attributes & 64)) continue;
+      if (!cell || !cell.width || !cell.text.trim() || (cell.attributes & 64) || isKgpPlaceholder(cell)) continue;
       visible.set(glyphKey(cell), cell);
     }
     const keyUnits = (glyphs: ReadonlyMap<string, TerminalCell>) => [...glyphs.keys()].reduce((total, key) => total + key.length, 0);
@@ -385,7 +391,7 @@ export class TerminalRenderer {
       const y = Math.floor(i / this.columns) * CELL_HEIGHT;
       const width = Math.min(cell.width * CELL_WIDTH, this.width - x);
       const foreground = rgba(cell.foreground);
-      const glyph = this.glyphs.get(glyphKey(cell));
+      const glyph = isKgpPlaceholder(cell) ? undefined : this.glyphs.get(glyphKey(cell));
       if (glyph) {
         const tint: Vector4 = glyph.colored ? (cell.attributes & 2 ? [0.5, 0.5, 0.5, 1] : WHITE) : foreground;
         this.quad(this.atlas, x, y, cell.width * CELL_WIDTH, CELL_HEIGHT,
@@ -444,7 +450,13 @@ export class TerminalRenderer {
     this.disposed = true;
     for (const image of this.images.values()) image.destroy();
     this.images.clear();
+    this.textureBytes = 0;
     this.atlas?.destroy();
+    this.glyphs.clear();
+    this.glyphKeyUnits = 0;
+    this.batches = [];
+    this.quadCount = 0;
+    this.instances = new Float32Array(0);
     this.font?.dispose();
     this.fontMetrics.clear();
     this.backend.dispose();

--- a/tests/Hex1b.Tests/Diagnostics/CapturedWorkloadAdapter.cs
+++ b/tests/Hex1b.Tests/Diagnostics/CapturedWorkloadAdapter.cs
@@ -1,0 +1,73 @@
+namespace Hex1b.Tests.Diagnostics;
+
+internal sealed class CapturedWorkloadAdapter : IHex1bTerminalWorkloadAdapter
+{
+    private readonly byte[][] _outputChunks;
+    private readonly object _gate = new();
+    private readonly List<byte> _written = [];
+    private readonly TaskCompletionSource _disposedSignal =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private int _nextChunk;
+    private bool _disposed;
+    private (int Width, int Height)? _lastResize;
+
+    public CapturedWorkloadAdapter(IReadOnlyList<byte[]> outputChunks)
+    {
+        ArgumentNullException.ThrowIfNull(outputChunks);
+        _outputChunks = outputChunks.Select(chunk => chunk.ToArray()).ToArray();
+    }
+
+    public byte[] WrittenBytes { get { lock (_gate) return _written.ToArray(); } }
+    public byte[] WrittenInput => WrittenBytes;
+    public (int Width, int Height)? LastResize { get { lock (_gate) return _lastResize; } }
+    public event Action? Disconnected;
+
+    public async ValueTask<ReadOnlyMemory<byte>> ReadOutputAsync(CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (_nextChunk < _outputChunks.Length)
+                return _outputChunks[_nextChunk++].ToArray();
+        }
+
+        await _disposedSignal.Task.WaitAsync(ct).ConfigureAwait(false);
+        return ReadOnlyMemory<byte>.Empty;
+    }
+
+    public ValueTask WriteInputAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            _written.AddRange(data.ToArray());
+        }
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask ResizeAsync(int width, int height, CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        lock (_gate)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            _lastResize = (width, height);
+        }
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        lock (_gate)
+        {
+            if (_disposed)
+                return ValueTask.CompletedTask;
+            _disposed = true;
+        }
+        _disposedSignal.TrySetResult();
+        Disconnected?.Invoke();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/tests/Hex1b.Tests/Diagnostics/DuplexPtyCapture.cs
+++ b/tests/Hex1b.Tests/Diagnostics/DuplexPtyCapture.cs
@@ -1,0 +1,230 @@
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace Hex1b.Tests.Diagnostics;
+
+// Observes adapter calls, not physical PTY syscalls or application input consumption.
+internal sealed class DuplexPtyCapture : IHex1bTerminalWorkloadAdapter
+{
+    private readonly IHex1bTerminalWorkloadAdapter _inner;
+    private readonly long _maxBytes;
+    private readonly int _maxEvents;
+    private readonly object _gate = new();
+    private readonly List<DuplexCaptureRecord> _records = [];
+    private readonly CancellationTokenSource _failureSignal = new();
+    private long _bytes;
+    private long _operationId;
+    private string? _failure;
+    private string _status = "incomplete";
+    private bool _complete;
+    private int _disposed;
+
+    public DuplexPtyCapture(IHex1bTerminalWorkloadAdapter inner, long maximumBytes, int maximumEvents)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        ArgumentOutOfRangeException.ThrowIfNegative(maximumBytes);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumEvents);
+        _inner = inner;
+        _maxBytes = maximumBytes;
+        _maxEvents = maximumEvents;
+        _inner.Disconnected += OnDisconnected;
+    }
+
+    public IReadOnlyList<DuplexCaptureRecord> Records
+    {
+        get { lock (_gate) return Snapshot(); }
+    }
+
+    public CancellationToken FailureToken => _failureSignal.Token;
+    public string? Failure { get { lock (_gate) return _failure; } }
+    public string Status { get { lock (_gate) return _status; } }
+    public bool IsComplete { get { lock (_gate) return _complete; } }
+    public event Action? Disconnected;
+
+    public async ValueTask<ReadOnlyMemory<byte>> ReadOutputAsync(CancellationToken ct = default)
+    {
+        var operation = BeginOperation();
+        ReadOnlyMemory<byte> bytes;
+        try
+        {
+            bytes = await _inner.ReadOutputAsync(ct).ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            RecordOutcome("output", operation, exception);
+            throw;
+        }
+        Record("output", operation, bytes);
+        return bytes;
+    }
+
+    public async ValueTask WriteInputAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default)
+    {
+        var operation = BeginOperation();
+        Record("input-start", operation, data);
+        try
+        {
+            await _inner.WriteInputAsync(data, ct).ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            RecordOutcome("input", operation, exception);
+            throw;
+        }
+        Record("input-complete", operation);
+    }
+
+    public async ValueTask ResizeAsync(int width, int height, CancellationToken ct = default)
+    {
+        var operation = BeginOperation();
+        Record("resize-start", operation, width: width, height: height);
+        try
+        {
+            await _inner.ResizeAsync(width, height, ct).ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            RecordOutcome("resize", operation, exception);
+            throw;
+        }
+        Record("resize-completed", operation, width: width, height: height);
+    }
+
+    public void Complete(string status)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(status);
+        lock (_gate)
+        {
+            if (_failure is not null)
+                return;
+            _status = status;
+            _complete = true;
+        }
+    }
+
+    public async Task SaveAsync(string path, object metadata, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(metadata);
+        ct.ThrowIfCancellationRequested();
+        object transcript;
+        lock (_gate)
+        {
+            transcript = new
+            {
+                Version = 1,
+                StopwatchFrequency = Stopwatch.Frequency,
+                Observation = "Adapter calls; not physical syscall boundaries or application input consumption.",
+                Metadata = metadata,
+                IsComplete = _complete,
+                Status = _status,
+                Failure = _failure,
+                MaxBytes = _maxBytes,
+                MaxEvents = _maxEvents,
+                RecordedBytes = _bytes,
+                Records = Snapshot()
+            };
+        }
+
+        var options = new FileStreamOptions
+        {
+            Mode = FileMode.CreateNew,
+            Access = FileAccess.Write,
+            Share = FileShare.None,
+            Options = FileOptions.Asynchronous
+        };
+        if (!OperatingSystem.IsWindows())
+            options.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+        await using var stream = new FileStream(path, options);
+        await JsonSerializer.SerializeAsync(stream, transcript, cancellationToken: ct).ConfigureAwait(false);
+        await stream.FlushAsync(ct).ConfigureAwait(false);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+        _inner.Disconnected -= OnDisconnected;
+        try
+        {
+            await _inner.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            if (Failure is null)
+                RecordOutcome("dispose", Interlocked.Increment(ref _operationId), exception);
+            throw;
+        }
+        // Cleanup must remain possible after a limit failure.
+        if (Failure is null)
+            Record("disposed", Interlocked.Increment(ref _operationId));
+    }
+
+    private long BeginOperation()
+    {
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
+        lock (_gate)
+        {
+            if (_failure is not null)
+                throw new InvalidOperationException(_failure);
+        }
+        return Interlocked.Increment(ref _operationId);
+    }
+
+    private void OnDisconnected()
+    {
+        try
+        {
+            Record("disconnected", Interlocked.Increment(ref _operationId));
+        }
+        finally
+        {
+            Disconnected?.Invoke();
+        }
+    }
+
+    private void RecordOutcome(string kind, long operation, Exception exception) =>
+        Record($"{kind}-{(exception is OperationCanceledException ? "canceled" : "faulted")}",
+            operation, detail: exception.GetType().FullName);
+
+    private void Record(string kind, long operation, ReadOnlyMemory<byte>? bytes = null,
+        int? width = null, int? height = null, string? detail = null)
+    {
+        string? failure;
+        lock (_gate)
+        {
+            if (_failure is null &&
+                (_records.Count >= _maxEvents || (bytes?.Length ?? 0) > _maxBytes - _bytes))
+            {
+                _failure = "Capture limit exceeded; transcript is incomplete.";
+                _status = "failed";
+                _complete = false;
+            }
+
+            failure = _failure;
+            if (failure is null)
+            {
+                var copy = bytes?.ToArray();
+                _records.Add(new(_records.Count + 1L, Stopwatch.GetTimestamp(), kind,
+                    operation, copy, width, height, detail));
+                _bytes += copy?.Length ?? 0;
+            }
+        }
+        if (failure is not null)
+        {
+            // Cancellation callbacks must not run under the recording lock.
+            _ = _failureSignal.CancelAsync();
+            throw new InvalidOperationException(failure);
+        }
+    }
+
+    private DuplexCaptureRecord[] Snapshot() =>
+        _records.Select(record => record with { Bytes = record.Bytes?.ToArray() }).ToArray();
+}
+
+internal sealed record DuplexCaptureRecord(
+    long Sequence, long Timestamp, string Kind, long OperationId, byte[]? Bytes,
+    int? Width, int? Height, string? Detail)
+{
+    [System.Text.Json.Serialization.JsonIgnore]
+    public byte[] Data => Bytes ?? [];
+}

--- a/tests/Hex1b.Tests/Diagnostics/DuplexPtyCaptureTests.cs
+++ b/tests/Hex1b.Tests/Diagnostics/DuplexPtyCaptureTests.cs
@@ -1,0 +1,316 @@
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace Hex1b.Tests.Diagnostics;
+
+[TestClass]
+public class DuplexPtyCaptureTests
+{
+    [TestMethod]
+    public async Task Capture_BinaryChunksAndInput_PreservesExactBytesAndOrdering()
+    {
+        byte[][] chunks = [[0xff, 0, 0xc3], [], [0xa9, 0x1b, 0x5b]];
+        await using var replay = new CapturedWorkloadAdapter(chunks);
+        await using var capture = new DuplexPtyCapture(replay, maximumBytes: 100, maximumEvents: 20);
+        foreach (var chunk in chunks)
+            TestSeq.AreEqual(chunk, (await capture.ReadOutputAsync()).ToArray());
+        await capture.WriteInputAsync(new byte[] { 0, 0xfe, 0x1b });
+
+        var records = capture.Records;
+        TestSeq.AreEqual(chunks, records.Where(record => record.Kind == "output")
+            .Select(record => record.Data).ToArray());
+        TestSeq.AreEqual(new byte[] { 0, 0xfe, 0x1b }, replay.WrittenInput);
+        TestSeq.AreEqual(Enumerable.Range(1, records.Count).Select(value => (long)value),
+            records.Select(record => record.Sequence));
+        Assert.IsTrue(records.Zip(records.Skip(1)).All(pair =>
+            pair.First.Timestamp <= pair.Second.Timestamp));
+        Assert.AreEqual(records[^2].OperationId, records[^1].OperationId);
+        Assert.AreEqual("input-start", records[^2].Kind);
+        Assert.AreEqual("input-complete", records[^1].Kind);
+    }
+
+    [TestMethod]
+    public async Task WriteInputAsync_WhileOutputReadBlocked_ProgressesIndependently()
+    {
+        var inner = new ControlledAdapter();
+        await using var capture = new DuplexPtyCapture(inner, 100, 20);
+        var read = capture.ReadOutputAsync().AsTask();
+        await inner.ReadStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await capture.WriteInputAsync(new byte[] { 7 }).AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.IsFalse(read.IsCompleted);
+        inner.Output.TrySetResult(new byte[] { 8 });
+        TestSeq.AreEqual(new byte[] { 8 }, (await read).ToArray());
+        TestSeq.AreEqual(new[] { "input-start", "input-complete", "output" },
+            capture.Records.Select(record => record.Kind));
+        Assert.AreNotEqual(capture.Records[0].OperationId, capture.Records[2].OperationId);
+    }
+
+    [TestMethod]
+    public async Task Records_CallerAndSnapshotMutation_DoesNotChangeRecording()
+    {
+        var output = new byte[] { 1, 2 };
+        var input = new byte[] { 3, 4 };
+        var inner = new ControlledAdapter();
+        inner.Output.TrySetResult(output);
+        await using var capture = new DuplexPtyCapture(inner, 100, 20);
+        _ = await capture.ReadOutputAsync();
+        await capture.WriteInputAsync(input);
+        output[0] = 9;
+        input[0] = 9;
+        var snapshot = capture.Records;
+        snapshot[0].Bytes![0] = 9;
+        snapshot[1].Bytes![0] = 9;
+        TestSeq.AreEqual(new byte[] { 1, 2 }, capture.Records[0].Bytes!);
+        TestSeq.AreEqual(new byte[] { 3, 4 }, capture.Records[1].Bytes!);
+    }
+
+    [TestMethod]
+    public async Task Replay_OriginalAndWrittenSnapshotMutation_DoesNotChangeBytes()
+    {
+        var chunk = new byte[] { 0xff, 1 };
+        await using var replay = new CapturedWorkloadAdapter([chunk]);
+        chunk[0] = 0;
+        TestSeq.AreEqual(new byte[] { 0xff, 1 }, (await replay.ReadOutputAsync()).ToArray());
+        var input = new byte[] { 2, 3 };
+        await replay.WriteInputAsync(input);
+        input[0] = 0;
+        replay.WrittenBytes[0] = 0;
+        await replay.WriteInputAsync(new byte[] { 4 });
+        TestSeq.AreEqual(new byte[] { 2, 3, 4 }, replay.WrittenBytes);
+    }
+
+    [TestMethod]
+    public async Task WriteInputAsync_FaultAndCancellation_HaveDistinctOutcomes()
+    {
+        var inner = new ControlledAdapter { WriteFailure = new IOException("write failed") };
+        await using var capture = new DuplexPtyCapture(inner, 100, 20);
+        await Assert.ThrowsExactlyAsync<IOException>(() =>
+            capture.WriteInputAsync(new byte[] { 1 }).AsTask());
+        inner.WriteFailure = new OperationCanceledException();
+        await Assert.ThrowsExactlyAsync<OperationCanceledException>(() =>
+            capture.WriteInputAsync(new byte[] { 2 }).AsTask());
+        TestSeq.AreEqual(new[]
+        {
+            "input-start", "input-faulted",
+            "input-start", "input-canceled"
+        }, capture.Records.Select(record => record.Kind));
+        Assert.AreEqual(capture.Records[0].OperationId, capture.Records[1].OperationId);
+        Assert.AreEqual(capture.Records[2].OperationId, capture.Records[3].OperationId);
+        Assert.IsFalse(capture.IsComplete);
+    }
+
+    [TestMethod]
+    public async Task ReadOutputAsync_CanceledWhileBlocked_RecordsCancellation()
+    {
+        await using var replay = new CapturedWorkloadAdapter([]);
+        await using var capture = new DuplexPtyCapture(replay, 100, 20);
+        using var canceled = new CancellationTokenSource();
+        var read = capture.ReadOutputAsync(canceled.Token).AsTask();
+        Assert.IsFalse(read.IsCompleted);
+        canceled.Cancel();
+        await Assert.ThrowsAsync<OperationCanceledException>(() => read);
+        Assert.AreEqual("output-canceled", TestSeq.Single(capture.Records).Kind);
+    }
+
+    [TestMethod]
+    public async Task ReadOutputAsync_Faulted_RecordsFaultWithoutInventingOutput()
+    {
+        var inner = new ControlledAdapter();
+        inner.Output.TrySetException(new IOException("read failed"));
+        await using var capture = new DuplexPtyCapture(inner, 100, 20);
+        await Assert.ThrowsExactlyAsync<IOException>(() => capture.ReadOutputAsync().AsTask());
+        var record = TestSeq.Single(capture.Records);
+        Assert.AreEqual("output-faulted", record.Kind);
+        Assert.IsNull(record.Bytes);
+    }
+
+    [TestMethod]
+    [DataRow(1L, 20, false)]
+    [DataRow(100L, 1, true)]
+    public async Task Capture_LimitExceeded_FailsDurablyAndSignalsRunner(
+        long maxBytes, int maxEvents, bool completionEventOverflows)
+    {
+        await using var replay = new CapturedWorkloadAdapter([]);
+        await using var capture = new DuplexPtyCapture(replay, maxBytes, maxEvents);
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
+            capture.WriteInputAsync(new byte[] { 1, 2 }).AsTask());
+        Assert.IsTrue(capture.FailureToken.IsCancellationRequested);
+        Assert.IsNotNull(capture.Failure);
+        Assert.AreEqual("failed", capture.Status);
+        capture.Complete("success");
+        Assert.IsFalse(capture.IsComplete);
+        Assert.AreEqual("failed", capture.Status);
+        Assert.AreEqual(completionEventOverflows ? 2 : 0, replay.WrittenBytes.Length);
+        Assert.IsTrue(capture.Records.Count <= maxEvents);
+        Assert.IsTrue(capture.Records.Sum(record => record.Bytes?.Length ?? 0) <= maxBytes);
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
+            capture.ResizeAsync(80, 24).AsTask());
+    }
+
+    [TestMethod]
+    public async Task ReadOutputAsync_ByteLimitExceeded_DoesNotReturnUnrecordedSuccess()
+    {
+        await using var replay = new CapturedWorkloadAdapter([new byte[] { 1, 2 }]);
+        await using var capture = new DuplexPtyCapture(replay, 1, 20);
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => capture.ReadOutputAsync().AsTask());
+        Assert.AreEqual(0, capture.Records.Count);
+        Assert.IsTrue(capture.FailureToken.IsCancellationRequested);
+    }
+
+    [TestMethod]
+    public async Task ResizeDisconnectAndDispose_ForwardsLifecycleWithoutCompletingCapture()
+    {
+        var inner = new ControlledAdapter();
+        var capture = new DuplexPtyCapture(inner, 100, 20);
+        var disconnected = 0;
+        capture.Disconnected += () => disconnected++;
+        await capture.ResizeAsync(192, 54);
+        Assert.AreEqual((192, 54), inner.LastResize);
+        inner.Disconnect();
+        Assert.AreEqual(1, disconnected);
+        await capture.DisposeAsync();
+        await capture.DisposeAsync();
+        inner.Disconnect();
+        Assert.AreEqual(1, disconnected);
+        Assert.AreEqual(1, inner.DisposeCount);
+        Assert.IsFalse(capture.IsComplete);
+        TestSeq.AreEqual(new[] { "resize-start", "resize-completed", "disconnected", "disposed" },
+            capture.Records.Select(record => record.Kind));
+        await Assert.ThrowsExactlyAsync<ObjectDisposedException>(() =>
+            capture.WriteInputAsync(new byte[] { 1 }).AsTask());
+    }
+
+    [TestMethod]
+    public async Task Replay_ExhaustedOutput_WaitsForCancellationOrDispose()
+    {
+        var replay = new CapturedWorkloadAdapter([]);
+        using var canceled = new CancellationTokenSource();
+        var canceledRead = replay.ReadOutputAsync(canceled.Token).AsTask();
+        Assert.IsFalse(canceledRead.IsCompleted);
+        canceled.Cancel();
+        await Assert.ThrowsAsync<OperationCanceledException>(() => canceledRead);
+        var disposedRead = replay.ReadOutputAsync().AsTask();
+        Assert.IsFalse(disposedRead.IsCompleted);
+        var disconnects = 0;
+        replay.Disconnected += () => disconnects++;
+        await replay.ResizeAsync(90, 30);
+        Assert.AreEqual((90, 30), replay.LastResize);
+        await replay.DisposeAsync();
+        await replay.DisposeAsync();
+        Assert.IsTrue((await disposedRead.WaitAsync(TimeSpan.FromSeconds(5))).IsEmpty);
+        Assert.AreEqual(1, disconnects);
+        await Assert.ThrowsExactlyAsync<ObjectDisposedException>(() => replay.ReadOutputAsync().AsTask());
+    }
+
+    [TestMethod]
+    public async Task Replay_PreCanceledOperations_DoNotConsumeOrWrite()
+    {
+        await using var replay = new CapturedWorkloadAdapter([new byte[] { 1 }]);
+        using var canceled = new CancellationTokenSource();
+        canceled.Cancel();
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            replay.ReadOutputAsync(canceled.Token).AsTask());
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            replay.WriteInputAsync(new byte[] { 2 }, canceled.Token).AsTask());
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            replay.ResizeAsync(90, 30, canceled.Token).AsTask());
+        TestSeq.AreEqual(new byte[] { 1 }, (await replay.ReadOutputAsync()).ToArray());
+        Assert.AreEqual(0, replay.WrittenBytes.Length);
+        Assert.IsNull(replay.LastResize);
+    }
+
+    [TestMethod]
+    public async Task SaveAsync_WithoutExplicitCompletion_PersistsIncompleteState()
+    {
+        var path = Path.Combine(Directory.GetCurrentDirectory(), $"duplex-incomplete-{Guid.NewGuid():N}.json");
+        try
+        {
+            await using var capture = new DuplexPtyCapture(new CapturedWorkloadAdapter([]), 100, 20);
+            await capture.DisposeAsync();
+            await capture.SaveAsync(path, new { }, TestContext.Current.CancellationToken);
+            using var json = JsonDocument.Parse(await File.ReadAllTextAsync(path, TestContext.Current.CancellationToken));
+            Assert.IsFalse(json.RootElement.GetProperty("IsComplete").GetBoolean());
+            Assert.AreEqual("incomplete", json.RootElement.GetProperty("Status").GetString());
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public async Task SaveAsync_CompleteOrFailed_UsesVersionedPrivateCreateNewTranscript(bool fail)
+    {
+        var path = Path.Combine(Directory.GetCurrentDirectory(), $"duplex-capture-{Guid.NewGuid():N}.json");
+        try
+        {
+            await using var replay = new CapturedWorkloadAdapter([new byte[] { 0, 0xff, 0xc3 }]);
+            await using var capture = new DuplexPtyCapture(replay, 3, 20);
+            _ = await capture.ReadOutputAsync();
+            Assert.IsFalse(capture.IsComplete);
+            Assert.AreEqual("incomplete", capture.Status);
+            if (fail)
+                await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
+                    capture.WriteInputAsync(new byte[] { 1 }).AsTask());
+            capture.Complete("success");
+            await capture.SaveAsync(path, new { Fixture = "binary" }, TestContext.Current.CancellationToken);
+            using var json = JsonDocument.Parse(await File.ReadAllTextAsync(path, TestContext.Current.CancellationToken));
+            var root = json.RootElement;
+            Assert.AreEqual(1, root.GetProperty("Version").GetInt32());
+            Assert.AreEqual(Stopwatch.Frequency, root.GetProperty("StopwatchFrequency").GetInt64());
+            Assert.AreEqual(!fail, root.GetProperty("IsComplete").GetBoolean());
+            Assert.AreEqual(fail ? "failed" : "success", root.GetProperty("Status").GetString());
+            Assert.AreEqual(fail ? JsonValueKind.String : JsonValueKind.Null,
+                root.GetProperty("Failure").ValueKind);
+            TestSeq.AreEqual(new byte[] { 0, 0xff, 0xc3 },
+                root.GetProperty("Records")[0].GetProperty("Bytes").GetBytesFromBase64());
+            Assert.AreEqual("binary", root.GetProperty("Metadata").GetProperty("Fixture").GetString());
+            Assert.IsFalse(root.TryGetProperty("Environment", out _));
+            if (!OperatingSystem.IsWindows())
+                Assert.AreEqual(UnixFileMode.UserRead | UnixFileMode.UserWrite, File.GetUnixFileMode(path));
+            await Assert.ThrowsExactlyAsync<IOException>(() =>
+                capture.SaveAsync(path, new { }, TestContext.Current.CancellationToken));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    private sealed class ControlledAdapter : IHex1bTerminalWorkloadAdapter
+    {
+        public TaskCompletionSource ReadStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource<ReadOnlyMemory<byte>> Output { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public Exception? WriteFailure { get; set; }
+        public (int Width, int Height)? LastResize { get; private set; }
+        public int DisposeCount { get; private set; }
+        public event Action? Disconnected;
+
+        public async ValueTask<ReadOnlyMemory<byte>> ReadOutputAsync(CancellationToken ct = default)
+        {
+            ReadStarted.TrySetResult();
+            return await Output.Task.WaitAsync(ct);
+        }
+
+        public ValueTask WriteInputAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default) =>
+            WriteFailure is null ? ValueTask.CompletedTask : ValueTask.FromException(WriteFailure);
+
+        public ValueTask ResizeAsync(int width, int height, CancellationToken ct = default)
+        {
+            LastResize = (width, height);
+            return ValueTask.CompletedTask;
+        }
+
+        public void Disconnect() => Disconnected?.Invoke();
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            Output.TrySetResult(ReadOnlyMemory<byte>.Empty);
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/tests/Hex1b.Tests/Diagnostics/GraphicsStreamReplayTests.cs
+++ b/tests/Hex1b.Tests/Diagnostics/GraphicsStreamReplayTests.cs
@@ -1,0 +1,55 @@
+using System.Text;
+
+namespace Hex1b.Tests.Diagnostics;
+
+[TestClass]
+public class GraphicsStreamReplayTests
+{
+    [TestMethod]
+    public async Task Replay_ExplicitReducedStream_WritesStateAndBrowserFrame()
+    {
+        var path = Environment.GetEnvironmentVariable("HEX1B_GRAPHICS_STREAM");
+        var directory = Environment.GetEnvironmentVariable("HEX1B_GRAPHICS_REPLAY_OUTPUT");
+        if (string.IsNullOrEmpty(path) || string.IsNullOrEmpty(directory))
+            Assert.Inconclusive("Set HEX1B_GRAPHICS_STREAM and HEX1B_GRAPHICS_REPLAY_OUTPUT for reviewed-stream replay.");
+        Assert.IsTrue(File.Exists(path));
+        Assert.IsTrue(new FileInfo(path).Length <= 8 * 1024 * 1024, "Reviewed replay input must fit the 8 MiB budget.");
+        Assert.IsFalse(Directory.Exists(directory), "Use a new output directory.");
+        if (OperatingSystem.IsWindows())
+            Directory.CreateDirectory(directory);
+        else
+            Directory.CreateDirectory(directory, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        var bytes = await File.ReadAllBytesAsync(path, TestContext.Current.CancellationToken);
+        var marker = Encoding.UTF8.GetBytes($"\x1b[24;1H{ProteinViewGraphicsStreamTests.Marker}");
+        var chunks = ProteinViewGraphicsStreamTests.Chunks(bytes, 997).Append(marker).ToArray();
+        await using var workload = new CapturedWorkloadAdapter(chunks);
+        await using var capture = new DuplexPtyCapture(workload, 8 * 1024 * 1024, 10000);
+        await using var producer = new Hmp1PresentationAdapter(80, 24);
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(capture).WithPresentation(producer).WithDimensions(80, 24).Build();
+        await using var presentation = await producer.CreateBrowserViewAsync("Reduced stream", TestContext.Current.CancellationToken);
+        await ProteinViewGraphicsStreamTests.WaitForMarkerAsync(terminal);
+        var frame = await presentation.ReadFrameAsync(TestContext.Current.CancellationToken);
+        using var snapshot = terminal.CreateSnapshot();
+        await File.WriteAllBytesAsync(Path.Combine(directory, "frame.hwt"), frame.ToArray(), TestContext.Current.CancellationToken);
+        capture.Complete("reviewed-stream-replayed");
+        await capture.SaveAsync(Path.Combine(directory, "transcript.json"), new
+        {
+            provenance = "explicit external reduced stream; inspect its reduction manifest for transformations",
+            inputName = Path.GetFileName(path),
+            inputSha256 = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(bytes)),
+            replayChunkSize = 997,
+            addedMarker = "cursor move and text on last row to establish processing boundary",
+            images = snapshot.KgpImages.Count,
+            placements = snapshot.KgpPlacements.Count,
+            virtualPlacements = terminal.KgpVirtualPlacementCount,
+            imageData = snapshot.KgpImages.Values.Select(image => new
+            {
+                image.ImageId, image.Width, image.Height, format = image.Format.ToString(),
+                length = image.Data.Length,
+                sha256 = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(image.Data))
+            }),
+            replies = Convert.ToBase64String(workload.WrittenInput)
+        }, TestContext.Current.CancellationToken);
+    }
+}

--- a/tests/Hex1b.Tests/Diagnostics/GraphicsStreamReplayTests.cs
+++ b/tests/Hex1b.Tests/Diagnostics/GraphicsStreamReplayTests.cs
@@ -43,11 +43,15 @@ public class GraphicsStreamReplayTests
             images = snapshot.KgpImages.Count,
             placements = snapshot.KgpPlacements.Count,
             virtualPlacements = terminal.KgpVirtualPlacementCount,
-            imageData = snapshot.KgpImages.Values.Select(image => new
+            imageData = snapshot.KgpImages.Values.Select(image =>
             {
-                image.ImageId, image.Width, image.Height, format = image.Format.ToString(),
-                length = image.Data.Length,
-                sha256 = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(image.Data))
+                var data = image.Data;
+                return new
+                {
+                    image.ImageId, image.Width, image.Height, format = image.Format.ToString(),
+                    length = data.Length,
+                    sha256 = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(data))
+                };
             }),
             replies = Convert.ToBase64String(workload.WrittenInput)
         }, TestContext.Current.CancellationToken);

--- a/tests/Hex1b.Tests/Diagnostics/ProteinViewInvestigationTests.cs
+++ b/tests/Hex1b.Tests/Diagnostics/ProteinViewInvestigationTests.cs
@@ -1,0 +1,172 @@
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace Hex1b.Tests.Diagnostics;
+
+[TestClass]
+[DoNotParallelize]
+public class ProteinViewInvestigationTests
+{
+    [TestMethod]
+    [DataRow("plain", false, false)]
+    [DataRow("braille", false, false)]
+    [DataRow("fullhd", false, false)]
+    [DataRow("toggle", false, false)]
+    [DataRow("fullhd", true, false)]
+    [DataRow("fullhd", false, true)]
+    public async Task Capture_ExplicitApplicationRun_PreservesDuplexEvidence(string mode, bool normalizedEnvironment, bool direct)
+    {
+        var executable = Environment.GetEnvironmentVariable("HEX1B_PROTEINVIEW_EXECUTABLE");
+        var model = Environment.GetEnvironmentVariable("HEX1B_PROTEINVIEW_MODEL");
+        var root = Environment.GetEnvironmentVariable("HEX1B_GRAPHICS_EVIDENCE");
+        if (string.IsNullOrEmpty(executable) || string.IsNullOrEmpty(model) || string.IsNullOrEmpty(root))
+            Assert.Inconclusive("Opt-in: set HEX1B_PROTEINVIEW_EXECUTABLE, HEX1B_PROTEINVIEW_MODEL and HEX1B_GRAPHICS_EVIDENCE.");
+        Assert.IsTrue(File.Exists(executable), "Explicit ProteinView executable must exist.");
+        Assert.IsTrue(File.Exists(model), "Explicit local model must exist.");
+        if (!OperatingSystem.IsMacOS() && !OperatingSystem.IsLinux())
+        {
+            Assert.Inconclusive("This initial real-PTY investigation runner is Unix-only.");
+            return;
+        }
+
+        var directory = Path.Combine(root, $"{mode}-{(normalizedEnvironment ? "normalized" : "observed")}-{(direct ? "direct" : "producer")}");
+        Assert.IsFalse(Directory.Exists(directory), "Choose a new evidence directory; never overwrite a capture.");
+        Directory.CreateDirectory(directory, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        var environment = LaunchEnvironment(normalizedEnvironment);
+        var logPath = Path.Combine(directory, "proteinview.log");
+        var arguments = new[] { Path.GetFullPath(model), "--log", logPath }
+            .Concat(mode == "plain" ? [] : mode == "fullhd" ? ["--fullhd"] : new[] { "--render", "braille" })
+            .ToArray();
+        using var deadline = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        deadline.CancelAfter(TimeSpan.FromSeconds(20));
+        await using var child = new Hex1bTerminalChildProcess(Path.GetFullPath(executable), arguments,
+            workingDirectory: directory, environment: environment, inheritEnvironment: false,
+            initialWidth: 80, initialHeight: 24);
+        await using var capture = new DuplexPtyCapture(child, 64 * 1024 * 1024, 100000);
+        using var stopped = CancellationTokenSource.CreateLinkedTokenSource(deadline.Token, capture.FailureToken);
+        await using var producer = new Hmp1PresentationAdapter(80, 24);
+        await using var directPresentation = new Hwt1PresentationAdapter(80, 24);
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(capture).WithPresentation(direct ? directPresentation : producer).WithDimensions(80, 24).Build();
+        await using var presentation = direct
+            ? directPresentation
+            : await producer.CreateBrowserViewAsync("ProteinView investigation", stopped.Token);
+        var observations = new List<object>();
+        var completed = false;
+        try
+        {
+            await child.StartAsync(stopped.Token);
+            await ObserveAsync(mode == "toggle" ? "before-M" : mode);
+            if (mode == "toggle")
+            {
+                await terminal.SendInputAsync("M"u8.ToArray(), stopped.Token);
+                await ObserveAsync("after-M");
+            }
+            await terminal.SendInputAsync("q"u8.ToArray(), stopped.Token);
+            var exitCode = await child.WaitForExitAsync(stopped.Token);
+            Assert.AreEqual(0, exitCode, "ProteinView must exit normally; inspect log and transcript on failure.");
+            // A read pending at exit must finish before the capture is declared complete.
+            using var drain = CancellationTokenSource.CreateLinkedTokenSource(stopped.Token);
+            drain.CancelAfter(TimeSpan.FromSeconds(2));
+            while (!capture.Records.Any(record => record.Kind == "output" && record.Data.Length == 0))
+                await Task.Delay(10, drain.Token);
+            capture.Complete("application-exited-and-output-drained");
+            completed = true;
+        }
+        finally
+        {
+            try
+            {
+                if (child.HasStarted && !child.HasExited)
+                {
+                    child.Kill();
+                    using var exitTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+                    await child.WaitForExitAsync(exitTimeout.Token);
+                }
+            }
+            finally
+            {
+                try { await terminal.DisposeAsync(); }
+                finally
+                {
+                    await capture.SaveAsync(Path.Combine(directory, "transcript.json"), new
+                    {
+                        provenance = "real ProteinView process; verify requested baseline using executable hash, not the unknown reporter environment",
+                        requestedBaselineRevision = "9b9a0790bc78f1d2a7c0923905049d27c67c05e2",
+                        hexAssembly = typeof(Hex1bTerminal).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion,
+                        executableHash = Hash(executable),
+                        modelName = Path.GetFileName(model), modelHash = Hash(model),
+                        arguments, environment, normalizedEnvironment,
+                        operatingSystem = System.Runtime.InteropServices.RuntimeInformation.OSDescription,
+                        topology = direct ? "direct HWT1" : "HMP1 producer-backed HWT1 (web demo default)",
+                        columns = 80, rows = 24, cellPixelWidth = 10, cellPixelHeight = 20,
+                        ptyPixelFields = "not independently queried; inspect CSI16 reply for effective protocol geometry",
+                        deadlineSeconds = 20, maximumBytes = 64 * 1024 * 1024, maximumEvents = 100000,
+                        completed, child.HasExited, exitCode = child.HasExited ? (int?)child.ExitCode : null,
+                        observations
+                    }, CancellationToken.None);
+                }
+            }
+        }
+
+        async Task ObserveAsync(string phase)
+        {
+            // This is an explicit sampling window, not a wait-for-render correctness assertion.
+            await Task.Delay(TimeSpan.FromSeconds(4), stopped.Token);
+            var frame = await presentation.ReadFrameAsync(stopped.Token);
+            using var metadata = ProteinViewGraphicsStreamTests.Metadata(frame);
+            using var snapshot = terminal.CreateSnapshot();
+            await File.WriteAllBytesAsync(Path.Combine(directory, $"{phase}.hwt"), frame.ToArray(), stopped.Token);
+            await File.WriteAllTextAsync(Path.Combine(directory, $"{phase}.txt"),
+                string.Join('\n', Enumerable.Range(0, snapshot.Height).Select(snapshot.GetLine)), stopped.Token);
+            observations.Add(new
+            {
+                phase,
+                images = snapshot.KgpImages.Count,
+                placements = snapshot.KgpPlacements.Count,
+                virtualPlacements = terminal.KgpVirtualPlacementCount,
+                sixelPlacements = snapshot.SixelPlacements.Count,
+                hwt = metadata.RootElement.Clone()
+            });
+            await presentation.HandleMessageAsync(Encoding.UTF8.GetBytes(
+                $$"""{"type":"ack","revision":{{metadata.RootElement.GetProperty("revision").GetUInt32()}}}"""), stopped.Token);
+        }
+    }
+
+    private static Dictionary<string, string> LaunchEnvironment(bool normalized)
+    {
+        var environment = new Dictionary<string, string>
+        {
+            ["TERM"] = Environment.GetEnvironmentVariable("TERM") ?? "xterm-256color",
+            ["COLORTERM"] = Environment.GetEnvironmentVariable("COLORTERM") ?? "truecolor",
+            ["LANG"] = "en_US.UTF-8"
+        };
+        if (!normalized)
+        {
+            foreach (var key in new[] { "TERM_PROGRAM", "LC_TERMINAL" })
+            {
+                if (Environment.GetEnvironmentVariable(key) is { } value)
+                    environment[key] = value;
+            }
+            foreach (var key in new[] { "SSH_CLIENT", "SSH_TTY", "SSH_CONNECTION", "KITTY_WINDOW_ID", "ITERM_SESSION_ID", "WEZTERM_EXECUTABLE" })
+            {
+                if (Environment.GetEnvironmentVariable(key) is not null)
+                    environment[key] = "present";
+            }
+        }
+        else
+            environment["TERM"] = "xterm-256color";
+        if (environment["TERM"].StartsWith("tmux", StringComparison.Ordinal) ||
+            environment.GetValueOrDefault("TERM_PROGRAM") == "tmux")
+            Assert.Inconclusive("Do not run this capture under tmux; upstream changes its passthrough setting.");
+        return environment;
+    }
+
+    private static string Hash(string path)
+    {
+        using var stream = File.OpenRead(path);
+        return Convert.ToHexString(SHA256.HashData(stream));
+    }
+}

--- a/tests/Hex1b.Tests/Diagnostics/ProteinViewInvestigationTests.cs
+++ b/tests/Hex1b.Tests/Diagnostics/ProteinViewInvestigationTests.cs
@@ -135,6 +135,194 @@ public class ProteinViewInvestigationTests
         }
     }
 
+    [TestMethod]
+    public async Task Capture_ExplicitSustainedRun_BoundsCurrentOwnersAcrossRotation()
+    {
+        var executable = Environment.GetEnvironmentVariable("HEX1B_PROTEINVIEW_EXECUTABLE");
+        var model = Environment.GetEnvironmentVariable("HEX1B_PROTEINVIEW_MODEL");
+        var root = Environment.GetEnvironmentVariable("HEX1B_GRAPHICS_SUSTAINED_EVIDENCE");
+        if (string.IsNullOrEmpty(executable) || string.IsNullOrEmpty(model) || string.IsNullOrEmpty(root))
+            Assert.Inconclusive("Opt-in: set HEX1B_PROTEINVIEW_EXECUTABLE, HEX1B_PROTEINVIEW_MODEL and HEX1B_GRAPHICS_SUSTAINED_EVIDENCE.");
+        Assert.IsTrue(File.Exists(executable));
+        Assert.IsTrue(File.Exists(model));
+        if (!OperatingSystem.IsMacOS() && !OperatingSystem.IsLinux())
+        {
+            Assert.Inconclusive("The real-PTY runner requires Unix.");
+            return;
+        }
+
+        var acknowledgementIntervalMs = 0;
+        if (Environment.GetEnvironmentVariable("HEX1B_GRAPHICS_ACK_INTERVAL_MS") is { } interval)
+            Assert.IsTrue(int.TryParse(interval, out acknowledgementIntervalMs) &&
+                acknowledgementIntervalMs is >= 0 and <= 1000, "ACK interval must be 0..1000 milliseconds.");
+        Assert.IsFalse(Directory.Exists(root), "Use a new private evidence directory.");
+        Directory.CreateDirectory(root, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        var environment = LaunchEnvironment(normalized: true);
+        var arguments = new[] { Path.GetFullPath(model), "--fullhd", "--log", Path.Combine(root, "proteinview.log") };
+        using var deadline = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        deadline.CancelAfter(TimeSpan.FromSeconds(60));
+        await using var child = new Hex1bTerminalChildProcess(Path.GetFullPath(executable), arguments,
+            workingDirectory: root, environment: environment, inheritEnvironment: false,
+            initialWidth: 80, initialHeight: 24);
+        await using var capture = new DuplexPtyCapture(child, 64 * 1024 * 1024, 100000);
+        using var stopped = CancellationTokenSource.CreateLinkedTokenSource(deadline.Token, capture.FailureToken);
+        await using var producer = new Hmp1PresentationAdapter(80, 24);
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(capture).WithPresentation(producer).WithDimensions(80, 24).Build();
+        await using var presentation = await producer.CreateBrowserViewAsync("Sustained ProteinView", stopped.Token);
+        var generations = new HashSet<string>(StringComparer.Ordinal);
+        var observations = new List<object>();
+        var frames = 0;
+        var completed = false;
+        var allocationStart = GC.GetTotalAllocatedBytes();
+        long rotationAllocations = 0;
+        KgpImageData? observedImage = null;
+        long previousMaterializations = 0;
+        long observedMaterializations = 0;
+        long observedMaterializedBytes = 0;
+        long rotationMaterializedBytes = 0;
+        var observedVersions = 0;
+        try
+        {
+            await child.StartAsync(stopped.Token);
+            await new Hex1bTerminalInputSequenceBuilder()
+                .WaitUntil(s => s.KgpImages.Count == 1, TimeSpan.FromSeconds(10), "initial actual compressed image")
+                .Build().ApplyAsync(terminal, stopped.Token);
+            using var initial = terminal.CreateSnapshot();
+            var first = TestSeq.Single(initial.KgpImages.Values);
+            Assert.IsTrue(first.IsZlibCompressed);
+            var initialHash = Convert.ToHexString(first.ContentHash);
+            var initialPixels = first.Data;
+            Assert.AreEqual(initialHash, Convert.ToHexString(SHA256.HashData(initialPixels)));
+            await RecordFrameAsync("initial");
+            await terminal.SendInputAsync(" "u8.ToArray(), stopped.Token);
+
+            while (generations.Count < 200)
+                await RecordFrameAsync(generations.Count == 100 ? "rotation" : null);
+
+            ObserveMaterializations();
+            rotationAllocations = GC.GetTotalAllocatedBytes() - allocationStart;
+            rotationMaterializedBytes = observedMaterializedBytes;
+            await terminal.SendInputAsync(" r"u8.ToArray(), stopped.Token);
+            await new Hex1bTerminalInputSequenceBuilder()
+                .WaitUntil(s => s.KgpImages.Values.Any(image =>
+                    Convert.ToHexString(image.ContentHash) == initialHash),
+                    TimeSpan.FromSeconds(10), "paused camera reset to exact initial pixels")
+                .Build().ApplyAsync(terminal, stopped.Token);
+            using (var reset = terminal.CreateSnapshot())
+                CollectionAssert.AreEqual(initialPixels, TestSeq.Single(reset.KgpImages.Values).Data);
+            await RecordFrameAsync("reset");
+            ObserveMaterializations();
+            Assert.IsTrue(generations.Count >= 200);
+
+            await terminal.SendInputAsync("q"u8.ToArray(), stopped.Token);
+            Assert.AreEqual(0, await child.WaitForExitAsync(stopped.Token));
+            using var drain = CancellationTokenSource.CreateLinkedTokenSource(stopped.Token);
+            drain.CancelAfter(TimeSpan.FromSeconds(2));
+            while (!capture.Records.Any(record => record.Kind == "output" && record.Data.Length == 0))
+                await Task.Delay(10, drain.Token);
+            capture.Complete("sustained-application-exited-and-output-drained");
+            completed = true;
+        }
+        finally
+        {
+            try
+            {
+                if (child.HasStarted && !child.HasExited)
+                {
+                    child.Kill();
+                    using var exitTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+                    await child.WaitForExitAsync(exitTimeout.Token);
+                }
+            }
+            finally
+            {
+                try { await terminal.DisposeAsync(); }
+                finally
+                {
+                    await capture.SaveAsync(Path.Combine(root, "transcript.json"), new
+                    {
+                        provenance = "real unmodified ProteinView; server-side producer/HWT1 ownership run, not browser presentation counts",
+                        requestedBaselineRevision = "9b9a0790bc78f1d2a7c0923905049d27c67c05e2",
+                        executableHash = Hash(executable), modelHash = Hash(model), arguments, environment,
+                        deadlineSeconds = 60, maximumBytes = 64 * 1024 * 1024, maximumEvents = 100000,
+                        observedDistinctAcceptedGenerations = generations.Count,
+                        hwtFramesReadAndAcknowledged = frames,
+                        acknowledgementIntervalMs,
+                        completed,
+                        rotationAllocationBytesIncludingCaptureAndProjection = rotationAllocations,
+                        rotationMaterializedFormatBytesObserved = rotationMaterializedBytes,
+                        observedImageVersions = observedVersions,
+                        successfulDataReadsObserved = observedMaterializations,
+                        materializedFormatBytesObserved = observedMaterializedBytes,
+                        note = "Generations sampled from atomic terminal snapshots; source uploads can exceed observations. Current store gauges are sampled independently during rotation. The initial snapshot, one decoded array, and only the last observed image for counter deltas remain caller-owned; no per-generation image registry is retained.",
+                        actualBytesAfterTerminalDisposal = terminal.KgpImageStore.TotalSize,
+                        reservedBytesAfterTerminalDisposal = terminal.KgpImageStore.ReservedDecodedBytes,
+                        observations
+                    }, CancellationToken.None);
+                }
+            }
+        }
+
+        Assert.IsTrue(completed);
+        Assert.AreEqual(0L, terminal.KgpImageStore.ChargedSize);
+
+        async Task RecordFrameAsync(string? name)
+        {
+            var frame = await presentation.ReadFrameAsync(stopped.Token);
+            using var metadata = ProteinViewGraphicsStreamTests.Metadata(frame);
+            using var snapshot = terminal.CreateSnapshot();
+            frames++;
+            if (snapshot.KgpImages.Count > 0)
+            {
+                var image = TestSeq.Single(snapshot.KgpImages.Values);
+                Assert.IsTrue(image.IsZlibCompressed);
+                if (!ReferenceEquals(observedImage, image))
+                {
+                    ObserveMaterializations();
+                    observedImage = image;
+                    previousMaterializations = 0;
+                    observedVersions++;
+                }
+                ObserveMaterializations();
+                var hash = Convert.ToHexString(image.ContentHash);
+                if (generations.Add(hash))
+                {
+                    observations.Add(new
+                    {
+                        generation = generations.Count, hash, image.Width, image.Height,
+                        snapshotEncodedBytes = image.EncodedData.Length,
+                        snapshotReservedBytes = image.ReservedDecodedBytes,
+                        currentStoreActualBytes = terminal.KgpImageStore.TotalSize,
+                        currentStoreReservedBytes = terminal.KgpImageStore.ReservedDecodedBytes,
+                        currentStoreChargedBytes = terminal.KgpImageStore.ChargedSize,
+                        frameBytes = frame.Length
+                    });
+                }
+                Assert.IsTrue(terminal.KgpImageStore.ImageCount <= 1);
+                Assert.IsTrue(terminal.KgpImageStore.ChargedSize <= 320L * 1024 * 1024);
+            }
+            if (name is not null && !File.Exists(Path.Combine(root, $"{name}.hwt")))
+                await File.WriteAllBytesAsync(Path.Combine(root, $"{name}.hwt"), frame.ToArray(), stopped.Token);
+            // Explicit presentation pacing for allocation comparisons, not a render-readiness delay.
+            if (acknowledgementIntervalMs != 0)
+                await Task.Delay(acknowledgementIntervalMs, stopped.Token);
+            await presentation.HandleMessageAsync(Encoding.UTF8.GetBytes(
+                $$"""{"type":"ack","revision":{{metadata.RootElement.GetProperty("revision").GetUInt32()}}}"""), stopped.Token);
+        }
+
+        void ObserveMaterializations()
+        {
+            if (observedImage is null)
+                return;
+            var count = observedImage.MaterializationCount;
+            var delta = count - previousMaterializations;
+            observedMaterializations = checked(observedMaterializations + delta);
+            observedMaterializedBytes = checked(observedMaterializedBytes + delta * observedImage.ReservedDecodedBytes);
+            previousMaterializations = count;
+        }
+    }
+
     private static Dictionary<string, string> LaunchEnvironment(bool normalized)
     {
         var environment = new Dictionary<string, string>

--- a/tests/Hex1b.Tests/Hmp1/Hmp1GraphicsLifetimeTests.cs
+++ b/tests/Hex1b.Tests/Hmp1/Hmp1GraphicsLifetimeTests.cs
@@ -1,0 +1,70 @@
+using System.Reflection;
+using System.Threading.Channels;
+
+namespace Hex1b.Tests.Hmp1;
+
+[TestClass]
+public class Hmp1GraphicsLifetimeTests
+{
+    [TestMethod]
+    public async Task DisposeAsync_RetainedPresentation_DropsProducerAndInputQueue()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var adapter = new Hmp1PresentationAdapter();
+        await using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload)
+            .WithPresentation(adapter).Build();
+        var channel = (Channel<ReadOnlyMemory<byte>>)typeof(Hmp1PresentationAdapter)
+            .GetField("_inputChannel", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(adapter)!;
+        Assert.IsTrue(channel.Writer.TryWrite(new byte[1024 * 1024]));
+
+        await adapter.DisposeAsync();
+
+        Assert.AreEqual(0, channel.Reader.Count);
+        foreach (var name in new[] { "_terminal", "Resized", "Disconnected" })
+            Assert.IsNull(typeof(Hmp1PresentationAdapter)
+                .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(adapter), name);
+        GC.KeepAlive(adapter);
+    }
+
+    [TestMethod]
+    public async Task RemoveSessionAsync_BeforeReplayPumpStarts_DropsQueuedSnapshotsAndPayloads()
+    {
+        await using var adapter = new Hmp1PresentationAdapter();
+        var session = new Hmp1PresentationAdapter.Hmp1ClientSession(
+            new MemoryStream(), new CancellationTokenSource(), "pending", null, null);
+        var image = new KgpImageData(1, 0, new byte[1024 * 1024], 512, 512, KgpFormat.Rgba32);
+        var images = new Dictionary<uint, KgpImageData> { [1] = image };
+        Assert.IsTrue(session.OutputChannel.Writer.TryWrite(new(default, stream =>
+            Hmp1KgpStateReplay.WriteAsync(stream, [], images, 0, 0, session.Cts.Token))));
+        Assert.IsTrue(session.OutputChannel.Writer.TryWrite(new(new byte[1024 * 1024], null)));
+        Assert.AreEqual(2, session.OutputChannel.Reader.Count);
+
+        await adapter.RemoveSessionAsync(session);
+
+        Assert.AreEqual(0, session.OutputChannel.Reader.Count,
+            "Completing a channel alone leaves its graphics snapshots and buffers retained.");
+        Assert.IsFalse(session.OutputChannel.Writer.TryWrite(new(new byte[1], null)));
+        Assert.AreEqual(1, session.Disposed);
+        GC.KeepAlive(session);
+    }
+
+    [TestMethod]
+    public async Task DisposeAsync_UnreadWorkloadFrames_DropsBuffersWhileAdapterRemainsReferenced()
+    {
+        await using var adapter = new Hmp1WorkloadAdapter(new Hmp1ClientOptions
+        {
+            StreamFactory = _ => Task.FromResult(Stream.Null)
+        });
+        var channel = (Channel<Hmp1WorkloadOutput>)typeof(Hmp1WorkloadAdapter)
+            .GetField("_outputChannel", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(adapter)!;
+        Assert.IsTrue(channel.Writer.TryWrite(new(new byte[1024 * 1024])));
+        Assert.IsTrue(channel.Writer.TryWrite(new(new byte[1024 * 1024])));
+        Assert.AreEqual(2, channel.Reader.Count);
+
+        await adapter.DisposeAsync();
+
+        Assert.AreEqual(0, channel.Reader.Count);
+        Assert.IsFalse(channel.Writer.TryWrite(new(new byte[1])));
+        GC.KeepAlive(adapter);
+    }
+}

--- a/tests/Hex1b.Tests/Hmp1/Hmp1KgpStateReplayTests.cs
+++ b/tests/Hex1b.Tests/Hmp1/Hmp1KgpStateReplayTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using System.IO.Compression;
 using Hex1b.Automation;
 using Hex1b.Tokens;
 using Microsoft.Extensions.Time.Testing;
@@ -10,10 +11,49 @@ namespace Hex1b.Tests.Hmp1;
 public class Hmp1KgpStateReplayTests
 {
     [TestMethod]
-    [DataRow(KgpFormat.Rgb24)]
-    [DataRow(KgpFormat.Rgba32)]
-    [DataRow(KgpFormat.Png)]
-    public async Task WriteAsync_UnplacedResidentImage_PreservesFormatAndLaterPlacement(KgpFormat format)
+    public async Task WriteAsync_CompressedRoot_ChunksEncodedBytesWithMatchingCompressionControl()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var producer = CreateTerminal(workload, TimeProvider.System);
+        var pixels = new byte[1024 * 512 * 4];
+        var encoded = Compress(pixels);
+        Assert.IsGreaterThan(3072, encoded.Length);
+        producer.ApplyTokens(AnsiTokenizer.Tokenize(KgpTestHelper.BuildCommand(
+            "a=T,f=32,s=1024,v=512,o=z,i=7,c=1,r=1,C=1,q=2", encoded)));
+        using var snapshot = producer.CreateSnapshot(includeAllKgpImages: true);
+        Assert.AreEqual(1, snapshot.KgpImages.Count);
+        using var stream = new MemoryStream();
+        await Hmp1KgpStateReplay.WriteAsync(stream, snapshot.KgpPlacements, snapshot.KgpImages,
+            snapshot.CursorX, snapshot.CursorY, TestContext.Current.CancellationToken);
+        Assert.IsLessThan((long)pixels.Length / 8, stream.Length,
+            "Replay must transmit the retained encoded root, not materialized pixels.");
+        stream.Position = 0;
+        using var viewerWorkload = new Hex1bAppWorkloadAdapter();
+        using var viewer = CreateTerminal(viewerWorkload, TimeProvider.System);
+        var wire = new StringBuilder();
+        while (stream.Position < stream.Length)
+        {
+            var frame = (await Hmp1Protocol.ReadFrameAsync(stream, TestContext.Current.CancellationToken))!.Value;
+            Assert.AreEqual(Hmp1FrameType.Output, frame.Type);
+            var ansi = Encoding.UTF8.GetString(frame.Payload.Span);
+            wire.Append(ansi);
+            viewer.ApplyTokens(AnsiTokenizer.Tokenize(ansi));
+        }
+        Assert.Contains(",o=z,m=1;", wire.ToString());
+        var replay = viewer.KgpImageStore.GetImageById(7)!;
+        Assert.IsTrue(replay.IsZlibCompressed);
+        TestSeq.AreEqual(encoded, replay.EncodedData.ToArray());
+        TestSeq.AreEqual(pixels, replay.Data);
+    }
+
+    [TestMethod]
+    [DataRow(KgpFormat.Rgb24, false)]
+    [DataRow(KgpFormat.Rgba32, false)]
+    [DataRow(KgpFormat.Png, false)]
+    [DataRow(KgpFormat.Rgb24, true)]
+    [DataRow(KgpFormat.Rgba32, true)]
+    [DataRow(KgpFormat.Png, true)]
+    public async Task WriteAsync_UnplacedResidentImage_PreservesFormatAndLaterPlacement(KgpFormat format, bool compressed)
     {
         var time = new FakeTimeProvider();
         using var producerWorkload = new Hex1bAppWorkloadAdapter();
@@ -22,8 +62,10 @@ public class Hmp1KgpStateReplayTests
             ? Convert.FromBase64String(
                 "iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAYAAABWKLW/AAAAEUlEQVR4nGP4z8DwH4YZcHIAXdcR79xPMRAAAAAASUVORK5CYII=")
             : Enumerable.Range(0, 3 * 3 * (format == KgpFormat.Rgb24 ? 3 : 4)).Select(i => (byte)i).ToArray();
+        var encoded = compressed ? Compress(pixels) : pixels;
         producer.ApplyTokens(AnsiTokenizer.Tokenize(
-            KgpTestHelper.BuildCommand($"a=t,f={(int)format},s=3,v=3,i=7300,q=2", pixels)));
+            KgpTestHelper.BuildCommand($"a=t,f={(int)format},s=3,v=3,i=7300,q=2" +
+                (compressed ? ",o=z" : ""), encoded)));
         using var source = producer.CreateSnapshot(includeAllKgpImages: true);
         using var viewerWorkload = new Hex1bAppWorkloadAdapter();
         using var viewer = CreateTerminal(viewerWorkload, time);
@@ -40,6 +82,9 @@ public class Hmp1KgpStateReplayTests
         using var replay = viewer.CreateSnapshot();
         Assert.AreEqual(format, replay.KgpImages[7300].Format);
         TestSeq.AreEqual(pixels, replay.KgpImages[7300].Data);
+        Assert.AreEqual(compressed, replay.KgpImages[7300].IsZlibCompressed);
+        if (compressed)
+            TestSeq.AreEqual(encoded, replay.KgpImages[7300].EncodedData.ToArray());
         Assert.AreEqual(7, TestSeq.Single(replay.KgpPlacements).Column);
     }
 
@@ -81,9 +126,11 @@ public class Hmp1KgpStateReplayTests
     }
 
     [TestMethod]
-    [DataRow(false)]
-    [DataRow(true)]
-    public async Task WriteAsync_UnplacedNewerImageNumber_PreservesOlderPlacementAndFutureNumberLookup(bool wrappedIds)
+    [DataRow(false, false)]
+    [DataRow(true, false)]
+    [DataRow(false, true)]
+    [DataRow(true, true)]
+    public async Task WriteAsync_UnplacedNewerImageNumber_PreservesOlderPlacementAndFutureNumberLookup(bool wrappedIds, bool compressed)
     {
         var time = new FakeTimeProvider();
         using var producerWorkload = new Hex1bAppWorkloadAdapter();
@@ -96,9 +143,11 @@ public class Hmp1KgpStateReplayTests
         }
         else
             producer.ApplyTokens(AnsiTokenizer.Tokenize(
-                KgpTestHelper.BuildCommand("a=T,f=32,s=1,v=1,I=42,C=1,q=2", [1, 0, 0, 255])));
+                KgpTestHelper.BuildCommand("a=T,f=32,s=1,v=1,I=42,C=1,q=2" + (compressed ? ",o=z" : ""),
+                    compressed ? Compress([1, 0, 0, 255]) : [1, 0, 0, 255])));
         producer.ApplyTokens(AnsiTokenizer.Tokenize(
-            KgpTestHelper.BuildCommand("a=t,f=32,s=1,v=1,I=42,q=2", [2, 0, 0, 255])));
+            KgpTestHelper.BuildCommand("a=t,f=32,s=1,v=1,I=42,q=2" + (compressed ? ",o=z" : ""),
+                compressed ? Compress([2, 0, 0, 255]) : [2, 0, 0, 255])));
         using var source = producer.CreateSnapshot(includeAllKgpImages: true);
         using var viewerWorkload = new Hex1bAppWorkloadAdapter();
         using var viewer = CreateTerminal(viewerWorkload, time);
@@ -198,7 +247,9 @@ public class Hmp1KgpStateReplayTests
     }
 
     [TestMethod]
-    public async Task WriteAsync_ComposedAnimation_PreservesAllFramesGapsAndStoppedCurrentFrame()
+    [DataRow(false)]
+    [DataRow(true)]
+    public async Task WriteAsync_ComposedAnimation_PreservesAllFramesGapsAndStoppedCurrentFrame(bool compressed)
     {
         var time = new FakeTimeProvider();
         using var producerWorkload = new Hex1bAppWorkloadAdapter();
@@ -206,7 +257,8 @@ public class Hmp1KgpStateReplayTests
         var root = Enumerable.Range(0, 40 * 30).SelectMany(_ => new byte[] { 80, 40, 20 }).ToArray();
         producer.ApplyTokens(AnsiTokenizer.Tokenize(
             "\x1b[3;5H" +
-            KgpTestHelper.BuildCommand("a=T,f=24,s=40,v=30,i=7,p=11,X=9,Y=19,C=1,q=2", root) +
+            KgpTestHelper.BuildCommand("a=T,f=24,s=40,v=30,i=7,p=11,X=9,Y=19,C=1,q=2" +
+                (compressed ? ",o=z" : ""), compressed ? Compress(root) : root) +
             KgpTestHelper.BuildCommand("a=f,f=32,s=1,v=1,i=7,c=1,x=2,y=3,z=30,q=2", [200, 100, 50, 128]) +
             KgpTestHelper.BuildCommand("a=f,f=32,s=1,v=1,i=7,x=1,y=1,X=1,z=-1,q=2", [17, 34, 51, 0]) +
             KgpTestHelper.BuildCommand("a=f,f=32,s=40,v=30,i=7,X=1,z=45,q=2", KgpTestHelper.CreatePixelData(40, 30)) +
@@ -341,6 +393,14 @@ public class Hmp1KgpStateReplayTests
         viewerTime.Advance(TimeSpan.FromSeconds(10));
         Assert.AreEqual(2, viewer.KgpImageStore.GetImageById(7)!.CurrentFrameNumber);
         TestSeq.AreEqual(new byte[] { 2, 0, 0, 255 }, viewer.KgpImageStore.GetImageById(7)!.CurrentFrameData);
+    }
+
+    private static byte[] Compress(byte[] data)
+    {
+        using var output = new MemoryStream();
+        using (var zlib = new ZLibStream(output, CompressionLevel.Fastest, leaveOpen: true))
+            zlib.Write(data);
+        return output.ToArray();
     }
 
     private static Hex1bTerminal CreateTerminal(Hex1bAppWorkloadAdapter workload, TimeProvider time)

--- a/tests/Hex1b.Tests/Hwt1Hmp1IntegrationTests.cs
+++ b/tests/Hex1b.Tests/Hwt1Hmp1IntegrationTests.cs
@@ -109,12 +109,16 @@ public class Hwt1Hmp1IntegrationTests
     }
 
     [TestMethod]
-    [DataRow(false, false)]
-    [DataRow(false, true)]
-    [DataRow(true, false)]
-    [DataRow(true, true)]
+    [DataRow(false, false, false)]
+    [DataRow(false, true, false)]
+    [DataRow(true, false, false)]
+    [DataRow(true, true, false)]
+    [DataRow(false, false, true)]
+    [DataRow(false, true, true)]
+    [DataRow(true, false, true)]
+    [DataRow(true, true, true)]
     public async Task LateAttachment_DuringKgpPlacementReplacement_RetainsUnusedPalette(
-        bool alternateScreen, bool keepPlacement)
+        bool alternateScreen, bool keepPlacement, bool compressed)
     {
         using var workload = new Hex1bAppWorkloadAdapter();
         await using var server = new Hmp1PresentationAdapter(20, 10);
@@ -134,9 +138,12 @@ public class Hwt1Hmp1IntegrationTests
             .WithPresentation(firstView).Build();
         var red = Enumerable.Range(0, 9).SelectMany(_ => new byte[] { 255, 0, 0, 255 }).ToArray();
         var green = Enumerable.Range(0, 9).SelectMany(_ => new byte[] { 0, 255, 0, 255 }).ToArray();
+        var encodedRed = compressed ? Compress(red) : red;
+        var encodedGreen = compressed ? Compress(green) : green;
+        var compression = compressed ? ",o=z" : "";
         workload.Write((alternateScreen ? "\x1b[?1049h" : "") + "\x1b[?2026h" +
-            KgpTestHelper.BuildCommand("a=t,f=32,s=3,v=3,i=7300,q=2", red) +
-            KgpTestHelper.BuildCommand("a=t,f=32,s=3,v=3,i=7301,q=2", green) +
+            KgpTestHelper.BuildCommand("a=t,f=32,s=3,v=3,i=7300,q=2" + compression, encodedRed) +
+            KgpTestHelper.BuildCommand("a=t,f=32,s=3,v=3,i=7301,q=2" + compression, encodedGreen) +
             "\x1b[2;3H" + KgpTestHelper.BuildCommand("a=p,i=7300,C=1,q=2") +
             "\x1b[4;3H" + KgpTestHelper.BuildCommand("a=p,i=7301,C=1,q=2") + "\x1b[?2026l");
         await ReadUntilAsync(firstView, frame => frame.GetProperty("placements").GetArrayLength() == 2);
@@ -172,6 +179,13 @@ public class Hwt1Hmp1IntegrationTests
         Assert.AreEqual(alternateScreen, actual.InAlternateScreen);
         TestSeq.AreEqual(red, actual.KgpImages[7300].Data);
         TestSeq.AreEqual(green, actual.KgpImages[7301].Data);
+        Assert.AreEqual(compressed, actual.KgpImages[7300].IsZlibCompressed);
+        Assert.AreEqual(compressed, actual.KgpImages[7301].IsZlibCompressed);
+        if (compressed)
+        {
+            TestSeq.AreEqual(encodedRed, actual.KgpImages[7300].EncodedData.ToArray());
+            TestSeq.AreEqual(encodedGreen, actual.KgpImages[7301].EncodedData.ToArray());
+        }
         foreach (var placement in actual.KgpPlacements)
         {
             Assert.AreEqual(7, placement.Column);
@@ -180,6 +194,58 @@ public class Hwt1Hmp1IntegrationTests
             Assert.IsTrue(placement.UsesNativeSize);
         }
         await ReadUntilAsync(lateView, frame => frame.GetProperty("placements").GetArrayLength() == 2);
+    }
+
+    [TestMethod]
+    public async Task ProducerBackedView_ReplacementsAndReconnect_SendCurrentResourcesAsIndependentBaselines()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var server = new Hmp1PresentationAdapter(20, 10);
+        await using var producer = Hex1bTerminal.CreateBuilder().WithWorkload(workload)
+            .WithPresentation(server).WithDimensions(20, 10).Build();
+        producer.ApplyTokens(AnsiTokenizer.Tokenize(KgpTestHelper.BuildCommand(
+            "a=T,f=32,s=1,v=1,o=z,i=1,C=1,q=2", Compress([1, 0, 0, 255]))));
+        await using var first = await server.CreateBrowserViewAsync("first");
+        var firstBytes = await first.ReadFrameAsync();
+        var firstCopy = firstBytes.ToArray();
+        await first.HandleMessageAsync("""{"type":"ack","revision":1}"""u8.ToArray());
+        for (var generation = 2; generation <= 65; generation++)
+            producer.ApplyTokens(AnsiTokenizer.Tokenize(KgpTestHelper.BuildCommand(
+                "a=T,f=32,s=1,v=1,o=z,i=1,C=1,q=2", Compress([(byte)generation, 0, 0, 255]))));
+        var latest = await first.ReadFrameAsync();
+        using (var metadata = JsonDocument.Parse(latest.Slice(8, BinaryPrimitives.ReadInt32LittleEndian(latest.Span[4..]))))
+            Assert.AreEqual(1, metadata.RootElement.GetProperty("retainedImages").GetArrayLength());
+        TestSeq.AreEqual(new byte[] { 65, 0, 0, 255 }, latest.Span[^4..].ToArray());
+
+        await using var late = await server.CreateBrowserViewAsync("late");
+        var lateBytes = await late.ReadFrameAsync();
+        TestSeq.AreEqual(new byte[] { 65, 0, 0, 255 }, lateBytes.Span[^4..].ToArray());
+        await first.DisposeAsync();
+        TestSeq.AreEqual(firstCopy, firstBytes.ToArray());
+        for (var reconnect = 0; reconnect < 5; reconnect++)
+        {
+            await using var fresh = await server.CreateBrowserViewAsync($"reconnect-{reconnect}");
+            var bytes = await fresh.ReadFrameAsync();
+            using var metadata = JsonDocument.Parse(bytes.Slice(8, BinaryPrimitives.ReadInt32LittleEndian(bytes.Span[4..])));
+            Assert.IsTrue(metadata.RootElement.GetProperty("full").GetBoolean());
+            Assert.AreEqual(1, metadata.RootElement.GetProperty("images").GetArrayLength());
+            Assert.AreEqual(1, metadata.RootElement.GetProperty("retainedImages").GetArrayLength());
+            TestSeq.AreEqual(new byte[] { 65, 0, 0, 255 }, bytes.Span[^4..].ToArray());
+        }
+        producer.ApplyTokens(AnsiTokenizer.Tokenize(KgpTestHelper.BuildCommand("a=d,d=I,i=1,q=2")));
+        await late.HandleMessageAsync("""{"type":"ack","revision":1}"""u8.ToArray());
+        var empty = await late.ReadFrameAsync();
+        using var emptyMetadata = JsonDocument.Parse(empty.Slice(8, BinaryPrimitives.ReadInt32LittleEndian(empty.Span[4..])));
+        Assert.AreEqual(0, emptyMetadata.RootElement.GetProperty("retainedImages").GetArrayLength());
+    }
+
+    private static byte[] Compress(byte[] data)
+    {
+        using var output = new MemoryStream();
+        using (var zlib = new System.IO.Compression.ZLibStream(output,
+            System.IO.Compression.CompressionLevel.Fastest, leaveOpen: true))
+            zlib.Write(data);
+        return output.ToArray();
     }
 
     [TestMethod]

--- a/tests/Hex1b.Tests/Hwt1PresentationAdapterTests.cs
+++ b/tests/Hex1b.Tests/Hwt1PresentationAdapterTests.cs
@@ -11,6 +11,81 @@ namespace Hex1b.Tests;
 public class Hwt1PresentationAdapterTests
 {
     [TestMethod]
+    public async Task ReadFrameAsync_ReplacementAndDeletion_WaitForAckBeforePruningPreviousFrameResources()
+    {
+        await using var presentation = new Hwt1PresentationAdapter(20, 10);
+        await using var terminal = CreateTerminal(presentation, new RecordingWorkload());
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize(
+            KgpTestHelper.BuildCommand("a=T,f=32,s=1,v=1,i=1,C=1,q=2", [1, 0, 0, 255])));
+        var first = await presentation.ReadFrameAsync();
+        var firstCopy = first.ToArray();
+        using var firstMetadata = ReadMetadata(first);
+        var firstKey = firstMetadata.RootElement.GetProperty("retainedImages")[0].GetString()!;
+        var projection = (Hwt1RenderProjection)typeof(Hwt1PresentationAdapter)
+            .GetField("_projection", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .GetValue(presentation)!;
+        var images = (System.Collections.IDictionary)typeof(Hwt1RenderProjection)
+            .GetField("_images", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .GetValue(projection)!;
+        var next = presentation.ReadFrameAsync().AsTask();
+        for (var generation = 2; generation <= 65; generation++)
+            terminal.ApplyTokens(AnsiTokenizer.Tokenize(KgpTestHelper.BuildCommand(
+                "a=T,f=32,s=1,v=1,i=1,C=1,q=2", [(byte)generation, 0, 0, 255])));
+
+        Assert.IsFalse(next.IsCompleted);
+        Assert.AreEqual(1, projection.RetainedImageCount);
+        Assert.IsTrue(images.Contains(firstKey), "The outstanding frame still owns its resource until acknowledgement.");
+        await presentation.HandleMessageAsync("""{"type":"ack","revision":1}"""u8.ToArray());
+        var latest = await next.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+        var latestCopy = latest.ToArray();
+        using var latestMetadata = ReadMetadata(latest);
+        Assert.AreEqual(1, latestMetadata.RootElement.GetProperty("retainedImages").GetArrayLength());
+        Assert.IsFalse(images.Contains(firstKey));
+        TestSeq.AreEqual(new byte[] { 65, 0, 0, 255 }, latest.Span[^4..].ToArray());
+
+        var deletion = presentation.ReadFrameAsync().AsTask();
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize(KgpTestHelper.BuildCommand("a=d,d=I,i=1,q=2")));
+        Assert.IsFalse(deletion.IsCompleted);
+        Assert.AreEqual(1, projection.RetainedImageCount, "Deletion must not prune an outstanding frame before its ACK.");
+        await presentation.HandleMessageAsync("""{"type":"ack","revision":2}"""u8.ToArray());
+        using var deleted = ReadMetadata(await deletion.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken));
+        Assert.AreEqual(0, deleted.RootElement.GetProperty("retainedImages").GetArrayLength());
+        Assert.AreEqual(0L, projection.RetainedImageBytes);
+        await presentation.DisposeAsync();
+        TestSeq.AreEqual(firstCopy, first.ToArray());
+        TestSeq.AreEqual(latestCopy, latest.ToArray());
+    }
+
+    [TestMethod]
+    public async Task DisposeAsync_RetainedAdapter_ReleasesProjectedImagesButPreservesReturnedFrame()
+    {
+        await using var presentation = new Hwt1PresentationAdapter(20, 10);
+        await using var terminal = CreateTerminal(presentation, new RecordingWorkload());
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize(
+            "\x1b_Ga=T,f=32,s=1,v=1,i=1,p=1,C=1,q=2;/wAA/w==\x1b\\"));
+        var frame = await presentation.ReadFrameAsync();
+        var original = frame.ToArray();
+        var projection = (Hwt1RenderProjection)typeof(Hwt1PresentationAdapter)
+            .GetField("_projection", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .GetValue(presentation)!;
+        Assert.AreEqual(1, projection.RetainedImageCount);
+        Assert.AreEqual(4L, projection.RetainedImageBytes);
+        var pending = presentation.ReadFrameAsync().AsTask();
+
+        await presentation.DisposeAsync();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => pending);
+        Assert.AreEqual(0, projection.RetainedImageCount);
+        Assert.AreEqual(0L, projection.RetainedImageBytes);
+        foreach (var name in new[] { "_terminal", "_muxer", "_session", "Resized", "Disconnected" })
+            Assert.IsNull(typeof(Hwt1PresentationAdapter)
+                .GetField(name, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+                .GetValue(presentation), name);
+        TestSeq.AreEqual(original, frame.ToArray());
+        GC.KeepAlive(presentation);
+    }
+
+    [TestMethod]
     [DataRow(false, false)]
     [DataRow(true, false)]
     [DataRow(false, true)]

--- a/tests/Hex1b.Tests/KgpAnimationFrameTests.cs
+++ b/tests/Hex1b.Tests/KgpAnimationFrameTests.cs
@@ -448,7 +448,6 @@ public class KgpAnimationFrameTests
 
     [TestMethod]
     [DataRow("t=f", "EINVAL:Animation frame transmission requires direct data")]
-    [DataRow("o=z", "EINVAL:Animation frame compression is not supported")]
     [DataRow("f=100", "EINVAL:Animation frames require RGB or RGBA data")]
     public void AnimationFrame_UnsupportedTransferShape_ReturnsError(
         string control,

--- a/tests/Hex1b.Tests/KgpCompressedLifetimeTests.cs
+++ b/tests/Hex1b.Tests/KgpCompressedLifetimeTests.cs
@@ -1,0 +1,199 @@
+using System.IO.Compression;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+using Hex1b.Automation;
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests;
+
+[TestClass]
+public class KgpCompressedLifetimeTests
+{
+    [TestMethod]
+    public async Task Data_CompressedImage_ReturnsIndependentConcurrentCallerOwnedArrays()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        var pixels = Pixels(17);
+        var encoded = Upload(terminal, pixels);
+        var image = terminal.KgpImageStore.GetImageById(1)!;
+        Assert.IsNotNull(image);
+        Assert.IsTrue(image.IsZlibCompressed);
+
+        var first = image.Data;
+        var second = image.Data;
+        Assert.AreNotSame(first, second);
+        CollectionAssert.AreEqual(pixels, first);
+        first[0] ^= 255;
+        CollectionAssert.AreEqual(pixels, second);
+        CollectionAssert.AreEqual(pixels, image.Data);
+        CollectionAssert.AreEqual(SHA256.HashData(pixels), image.ContentHash);
+
+        var concurrent = await Task.WhenAll(Enumerable.Range(0, 8)
+            .Select(_ => Task.Run(() => image.Data, TestContext.Current.CancellationToken)));
+        foreach (var data in concurrent)
+            CollectionAssert.AreEqual(pixels, data);
+        for (var i = 1; i < concurrent.Length; i++)
+            Assert.AreNotSame(concurrent[0], concurrent[i]);
+
+        Assert.AreEqual((long)encoded.Length, terminal.KgpImageStore.TotalSize);
+        Assert.AreEqual((long)pixels.Length, terminal.KgpImageStore.ReservedDecodedBytes);
+        Assert.AreEqual((long)encoded.Length + pixels.Length, terminal.KgpImageStore.ChargedSize);
+        terminal.Dispose();
+        CollectionAssert.AreEqual(pixels, image.Data);
+        CollectionAssert.AreEqual(pixels, second);
+    }
+
+    [TestMethod]
+    public void Data_CompressedImage_DoesNotRetainMaterializedArray()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        Upload(terminal, Pixels(42));
+        var image = terminal.KgpImageStore.GetImageById(1)!;
+        var decoded = MaterializeWithoutRetaining(image);
+
+        Collect();
+
+        Assert.IsFalse(decoded.TryGetTarget(out _), "The live image must not cache caller-owned decoded arrays.");
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(1));
+        GC.KeepAlive(image);
+    }
+
+    [TestMethod]
+    public void Replacement_FiveHundredGenerations_ReleasesOldOwnersAndAccountsCurrentVersion()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        var oldOwners = ExerciseGenerations(terminal);
+
+        Collect();
+
+        foreach (var owner in oldOwners)
+            Assert.IsFalse(owner.TryGetTarget(out _), "An obsolete image remains reachable after all snapshots were released.");
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
+        Apply(terminal, "\x1b_Ga=d,d=A,q=2\x1b\\");
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(0L, terminal.KgpImageStore.TotalSize);
+        Assert.AreEqual(0L, terminal.KgpImageStore.ReservedDecodedBytes);
+        Assert.AreEqual(0L, terminal.KgpImageStore.ChargedSize);
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public async Task Screens_ResetAndDisposal_ReleaseLiveChargesWithoutInvalidatingSnapshots(bool asyncDispose)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        var terminal = CreateTerminal(workload);
+        try
+        {
+            Upload(terminal, Pixels(7));
+            var mainStore = terminal.KgpImageStore;
+            using var main = terminal.CreateSnapshot();
+            Apply(terminal, "\x1b[?1049h");
+            Upload(terminal, Pixels(8));
+            var alternateStore = terminal.KgpImageStore;
+            using var alternate = terminal.CreateSnapshot();
+            Apply(terminal, "\x1b[?1049l");
+
+            Assert.AreEqual(0L, alternateStore.TotalSize);
+            Assert.AreEqual(0L, alternateStore.ReservedDecodedBytes);
+            CollectionAssert.AreEqual(Pixels(7), main.KgpImages[1].Data);
+            CollectionAssert.AreEqual(Pixels(8), alternate.KgpImages[1].Data);
+            Apply(terminal, "\u001bc");
+            Assert.AreEqual(0L, mainStore.ChargedSize);
+            Upload(terminal, Pixels(9));
+            if (asyncDispose)
+                await terminal.DisposeAsync();
+            else
+                terminal.Dispose();
+
+            Assert.AreEqual(0L, mainStore.TotalSize);
+            Assert.AreEqual(0L, mainStore.ReservedDecodedBytes);
+            Assert.AreEqual(0L, alternateStore.ChargedSize);
+            main.Dispose();
+            alternate.Dispose();
+            CollectionAssert.AreEqual(Pixels(7), main.KgpImages[1].Data);
+            CollectionAssert.AreEqual(Pixels(8), alternate.KgpImages[1].Data);
+        }
+        finally
+        {
+            await terminal.DisposeAsync();
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference<KgpImageData>[] ExerciseGenerations(Hex1bTerminal terminal)
+    {
+        Hex1bTerminalSnapshot? first = null;
+        Hex1bTerminalSnapshot? middle = null;
+        var oldOwners = new List<WeakReference<KgpImageData>>();
+        try
+        {
+            for (var generation = 0; generation < 500; generation++)
+            {
+                var pixels = Pixels((byte)(generation % 251));
+                var encoded = Upload(terminal, pixels);
+                Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
+                Assert.AreEqual((long)encoded.Length, terminal.KgpImageStore.TotalSize);
+                Assert.AreEqual((long)pixels.Length, terminal.KgpImageStore.ReservedDecodedBytes);
+                Assert.AreEqual((long)encoded.Length + pixels.Length, terminal.KgpImageStore.ChargedSize);
+                if (generation == 0)
+                    first = terminal.CreateSnapshot();
+                if (generation == 249)
+                    middle = terminal.CreateSnapshot();
+                if (generation < 499)
+                    oldOwners.Add(new(terminal.KgpImageStore.GetImageById(1)!));
+            }
+
+            Assert.IsNotNull(first);
+            Assert.IsNotNull(middle);
+            CollectionAssert.AreEqual(Pixels(0), first.KgpImages[1].Data);
+            CollectionAssert.AreEqual(Pixels(249), middle.KgpImages[1].Data);
+            first.Dispose();
+            middle.Dispose();
+            CollectionAssert.AreEqual(Pixels(0), first.KgpImages[1].Data);
+            CollectionAssert.AreEqual(Pixels(249), middle.KgpImages[1].Data);
+        }
+        finally
+        {
+            first?.Dispose();
+            middle?.Dispose();
+        }
+        return oldOwners.ToArray();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference<byte[]> MaterializeWithoutRetaining(KgpImageData image)
+        => new(image.Data);
+
+    private static void Collect()
+    {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+    }
+
+    private static Hex1bTerminal CreateTerminal(IHex1bTerminalWorkloadAdapter workload)
+        => Hex1bTerminal.CreateBuilder().WithWorkload(workload)
+            .WithHeadless(new TerminalCapabilities { SupportsKgp = true, SupportsTrueColor = true })
+            .WithDimensions(20, 10).Build();
+
+    private static void Apply(Hex1bTerminal terminal, string text)
+        => terminal.ApplyTokens(AnsiTokenizer.Tokenize(text));
+
+    private static byte[] Upload(Hex1bTerminal terminal, byte[] pixels)
+    {
+        using var output = new MemoryStream();
+        using (var encoder = new ZLibStream(output, CompressionLevel.Fastest, leaveOpen: true))
+            encoder.Write(pixels);
+        var encoded = output.ToArray();
+        Apply(terminal, $"\x1b[1;1H\x1b_Ga=T,i=1,f=32,o=z,s=32,v=16,c=4,r=1,q=2;{Convert.ToBase64String(encoded)}\x1b\\");
+        return encoded;
+    }
+
+    private static byte[] Pixels(byte seed)
+        => Enumerable.Range(0, 32 * 16).SelectMany(i =>
+            new byte[] { seed, (byte)(i % 251), (byte)(255 - seed), 255 }).ToArray();
+}

--- a/tests/Hex1b.Tests/KgpSvgExportTests.cs
+++ b/tests/Hex1b.Tests/KgpSvgExportTests.cs
@@ -1,4 +1,5 @@
 using System.Xml.Linq;
+using System.IO.Compression;
 using Hex1b.Tokens;
 
 namespace Hex1b.Tests;
@@ -30,6 +31,76 @@ public class KgpSvgExportTests
     private static void Send(Hex1bTerminal terminal, string escapeSequence)
     {
         terminal.ApplyTokens(AnsiTokenizer.Tokenize(escapeSequence));
+    }
+
+    [TestMethod]
+    [DataRow(KgpFormat.Rgb24)]
+    [DataRow(KgpFormat.Rgba32)]
+    [DataRow(KgpFormat.Png)]
+    public void SvgExport_CompressedFormat_WithMultipleCropsMatchesRaw(KgpFormat format)
+    {
+        using var rawWorkload = new Hex1bAppWorkloadAdapter();
+        using var rawTerminal = CreateTerminal(rawWorkload, 20, 10);
+        using var compressedWorkload = new Hex1bAppWorkloadAdapter();
+        using var compressedTerminal = CreateTerminal(compressedWorkload, 20, 10);
+        var data = format == KgpFormat.Png
+            ? Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAYAAABWKLW/AAAAEUlEQVR4nGP4z8DwH4YZcHIAXdcR79xPMRAAAAAASUVORK5CYII=")
+            : Enumerable.Range(0, 9 * (format == KgpFormat.Rgb24 ? 3 : 4)).Select(i => (byte)i).ToArray();
+        var controls = $"a=t,f={(int)format},s=3,v=3,i=1,q=2";
+        Send(rawTerminal, KgpTestHelper.BuildCommand(controls, data));
+        Send(compressedTerminal, KgpTestHelper.BuildCommand(controls + ",o=z", Compress(data)));
+        var placements = KgpTestHelper.BuildCommand("a=p,i=1,p=1,x=1,y=1,w=2,h=2,C=1,q=2") +
+            "\x1b[3;4H" + KgpTestHelper.BuildCommand("a=p,i=1,p=2,x=2,y=2,w=1,h=1,C=1,q=2");
+        Send(rawTerminal, placements);
+        Send(compressedTerminal, placements);
+        using var raw = rawTerminal.CreateSnapshot();
+        using var compressed = compressedTerminal.CreateSnapshot();
+        Assert.AreEqual(2, compressed.KgpPlacements.Count);
+
+        Assert.AreEqual(raw.ToSvg(), compressed.ToSvg());
+    }
+
+    [TestMethod]
+    public void SvgExport_CompressedImage_MultipleCropsInflateOnlyOnce()
+    {
+        using var rawWorkload = new Hex1bAppWorkloadAdapter();
+        using var rawTerminal = CreateTerminal(rawWorkload, 20, 10);
+        using var compressedWorkload = new Hex1bAppWorkloadAdapter();
+        using var compressedTerminal = CreateTerminal(compressedWorkload, 20, 10);
+        var data = new byte[512 * 512 * 3];
+        var controls = "a=t,f=24,s=512,v=512,i=1,q=2";
+        Send(rawTerminal, KgpTestHelper.BuildCommand(controls, data));
+        Send(compressedTerminal, KgpTestHelper.BuildCommand(controls + ",o=z", Compress(data)));
+        for (var i = 1; i <= 8; i++)
+        {
+            var placement = $"\x1b[{i};1H" + KgpTestHelper.BuildCommand(
+                $"a=p,i=1,p={i},x={i},y={i},w=1,h=1,C=1,q=2");
+            Send(rawTerminal, placement);
+            Send(compressedTerminal, placement);
+        }
+        using var raw = rawTerminal.CreateSnapshot();
+        using var compressed = compressedTerminal.CreateSnapshot();
+        Assert.AreEqual(8, compressed.KgpPlacements.Count);
+        _ = raw.ToSvg();
+        _ = compressed.ToSvg();
+        var beforeRaw = GC.GetAllocatedBytesForCurrentThread();
+        var expected = raw.ToSvg();
+        var rawAllocation = GC.GetAllocatedBytesForCurrentThread() - beforeRaw;
+        var beforeCompressed = GC.GetAllocatedBytesForCurrentThread();
+        var actual = compressed.ToSvg();
+        var compressedAllocation = GC.GetAllocatedBytesForCurrentThread() - beforeCompressed;
+
+        Assert.AreEqual(expected, actual);
+        Assert.IsLessThan(rawAllocation + data.Length + 64 * 1024, compressedAllocation,
+            "Export owns one decoded-format array per image, not one per placement.");
+    }
+
+    private static byte[] Compress(byte[] data)
+    {
+        using var output = new MemoryStream();
+        using (var zlib = new ZLibStream(output, CompressionLevel.Fastest, leaveOpen: true))
+            zlib.Write(data);
+        return output.ToArray();
     }
 
     [TestMethod]

--- a/tests/Hex1b.Tests/KgpZlibCoreTests.cs
+++ b/tests/Hex1b.Tests/KgpZlibCoreTests.cs
@@ -1,0 +1,609 @@
+using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Channels;
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests;
+
+[TestClass]
+public class KgpZlibCoreTests
+{
+    [TestMethod]
+    [DataRow(KgpFormat.Rgb24, false)]
+    [DataRow(KgpFormat.Rgba32, false)]
+    [DataRow(KgpFormat.Png, false)]
+    [DataRow(KgpFormat.Rgb24, true)]
+    [DataRow(KgpFormat.Rgba32, true)]
+    [DataRow(KgpFormat.Png, true)]
+    public void Transmission_Formats_PreserveFormatBytes(KgpFormat format, bool compressed)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        var data = FormatBytes(format);
+        var encoded = compressed ? Compress(data) : data;
+        Send(terminal, $"a=t,i=1,f={(int)format},s=1,v=1{(compressed ? ",o=z" : "")}", encoded);
+
+        var image = terminal.KgpImageStore.GetImageById(1)!;
+        Assert.IsNotNull(image);
+        Assert.AreEqual(format, image.Format);
+        Assert.AreEqual(1u, image.Width);
+        Assert.AreEqual(1u, image.Height);
+        Assert.AreEqual(compressed, image.IsZlibCompressed);
+        TestSeq.AreEqual(data, image.Data);
+        TestSeq.AreEqual(SHA256.HashData(data), image.ContentHash);
+        Assert.IsTrue(image.IsDataSizeValid());
+        Assert.AreEqual((long)encoded.Length, image.StorageSize);
+        Assert.AreEqual(compressed ? (long)data.Length : 0, image.ReservedDecodedBytes);
+        Assert.AreEqual(compressed ? Convert.ToHexString(SHA256.HashData(data)) : null,
+            image.CurrentFrameDataHash);
+        AssertAccounting(terminal.KgpImageStore, encoded.Length, compressed ? data.Length : 0);
+    }
+
+    [TestMethod]
+    public void Validation_EveryTruncatedPrefixAndBadChecksum_IsRejectedBeforePublication()
+    {
+        var store = new KgpImageStore();
+        var data = Enumerable.Range(0, 64).Select(i => (byte)i).ToArray();
+        var encoded = Compress(data);
+        var command = Command(width: 4, height: 4);
+        for (var length = 0; length < encoded.Length; length++)
+        {
+            Assert.IsNull(store.ProcessChunk(command, encoded[..length]),
+                $"Accepted truncated prefix {length}/{encoded.Length}");
+            Assert.IsFalse(store.IsChunkedTransferInProgress);
+        }
+        for (var index = encoded.Length - 4; index < encoded.Length; index++)
+        {
+            var corrupted = encoded.ToArray();
+            corrupted[index] ^= 1;
+            Assert.IsNull(store.ProcessChunk(command, corrupted), $"Accepted bad checksum at {index}");
+        }
+        var badHeader = encoded.ToArray();
+        badHeader[0] = 0;
+        Assert.IsNull(store.ProcessChunk(command, badHeader));
+        // RFC 1950 header with FDICT; this stream cannot be decoded without its dictionary.
+        Assert.IsNull(store.ProcessChunk(command, [0x78, 0x20, 0, 0, 0, 1, .. encoded[2..]]));
+        AssertAccounting(store, 0, 0);
+        TestSeq.AreEqual(data, store.ProcessChunk(command, encoded)!.Data);
+    }
+
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(3)]
+    [DataRow(5)]
+    [DataRow(8192)]
+    public void Validation_WrongDecodedLength_IsRejected(int length)
+    {
+        var store = new KgpImageStore();
+        Assert.IsNull(store.ProcessChunk(Command(), Compress(new byte[length])));
+        AssertAccounting(store, 0, 0);
+    }
+
+    [TestMethod]
+    public void Validation_TrailingBytesAndSecondMember_AreRetainedButNotInterpreted()
+    {
+        var store = new KgpImageStore();
+        byte[] data = [1, 2, 3, 4];
+        byte[] encoded = [.. Compress(data), .. Compress([5, 6, 7, 8]), 0xFF, 0];
+        var image = store.ProcessChunk(Command(), encoded)!;
+        Assert.IsNotNull(image);
+        TestSeq.AreEqual(data, image.Data);
+        TestSeq.AreEqual(encoded, image.EncodedData.ToArray());
+        store.StoreImage(image);
+        AssertAccounting(store, encoded.Length, data.Length);
+    }
+
+    [TestMethod]
+    public void PublicProcessChunk_ContinuationPreservesCompressionAndOwnsInput()
+    {
+        var store = new KgpImageStore();
+        var encoded = Compress([1, 2, 3, 4]);
+        for (var i = 0; i < encoded.Length; i++)
+        {
+            var piece = new[] { encoded[i] };
+            var command = i == 0
+                ? Command(moreData: 1)
+                : new KgpCommand { MoreData = i != encoded.Length - 1 ? 1 : 0 };
+            var image = store.ProcessChunk(command, piece);
+            piece[0] ^= 255;
+            if (i == encoded.Length - 1)
+            {
+                Assert.IsNotNull(image);
+                Assert.IsTrue(image.IsZlibCompressed);
+                TestSeq.AreEqual(new byte[] { 1, 2, 3, 4 }, image.Data);
+            }
+            else
+            {
+                Assert.IsNull(image);
+            }
+        }
+        Assert.AreEqual(0L, store.PendingUploadBytes);
+        Assert.AreEqual(0L, store.PendingUploadCapacity);
+    }
+
+    [TestMethod]
+    [DataRow(4)]
+    [DataRow(28)]
+    [DataRow(996)]
+    [DataRow(4096)]
+    public void Transmission_ChunkedBase64_PreservesInitialMetadata(int chunkSize)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        var data = Enumerable.Range(0, 4000).Select(i => (byte)(i * 31)).ToArray();
+        var encoded = Compress(data);
+        var base64 = Convert.ToBase64String(encoded);
+        for (var offset = 0; offset < base64.Length; offset += chunkSize)
+        {
+            var piece = base64.Substring(offset, Math.Min(chunkSize, base64.Length - offset));
+            var more = offset + piece.Length < base64.Length ? 1 : 0;
+            var controls = offset == 0
+                ? $"a=t,i=1,f=32,s=100,v=10,o=z,q=2,m={more}"
+                : $"m={more}";
+            Apply(terminal, $"\x1b_G{controls};{piece}\x1b\\");
+        }
+        var image = terminal.KgpImageStore.GetImageById(1)!;
+        Assert.IsNotNull(image);
+        TestSeq.AreEqual(data, image.Data);
+        AssertAccounting(terminal.KgpImageStore, encoded.Length, data.Length);
+        Assert.AreEqual(0L, terminal.KgpImageStore.PendingUploadCapacity);
+    }
+
+    [TestMethod]
+    public async Task Transmission_MalformedQuietAndQuery_ReturnExpectedResponsesWithoutStorage()
+    {
+        var workload = new ResponseWorkload();
+        using var terminal = CreateTerminal(workload);
+        var encoded = Compress([1, 2, 3, 4]);
+        Send(terminal, "a=q,i=1,f=32,s=1,v=1,o=z", encoded);
+        Assert.AreEqual("\x1b_Gi=1;OK\x1b\\", await workload.ReadAsync());
+        AssertAccounting(terminal.KgpImageStore, 0, 0);
+
+        Send(terminal, "a=q,i=2,f=32,s=1,v=1,o=z,q=1", encoded[..^1]);
+        StringAssert.Contains(await workload.ReadAsync(), "i=2;EINVAL:");
+        Send(terminal, "a=t,i=3,f=32,s=1,v=1,o=z,q=2", encoded[..^1]);
+        Send(terminal, "a=q,i=4,f=32,s=1,v=1,o=z,q=1", encoded);
+        Send(terminal, "a=q,i=5,f=32,s=1,v=1,o=z", encoded);
+        Assert.AreEqual("\x1b_Gi=5;OK\x1b\\", await workload.ReadAsync());
+        Assert.IsFalse(workload.Responses.TryRead(out _));
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+    }
+
+    [TestMethod]
+    public async Task Transmission_ContinuationQuietAndInvalidControls_AbortAndRecover()
+    {
+        var workload = new ResponseWorkload();
+        using var terminal = CreateTerminal(workload);
+        var encoded = Compress([1, 2, 3, 4]);
+        Send(terminal, "a=t,i=1,f=32,s=1,v=1,o=z,q=1,m=1", encoded[..3]);
+        Send(terminal, "m=0", encoded[3..^1]);
+        StringAssert.Contains(await workload.ReadAsync(), "i=1;EINVAL:");
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Send(terminal, "a=t,i=1,f=32,s=1,v=1,o=z,q=2,m=1", encoded[..3]);
+        Send(terminal, "m=0,f=32", encoded[3..]);
+        Send(terminal, "a=t,i=2,f=32,s=1,v=1,o=z", encoded);
+        Assert.AreEqual("\x1b_Gi=2;OK\x1b\\", await workload.ReadAsync());
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(1));
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(2));
+        Assert.AreEqual(0L, terminal.KgpImageStore.PendingUploadCapacity);
+    }
+
+    [TestMethod]
+    public void Transmission_InputRasterAndPendingBounds_RejectWithoutLeakingAssembly()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        var encoded = Compress([1, 2, 3, 4]);
+        using var terminal = CreateTerminal(workload, graphics =>
+        {
+            graphics.MaximumRetainedInputBytesPerImage = encoded.Length - 1;
+            graphics.MaximumRasterPixelsPerImage = 1;
+        });
+        Send(terminal, "a=t,i=1,f=32,s=1,v=1,o=z", encoded);
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(1));
+        Send(terminal, "a=t,i=1,f=32,s=1,v=1,o=z,m=1", encoded[..3]);
+        Assert.AreEqual(3L, terminal.KgpImageStore.PendingUploadBytes);
+        Send(terminal, "m=0", encoded[3..]);
+        Assert.AreEqual(0L, terminal.KgpImageStore.PendingUploadCapacity);
+        Send(terminal, "a=t,i=1,f=32,s=2,v=1,o=z", Compress(new byte[8]));
+        Send(terminal, "a=t,i=1,f=32,s=4294967295,v=4294967295,o=z", encoded);
+        AssertAccounting(terminal.KgpImageStore, 0, 0);
+
+        // The compressed-only raster/input limits do not retrofit legacy raw uploads.
+        Send(terminal, "a=t,i=1,f=32,s=2,v=1", new byte[8]);
+        AssertAccounting(terminal.KgpImageStore, 8, 0);
+    }
+
+    [TestMethod]
+    public void Validation_PngMetadataAndInflatedByteBounds_AreEnforced()
+    {
+        var png = FormatBytes(KgpFormat.Png);
+        var store = new KgpImageStore();
+        var command = Command(format: KgpFormat.Png);
+        var invalid = png.ToArray();
+        invalid[29] ^= 1;
+        Assert.IsNull(store.ProcessChunk(command, Compress(invalid)));
+        Assert.IsNull(store.ProcessChunk(command, Compress(png[..32])));
+        var encoded = Compress(png);
+        var exact = new KgpImageStore(encoded.Length + png.Length);
+        Assert.IsNotNull(exact.ProcessChunk(command, encoded));
+        var below = new KgpImageStore(encoded.Length + png.Length - 1);
+        Assert.IsNull(below.ProcessChunk(command, encoded));
+    }
+
+    [TestMethod]
+    public void Store_ExactQuotaAndOneByteOver_KeepActualAndReservedDistinct()
+    {
+        byte[] data = [1, 2, 3, 4];
+        var encoded = Compress(data);
+        var cost = encoded.Length + data.Length;
+        var exact = new KgpImageStore(cost);
+        var image = exact.ProcessChunk(Command(), encoded)!;
+        Assert.IsNotNull(exact.StoreImage(image));
+        AssertAccounting(exact, encoded.Length, data.Length);
+        var below = new KgpImageStore(cost - 1);
+        Assert.IsNull(below.StoreImage(image));
+        AssertAccounting(below, 0, 0);
+        exact.RemoveImage(1);
+        AssertAccounting(exact, 0, 0);
+    }
+
+    [TestMethod]
+    public void Store_ReplacementEvictionAndClear_ReleaseBothCharges()
+    {
+        var encoded = Compress([1, 2, 3, 4]);
+        var store = new KgpImageStore(encoded.Length + 4);
+        var first = store.ProcessChunk(Command(), encoded)!;
+        store.StoreImage(first);
+        store.StoreImage(first.WithImageId(2));
+        Assert.IsNull(store.GetImageById(1));
+        AssertAccounting(store, encoded.Length, 4);
+        store.StoreImage(new KgpImageData(2, 0, [5, 6, 7, 8], 1, 1, KgpFormat.Rgba32));
+        AssertAccounting(store, 4, 0);
+        store.StoreImage(first.WithImageId(2));
+        AssertAccounting(store, encoded.Length, 4);
+        store.Clear();
+        AssertAccounting(store, 0, 0);
+    }
+
+    [TestMethod]
+    public void Terminal_ResetAndDispose_ClearBothScreenAccounting()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        var encoded = Compress([1, 2, 3, 4]);
+        Send(terminal, "a=t,i=1,f=32,s=1,v=1,o=z", encoded);
+        var main = terminal.KgpImageStore;
+        Apply(terminal, "\x1b[?1049h");
+        Send(terminal, "a=t,i=1,f=32,s=1,v=1,o=z", encoded);
+        var alternate = terminal.KgpImageStore;
+        AssertAccounting(main, encoded.Length, 4);
+        AssertAccounting(alternate, encoded.Length, 4);
+        Apply(terminal, "\u001bc");
+        AssertAccounting(main, 0, 0);
+        AssertAccounting(alternate, 0, 0);
+        Send(terminal, "a=t,i=1,f=32,s=1,v=1,o=z", encoded);
+        var active = terminal.KgpImageStore;
+        terminal.Dispose();
+        AssertAccounting(active, 0, 0);
+    }
+
+    [TestMethod]
+    public void SharedBudget_CompressedReservation_BlocksSixelAndPreservesResidentSixel()
+    {
+        var encoded = Compress([1, 2, 3, 4]);
+        var cost = encoded.Length + 4;
+        var budget = new TerminalGraphicsRetainedBudget(cost + 10);
+        var store = new KgpImageStore(budget);
+        var image = store.ProcessChunk(Command(), encoded)!;
+        budget.SetSixelBytes(11);
+        Assert.IsNull(store.StoreImage(image));
+        Assert.AreEqual(11L, budget.SixelBytes);
+        budget.SetSixelBytes(10);
+        Assert.IsNotNull(store.StoreImage(image));
+        Assert.AreEqual((long)encoded.Length, budget.KgpBytes);
+        Assert.AreEqual(10L, budget.MaximumSixelBytes);
+        Assert.IsFalse(budget.CanSetSixelBytes(11));
+        store.Clear();
+        Assert.AreEqual((long)cost + 10, budget.MaximumSixelBytes);
+        Assert.AreEqual(10L, budget.SixelBytes);
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void SharedBudget_TerminalSixelAndCompressedImage_UseExactCombinedCapacity(bool sixelFirst)
+    {
+        const string sixel = "\x1bP0;0;0q\"1;1;1;6#1;2;100;0;0#1@\x1b\\";
+        using var measureWorkload = new Hex1bAppWorkloadAdapter();
+        using var measure = CreateTerminal(measureWorkload);
+        Apply(measure, sixel);
+        var sixelBytes = measure.SixelRetainedByteCount;
+        Assert.IsTrue(sixelBytes > 0);
+        var encoded = Compress([1, 2, 3, 4]);
+        var capacity = sixelBytes + encoded.Length + 4;
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload,
+            options => options.MaximumRetainedBytesPerScreen = capacity);
+        if (sixelFirst)
+            Apply(terminal, sixel);
+        Send(terminal, "a=t,i=1,f=32,s=1,v=1,o=z", encoded);
+        if (!sixelFirst)
+            Apply(terminal, sixel);
+        Assert.AreEqual(sixelBytes, terminal.SixelRetainedByteCount);
+        AssertAccounting(terminal.KgpImageStore, encoded.Length, 4);
+        Assert.AreEqual(sixelBytes + encoded.Length, terminal.GraphicsRetainedByteCount);
+        Assert.AreEqual(capacity, terminal.GraphicsChargedByteCount);
+
+        Send(terminal, "a=t,i=2,f=32,s=1,v=1,o=z", [.. encoded, 0]);
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(2));
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(1));
+        Assert.AreEqual(sixelBytes, terminal.SixelRetainedByteCount);
+        terminal.KgpImageStore.Clear();
+        Assert.AreEqual(sixelBytes, terminal.GraphicsChargedByteCount);
+    }
+
+    [TestMethod]
+    public void Store_AnonymousRelocationAndNumberGenerations_PreserveCharges()
+    {
+        var store = new KgpImageStore();
+        var encoded = Compress([1, 2, 3, 4]);
+        var anonymous = Command(imageId: 0);
+        var first = store.StoreImage(anonymous.ToTransmissionData(), encoded);
+        var explicitCommand = Command(imageId: first.Image.ImageId);
+        var second = store.StoreImage(explicitCommand.ToTransmissionData(), encoded);
+        Assert.IsNotNull(second.Relocation);
+        AssertAccounting(store, encoded.Length * 2, 8);
+        TestSeq.AreEqual(new byte[] { 1, 2, 3, 4 }, store.GetImageById(second.Relocation.Value.CurrentId)!.Data);
+        var numbered = Command(imageId: 0, imageNumber: 5);
+        store.StoreImage(numbered.ToTransmissionData(), encoded);
+        var newest = store.StoreImage(numbered.ToTransmissionData(), encoded);
+        Assert.AreSame(newest.Image, store.GetImageByNumber(5));
+        AssertAccounting(store, encoded.Length * 4, 16);
+        store.Clear();
+        AssertAccounting(store, 0, 0);
+    }
+
+    [TestMethod]
+    public void Transmission_ExplicitReplacementStart_RemovesOldImageBeforeMalformedCompletion()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        var encoded = Compress([1, 2, 3, 4]);
+        Send(terminal, "a=t,i=1,f=32,s=1,v=1,o=z", encoded);
+        Send(terminal, "a=t,i=1,f=32,s=1,v=1,o=z,m=1", encoded[..3]);
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(1));
+        AssertAccounting(terminal.KgpImageStore, 0, 0);
+        Send(terminal, "m=0", encoded[3..^1]);
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(1));
+        Assert.AreEqual(0L, terminal.KgpImageStore.PendingUploadCapacity);
+    }
+
+    [TestMethod]
+    [DataRow(KgpFormat.Rgb24)]
+    [DataRow(KgpFormat.Rgba32)]
+    public void Animation_CompressedRootAndFrame_PromoteUsingReservation(KgpFormat format)
+    {
+        var data = FormatBytes(format);
+        var encoded = Compress(data);
+        var store = new KgpImageStore(Math.Max(encoded.Length + data.Length, 8));
+        var original = store.ProcessChunk(Command(format: format), encoded)!;
+        store.StoreImage(original);
+        var command = ParseFrame($"a=f,i=1,f={(int)format},o=z,X=1");
+        var result = store.StoreAnimationFrame(command, Compress(data));
+        Assert.AreEqual(KgpImageStore.AnimationFrameStatus.Success, result.Info.Status);
+        Assert.IsNotNull(result.Image);
+        Assert.IsFalse(result.Image.IsZlibCompressed);
+        Assert.AreEqual(KgpFormat.Rgba32, result.Image.Format);
+        Assert.AreEqual(2, result.Image.FrameCount);
+        AssertAccounting(store, 8, 0);
+        TestSeq.AreEqual(data, original.Data);
+        Assert.IsTrue(original.IsZlibCompressed);
+        var edited = store.StoreAnimationFrame(ParseFrame("a=f,i=1,f=32,r=1,o=z,X=1"), Compress([9, 8, 7, 6]));
+        Assert.AreEqual(KgpImageStore.AnimationFrameStatus.Success, edited.Info.Status);
+        TestSeq.AreEqual(new byte[] { 9, 8, 7, 6 }, edited.Image!.Data);
+        AssertAccounting(store, 8, 0);
+        store.DeleteAnimationFrame(1, 0, 2, true);
+        AssertAccounting(store, 4, 0);
+        store.DeleteAnimationFrame(1, 0, 1, true);
+        AssertAccounting(store, 0, 0);
+    }
+
+    [TestMethod]
+    [DataRow(8191, false)]
+    [DataRow(8192, true)]
+    public void Animation_PromotionAtExactQuota_UsesNetChargedDelta(int quota, bool accepted)
+    {
+        var encoded = Compress(new byte[4096]);
+        var store = new KgpImageStore(quota);
+        var original = store.ProcessChunk(Command(width: 32, height: 32), encoded)!;
+        store.StoreImage(original);
+        var result = store.StoreAnimationFrame(
+            ParseFrame("a=f,i=1,f=32,s=1,v=1,o=z,X=1"), Compress([1, 2, 3, 4]));
+        Assert.AreEqual(accepted ? KgpImageStore.AnimationFrameStatus.Success :
+            KgpImageStore.AnimationFrameStatus.NoSpace, result.Info.Status);
+        if (accepted)
+        {
+            AssertAccounting(store, 8192, 0);
+            Assert.IsFalse(result.Image!.IsZlibCompressed);
+        }
+        else
+        {
+            Assert.AreSame(original, store.GetImageById(1));
+            AssertAccounting(store, encoded.Length, 4096);
+        }
+    }
+
+    [TestMethod]
+    public async Task Animation_MalformedCompressedFrame_ReturnsDecodedErrorWithoutMutation()
+    {
+        var workload = new ResponseWorkload();
+        using var terminal = CreateTerminal(workload);
+        var encoded = Compress([1, 2, 3, 4]);
+        Send(terminal, "a=t,i=1,f=32,s=1,v=1,o=z,q=2", encoded);
+        var original = terminal.KgpImageStore.GetImageById(1);
+        Send(terminal, "a=f,i=1,f=32,o=z", encoded[..^1]);
+        StringAssert.Contains(await workload.ReadAsync(), "EINVAL:");
+        Assert.AreSame(original, terminal.KgpImageStore.GetImageById(1));
+        Send(terminal, "a=f,i=1,f=32,o=z", Compress([1, 2, 3]));
+        StringAssert.Contains(await workload.ReadAsync(), "ENODATA:Insufficient decoded image data");
+        AssertAccounting(terminal.KgpImageStore, encoded.Length, 4);
+    }
+
+    [TestMethod]
+    public void Validation_LargeStaticRoot_UsesBoundedScratchInsteadOfDecodedArray()
+    {
+        var encoded = Compress(new byte[4 * 1024 * 1024]);
+        var store = new KgpImageStore();
+        // Warm up stream/hash initialization outside the allocation measurement.
+        Assert.IsNotNull(store.ProcessChunk(Command(), Compress([1, 2, 3, 4])));
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        var image = store.ProcessChunk(Command(width: 1024, height: 1024), encoded)!;
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.IsNotNull(image);
+        Assert.AreEqual(4L * 1024 * 1024, image.ReservedDecodedBytes);
+        Assert.IsTrue(allocated < 1024 * 1024, $"Validation allocated {allocated} bytes.");
+        var identity = image.CurrentFrameDataHash;
+        image.ContentHash[0] ^= 255;
+        Assert.AreEqual(identity, image.WithImageId(2).CurrentFrameDataHash);
+    }
+
+    [TestMethod]
+    public async Task Data_MaterializationDiagnostics_CountSuccessfulCompressedReadsOnly()
+    {
+        var store = new KgpImageStore();
+        var image = store.ProcessChunk(Command(), Compress([1, 2, 3, 4]))!;
+        Assert.AreEqual(0L, image.MaterializationCount);
+        Assert.AreEqual(0L, image.MaterializedBytes);
+        Assert.IsTrue(image.IsDataSizeValid());
+        _ = image.CurrentFrameDataHash;
+        _ = image.EncodedData;
+        Assert.AreEqual(0L, image.MaterializationCount);
+        var first = image.Data;
+        await Task.WhenAll(Enumerable.Range(0, 8).Select(_ => Task.Run(() =>
+        {
+            TestSeq.AreEqual(first, image.CurrentFrameData);
+        }, TestContext.Current.CancellationToken)));
+        Assert.AreEqual(9L, image.MaterializationCount);
+        Assert.AreEqual(36L, image.MaterializedBytes);
+        Assert.AreEqual(0L, image.WithImageId(2).MaterializationCount);
+        var raw = new KgpImageData(1, 0, first, 1, 1, KgpFormat.Rgba32);
+        Assert.AreSame(first, raw.Data);
+        Assert.AreEqual(0L, raw.MaterializationCount);
+        Assert.AreEqual(0L, raw.MaterializedBytes);
+    }
+
+    [TestMethod]
+    public void Animation_ControlOnlyPromotion_ReplacesCompressedChargeAndPlaybackRestores()
+    {
+        var encoded = Compress([1, 2, 3, 4]);
+        var store = new KgpImageStore(encoded.Length + 4);
+        var original = store.ProcessChunk(Command(), encoded)!;
+        store.StoreImage(original);
+        Assert.IsTrue(KgpCommandParser.TryParse("a=a,i=1,r=1,z=40,s=2", out var parsed, out _));
+        var result = store.ControlAnimation(((KgpParsedCommand.AnimationControl)parsed!).Control);
+        Assert.AreEqual(KgpImageStore.AnimationControlStatus.Success, result.Status);
+        AssertAccounting(store, 4, 0);
+        Assert.IsFalse(store.GetImageById(1)!.IsZlibCompressed);
+        Assert.IsTrue(original.IsZlibCompressed);
+        var playback = new KgpAnimationPlaybackSnapshot(1, 0, 1,
+            KgpParsedCommand.AnimationPlaybackState.Running, 1, 0, 0);
+        store.RestoreAnimationPlayback(playback, DateTimeOffset.UtcNow);
+        Assert.AreEqual(KgpParsedCommand.AnimationPlaybackState.Running,
+            store.GetImageById(1)!.AnimationState!.PlaybackState);
+        AssertAccounting(store, 4, 0);
+        store.Clear();
+        AssertAccounting(store, 0, 0);
+    }
+
+    [TestMethod]
+    public void Animation_CompressedFrameChunks_CanBeLargerThanDecodedFrame()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        Send(terminal, "a=t,i=1,f=32,s=1,v=1", [1, 2, 3, 4]);
+        var encoded = Compress([5, 6, 7, 8]);
+        Assert.IsTrue(encoded.Length > 4);
+        Send(terminal, "a=f,i=1,f=32,s=1,v=1,o=z,X=1,m=1", encoded[..3]);
+        Send(terminal, "a=f,m=0", encoded[3..]);
+        var image = terminal.KgpImageStore.GetImageById(1)!;
+        Assert.AreEqual(2, image.FrameCount);
+        Assert.IsTrue(image.TryGetFrame(2, out var data, out _, out _));
+        TestSeq.AreEqual(new byte[] { 5, 6, 7, 8 }, data);
+        AssertAccounting(terminal.KgpImageStore, 8, 0);
+    }
+
+    private static Hex1bTerminal CreateTerminal(
+        IHex1bTerminalWorkloadAdapter workload,
+        Action<Hex1bTerminalGraphicsOptions>? configure = null)
+    {
+        var builder = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload)
+            .WithHeadless(new TerminalCapabilities { SupportsKgp = true, SupportsSixel = true, CellPixelWidth = 10, CellPixelHeight = 20 })
+            .WithDimensions(80, 24);
+        if (configure is not null)
+            builder.WithGraphics(configure);
+        return builder.Build();
+    }
+
+    private static KgpCommand Command(uint width = 1, uint height = 1,
+        KgpFormat format = KgpFormat.Rgba32, uint imageId = 1, uint imageNumber = 0, int moreData = 0)
+        => new() { ImageId = imageId, ImageNumber = imageNumber, Width = width, Height = height,
+            Format = format, Compression = 'z', MoreData = moreData };
+
+    private static KgpParsedCommand.AnimationFrame ParseFrame(string controls)
+    {
+        Assert.IsTrue(KgpCommandParser.TryParse(controls, out var command, out _));
+        return (KgpParsedCommand.AnimationFrame)command!;
+    }
+
+    private static byte[] FormatBytes(KgpFormat format)
+        => format switch
+        {
+            KgpFormat.Rgb24 => [1, 2, 3],
+            KgpFormat.Rgba32 => [1, 2, 3, 4],
+            _ => Convert.FromBase64String(
+                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+a5xQAAAAASUVORK5CYII="),
+        };
+
+    private static byte[] Compress(byte[] data)
+    {
+        using var stream = new MemoryStream();
+        using (var zlib = new ZLibStream(stream, CompressionLevel.SmallestSize, leaveOpen: true))
+            zlib.Write(data);
+        return stream.ToArray();
+    }
+
+    private static void Send(Hex1bTerminal terminal, string controls, byte[] data)
+        => Apply(terminal, KgpTestHelper.BuildCommand(controls, data));
+
+    private static void Apply(Hex1bTerminal terminal, string text)
+        => terminal.ApplyTokens(AnsiTokenizer.Tokenize(text));
+
+    private static void AssertAccounting(KgpImageStore store, long expectedActual, long reserved)
+    {
+        Assert.AreEqual(expectedActual, store.TotalSize);
+        Assert.AreEqual(reserved, store.ReservedDecodedBytes);
+        Assert.AreEqual(expectedActual + reserved, store.ChargedSize);
+    }
+
+    private sealed class ResponseWorkload : IHex1bTerminalWorkloadAdapter
+    {
+        private readonly Channel<string> _responses = Channel.CreateUnbounded<string>();
+        internal ChannelReader<string> Responses => _responses.Reader;
+        public event Action? Disconnected { add { } remove { } }
+        public ValueTask<ReadOnlyMemory<byte>> ReadOutputAsync(CancellationToken ct = default)
+            => ValueTask.FromResult(ReadOnlyMemory<byte>.Empty);
+        public ValueTask WriteInputAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default)
+        {
+            _responses.Writer.TryWrite(Encoding.UTF8.GetString(data.Span));
+            return ValueTask.CompletedTask;
+        }
+        public ValueTask ResizeAsync(int width, int height, CancellationToken ct = default)
+            => ValueTask.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        internal async Task<string> ReadAsync()
+            => await _responses.Reader.ReadAsync(TestContext.Current.CancellationToken)
+                .AsTask().WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+    }
+}

--- a/tests/Hex1b.Tests/ProteinViewGraphicsStreamTests.cs
+++ b/tests/Hex1b.Tests/ProteinViewGraphicsStreamTests.cs
@@ -55,7 +55,30 @@ public class ProteinViewGraphicsStreamTests
     }
 
     [TestMethod]
-    public async Task Capture_ExplicitSyntheticInvestigation_WritesComparisonWithoutAssumingFailure()
+    [DataRow(1)]
+    [DataRow(7)]
+    [DataRow(997)]
+    [DataRow(4096)]
+    public async Task RawPump_CompressedVirtualImage_RetainsExactPixelsAndVisiblePlacement(int chunkSize)
+    {
+        await using var workload = new CapturedWorkloadAdapter(Chunks(BuildImage(compressed: true), chunkSize));
+        await using var presentation = new Hwt1PresentationAdapter(20, 10);
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithPresentation(presentation).Build();
+        await WaitForMarkerAsync(terminal);
+        using var snapshot = terminal.CreateSnapshot();
+        var image = TestSeq.Single(snapshot.KgpImages.Values);
+        Assert.IsTrue(image.IsZlibCompressed);
+        Assert.AreEqual(KgpFormat.Rgba32, image.Format);
+        CollectionAssert.AreEqual(Pixels(), image.Data);
+        Assert.IsNotEmpty(snapshot.KgpPlacements);
+        Assert.AreEqual(1, terminal.KgpVirtualPlacementCount);
+        using var metadata = Metadata(await presentation.ReadFrameAsync(TestContext.Current.CancellationToken));
+        Assert.IsTrue(metadata.RootElement.GetProperty("placements").GetArrayLength() > 0);
+    }
+
+    [TestMethod]
+    public async Task Capture_ExplicitSyntheticInvestigation_WritesCompressionParityEvidence()
     {
         var directory = Environment.GetEnvironmentVariable("HEX1B_GRAPHICS_EVIDENCE");
         if (string.IsNullOrEmpty(directory))
@@ -89,8 +112,7 @@ public class ProteinViewGraphicsStreamTests
                 virtualPlacements = terminal.KgpVirtualPlacementCount,
                 replies = Convert.ToBase64String(workload.WrittenInput)
             }, TestContext.Current.CancellationToken);
-            if (!compressed)
-                Assert.IsNotEmpty(snapshot.KgpPlacements, "The otherwise equivalent control must render.");
+            Assert.IsNotEmpty(snapshot.KgpPlacements, "Compressed and uncompressed graphics must both render.");
         }
     }
 

--- a/tests/Hex1b.Tests/ProteinViewGraphicsStreamTests.cs
+++ b/tests/Hex1b.Tests/ProteinViewGraphicsStreamTests.cs
@@ -1,0 +1,150 @@
+using System.Buffers.Binary;
+using System.IO.Compression;
+using System.Text;
+using System.Text.Json;
+using Hex1b.Tests.Diagnostics;
+
+namespace Hex1b.Tests;
+
+[TestClass]
+public class ProteinViewGraphicsStreamTests
+{
+    internal const string Probe = "\x1b_Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\\x1b[c\x1b[16t\x1b[5n";
+    internal const string ProbeReplies = "\x1b_Gi=31;OK\x1b\\\x1b[?62;4c\x1b[6;20;10t\x1b[0n";
+    internal const string Marker = "capture-complete";
+
+    [TestMethod]
+    [DataRow(1)]
+    [DataRow(7)]
+    [DataRow(4096)]
+    public async Task RawPump_PickerQueries_ReturnsOrderedCapabilitiesAndGeometry(int chunkSize)
+    {
+        await using var workload = new CapturedWorkloadAdapter(Chunks(Encoding.UTF8.GetBytes(Probe), chunkSize));
+        await using var presentation = new Hwt1PresentationAdapter(20, 10);
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithPresentation(presentation).Build();
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        while (workload.WrittenInput.Length < Encoding.UTF8.GetByteCount(ProbeReplies))
+            await Task.Delay(10, timeout.Token);
+        Assert.AreEqual(ProbeReplies, Encoding.UTF8.GetString(workload.WrittenInput));
+    }
+
+    [TestMethod]
+    [DataRow(1, false)]
+    [DataRow(7, false)]
+    [DataRow(4096, false)]
+    [DataRow(1, true)]
+    [DataRow(7, true)]
+    public async Task RawPump_UncompressedVirtualImage_RetainsPixelsAndVisiblePlacement(int chunkSize, bool png)
+    {
+        var bytes = BuildImage(compressed: false, png: png);
+        await using var workload = new CapturedWorkloadAdapter(Chunks(bytes, chunkSize));
+        await using var presentation = new Hwt1PresentationAdapter(20, 10);
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithPresentation(presentation).Build();
+        await WaitForMarkerAsync(terminal);
+        using var snapshot = terminal.CreateSnapshot();
+        var image = TestSeq.Single(snapshot.KgpImages.Values);
+        Assert.AreEqual(png ? KgpFormat.Png : KgpFormat.Rgba32, image.Format);
+        Assert.IsNotEmpty(snapshot.KgpPlacements);
+        Assert.AreEqual(1, terminal.KgpVirtualPlacementCount);
+        if (!png)
+            CollectionAssert.AreEqual(Pixels(), image.Data);
+        using var metadata = Metadata(await presentation.ReadFrameAsync(TestContext.Current.CancellationToken));
+        Assert.IsTrue(metadata.RootElement.GetProperty("placements").GetArrayLength() > 0);
+    }
+
+    [TestMethod]
+    public async Task Capture_ExplicitSyntheticInvestigation_WritesComparisonWithoutAssumingFailure()
+    {
+        var directory = Environment.GetEnvironmentVariable("HEX1B_GRAPHICS_EVIDENCE");
+        if (string.IsNullOrEmpty(directory))
+            Assert.Inconclusive("Set HEX1B_GRAPHICS_EVIDENCE to a new private directory for opt-in investigation.");
+        Directory.CreateDirectory(directory);
+        foreach (var (name, compressed, quiet, png) in new[]
+        {
+            ("rgba-control", false, 2, false),
+            ("png-control", false, 2, true),
+            ("zlib-original-quiet", true, 2, false),
+            ("zlib-diagnostic-replies", true, 0, false)
+        })
+        {
+            var chunks = Chunks(BuildImage(compressed, quiet, png), 7);
+            await using var workload = new CapturedWorkloadAdapter(chunks);
+            await using var capture = new DuplexPtyCapture(workload, 1024 * 1024, 10000);
+            await using var presentation = new Hwt1PresentationAdapter(20, 10);
+            await using var terminal = Hex1bTerminal.CreateBuilder()
+                .WithWorkload(capture).WithPresentation(presentation).Build();
+            await WaitForMarkerAsync(terminal);
+            using var snapshot = terminal.CreateSnapshot();
+            var frame = await presentation.ReadFrameAsync(TestContext.Current.CancellationToken);
+            await File.WriteAllBytesAsync(Path.Combine(directory, $"{name}.hwt"), frame.ToArray());
+            capture.Complete("synthetic-comparison");
+            await capture.SaveAsync(Path.Combine(directory, $"{name}.json"), new
+            {
+                provenance = "synthetic: pinned ProteinView control/payload/placeholder form, not an application recording",
+                compressed, quiet, png, expectedVisibleImages = 1,
+                actualImages = snapshot.KgpImages.Count,
+                actualPlacements = snapshot.KgpPlacements.Count,
+                virtualPlacements = terminal.KgpVirtualPlacementCount,
+                replies = Convert.ToBase64String(workload.WrittenInput)
+            }, TestContext.Current.CancellationToken);
+            if (!compressed)
+                Assert.IsNotEmpty(snapshot.KgpPlacements, "The otherwise equivalent control must render.");
+        }
+    }
+
+    internal static byte[] BuildImage(bool compressed, int quiet = 2, bool png = false)
+    {
+        var pixels = Pixels();
+        byte[] data;
+        if (png)
+            data = Convert.FromBase64String(
+                "iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAYAAABWKLW/AAAAEUlEQVR4nGP4z8DwH4YZcHIAXdcR79xPMRAAAAAASUVORK5CYII=");
+        else if (compressed)
+        {
+            using var output = new MemoryStream();
+            using (var encoder = new ZLibStream(output, CompressionLevel.Fastest, leaveOpen: true))
+                encoder.Write(pixels);
+            data = output.ToArray();
+        }
+        else
+            data = pixels;
+        var payload = Convert.ToBase64String(data);
+        var outputText = new StringBuilder("\x1b[2J\x1b[2;2H");
+        for (var offset = 0; offset < payload.Length; offset += 4096)
+        {
+            var count = Math.Min(4096, payload.Length - offset);
+            var more = offset + count < payload.Length ? 1 : 0;
+            var control = offset == 0
+                ? $"q={quiet},i=1,a=T,U=1,f={(png ? 100 : 32)},{(compressed ? "o=z," : "")}t=d,s={(png ? 3 : 40)},v={(png ? 3 : 20)},c=4,r=1,m={more}"
+                : $"q={quiet},m={more}";
+            outputText.Append("\x1b_G").Append(control).Append(';').Append(payload, offset, count).Append("\x1b\\");
+        }
+        var zero = new Rune(KgpUnicodePlaceholderDiacritics.CodePoints[0]).ToString();
+        outputText.Append("\x1b[s\x1b[38;2;0;0;1m\U0010EEEE")
+            .Append(zero).Append(zero).Append(zero)
+            .Append("\U0010EEEE\U0010EEEE\U0010EEEE\x1b[u\x1b[4C\x1b[1B")
+            .Append("\x1b[0m\x1b[10;1H").Append(Marker);
+        return Encoding.UTF8.GetBytes(outputText.ToString());
+    }
+
+    private static byte[] Pixels()
+        => Enumerable.Range(0, 40 * 20).SelectMany(_ => new byte[] { 255, 0, 0, 255 }).ToArray();
+
+    internal static byte[][] Chunks(byte[] bytes, int size)
+        => bytes.Chunk(size).Select(chunk => chunk.ToArray()).ToArray();
+
+    internal static async Task WaitForMarkerAsync(Hex1bTerminal terminal)
+    {
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(snapshot => snapshot.ContainsText(Marker), TimeSpan.FromSeconds(5), "raw stream fully applied")
+            .Build().ApplyAsync(terminal, TestContext.Current.CancellationToken);
+    }
+
+    internal static JsonDocument Metadata(ReadOnlyMemory<byte> frame)
+    {
+        var length = BinaryPrimitives.ReadInt32LittleEndian(frame.Span[4..]);
+        return JsonDocument.Parse(frame.Slice(8, length));
+    }
+}

--- a/tests/Hex1b.Tests/Sixel/SixelRetainedMemoryBudgetTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelRetainedMemoryBudgetTests.cs
@@ -462,7 +462,7 @@ public class SixelRetainedMemoryBudgetTests
     }
 
     [TestMethod]
-    public async Task FittingCompressedReplacement_NonMultipleOfThreeQuota_ReplacesNormally()
+    public async Task TruncatedCompressedReplacement_NonMultipleOfThreeQuota_RejectsWithoutEvictingSixel()
     {
         var state = await CreateMixedKgpSixelStateAsync();
         await using var terminal = state.Terminal;
@@ -475,16 +475,15 @@ public class SixelRetainedMemoryBudgetTests
                 replacement)));
 
         var stored = terminal.Terminal.KgpImageStore.GetImageById(1);
-        Assert.IsNotNull(stored);
-        TestSeq.AreEqual(replacement, stored.Data);
+        Assert.IsNull(stored);
         Assert.IsNotNull(terminal.Terminal.KgpImageStore.GetImageById(2));
-        Assert.AreEqual(8L, terminal.Terminal.KgpImageStore.TotalSize);
+        Assert.AreEqual(4L, terminal.Terminal.KgpImageStore.TotalSize);
         Assert.HasCount(1, terminal.Terminal.KgpPlacements);
         Assert.AreEqual(2u, terminal.Terminal.KgpPlacements[0].ImageId);
         Assert.AreEqual(
-            state.SixelBytes + 8,
+            state.SixelBytes + 4,
             terminal.Terminal.GraphicsRetainedByteCount);
-        StringAssert.Contains(terminal.WorkloadInput, ";OK");
+        StringAssert.Contains(terminal.WorkloadInput, ";EINVAL:");
     }
 
     [TestMethod]

--- a/tests/Hex1b.Tests/WebTerminalProjectionTests.cs
+++ b/tests/Hex1b.Tests/WebTerminalProjectionTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using System.IO.Compression;
 using Hex1b.Tokens;
 
 namespace Hex1b.Tests;
@@ -12,6 +13,323 @@ public class WebTerminalProjectionTests
         SupportsSixel = true, SupportsKgp = true, SupportsTrueColor = true,
         CellPixelWidth = 10, CellPixelHeight = 20
     };
+
+    [TestMethod]
+    [DataRow(KgpFormat.Rgb24)]
+    [DataRow(KgpFormat.Rgba32)]
+    [DataRow(KgpFormat.Png)]
+    public void Encode_CompressedImages_DeduplicatesBeforeInflatingAndPreservesFormat(KgpFormat format)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        var data = format == KgpFormat.Png
+            ? Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAYAAABWKLW/AAAAEUlEQVR4nGP4z8DwH4YZcHIAXdcR79xPMRAAAAAASUVORK5CYII=")
+            : Enumerable.Range(0, 9).SelectMany(_ => format == KgpFormat.Rgb24
+                ? new byte[] { 10, 20, 30 } : [10, 20, 30, 40]).ToArray();
+        var dimensions = format == KgpFormat.Png ? "" : ",s=3,v=3";
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize(
+            KgpTestHelper.BuildCommand($"a=T,f={(int)format}{dimensions},o=z,i=1,p=1,C=1,q=2", Compress(data)) +
+            "\x1b[2;2H" + KgpTestHelper.BuildCommand("a=p,i=1,p=2,C=1,q=2")));
+        var projection = new Hwt1RenderProjection();
+        using var snapshot = terminal.CreateSnapshot();
+        Assert.IsTrue(snapshot.KgpImages[1].IsZlibCompressed);
+        using var initial = Decode(projection.Encode(snapshot, Capabilities, 0, 1, 1));
+        Assert.AreEqual(1, projection.KgpMaterializationCount);
+        Assert.AreEqual(2, initial.Metadata.RootElement.GetProperty("placements").GetArrayLength());
+        Assert.AreEqual(format == KgpFormat.Png ? "png" : "rgba",
+            initial.Metadata.RootElement.GetProperty("images")[0].GetProperty("format").GetString());
+        var expected = format == KgpFormat.Rgb24
+            ? Enumerable.Range(0, 9).SelectMany(_ => new byte[] { 10, 20, 30, 255 }).ToArray() : data;
+        TestSeq.AreEqual(expected, initial.Pixels);
+        for (var i = 0; i < 5; i++)
+        {
+            using var unchanged = Decode(projection.Encode(snapshot, Capabilities, 0, 2, 2));
+            Assert.AreEqual(0, unchanged.Pixels.Length);
+        }
+        using var full = Decode(projection.Encode(snapshot, Capabilities, 0, 3, 3, forceFull: true));
+        TestSeq.AreEqual(expected, full.Pixels);
+        Assert.AreEqual(1, projection.KgpMaterializationCount, "Resync resends existing resources without reinflating.");
+
+        // The raw equivalent must have the same resource identity.
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize(
+            KgpTestHelper.BuildCommand($"a=T,f={(int)format}{dimensions},i=1,p=1,C=1,q=2", data)));
+        using var raw = terminal.CreateSnapshot();
+        using var delta = Decode(projection.Encode(raw, Capabilities, 0, 4, 4));
+        Assert.AreEqual(0, delta.Pixels.Length);
+        Assert.AreEqual(1, projection.RetainedImageCount);
+    }
+
+    [TestMethod]
+    public void Encode_CompressedUnchangedImage_DoesNotAllocateDecodedArrays()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        var pixels = new byte[512 * 512 * 4];
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize(
+            KgpTestHelper.BuildCommand("a=T,f=32,s=512,v=512,o=z,i=1,C=1,q=2", Compress(pixels))));
+        using var snapshot = terminal.CreateSnapshot();
+        var projection = new Hwt1RenderProjection();
+        projection.Encode(snapshot, Capabilities, 0, 0, 0);
+        projection.Encode(snapshot, Capabilities, 0, 0, 0);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < 5; i++)
+            projection.Encode(snapshot, Capabilities, 0, i, i);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.IsLessThan((long)pixels.Length, allocated, "Unchanged frames must not allocate even one decoded image.");
+        Assert.AreEqual(1, projection.KgpMaterializationCount);
+    }
+
+    [TestMethod]
+    [DataRow(1)]
+    [DataRow(20)]
+    [DataRow(1600)]
+    public void Encode_ProteinSizedImage_ReportsConsumerAllocationByPlacementCount(int placementCount)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        terminal.Resize(80, 24);
+        var pixels = new byte[800 * 400 * 4];
+        var projection = new Hwt1RenderProjection();
+        ApplyGeneration(0);
+        using (var baseline = terminal.CreateSnapshot())
+            projection.Encode(baseline, Capabilities, 0, 0, 0);
+        ApplyGeneration(1);
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        using var snapshot = terminal.CreateSnapshot();
+        var snapshotAllocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.AreEqual(placementCount, snapshot.KgpPlacements.Count);
+        before = GC.GetAllocatedBytesForCurrentThread();
+        var update = projection.Encode(snapshot, Capabilities, 0, 1, 1);
+        var resourceUpdateAllocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        before = GC.GetAllocatedBytesForCurrentThread();
+        var unchanged = projection.Encode(snapshot, Capabilities, 0, 2, 2);
+        var unchangedAllocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        before = GC.GetAllocatedBytesForCurrentThread();
+        var decoded = snapshot.KgpImages[1].Data;
+        var materializationAllocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        GC.KeepAlive(decoded);
+        var updateMetadataBytes = System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(update.AsSpan(4));
+        var unchangedMetadataBytes = System.Buffers.Binary.BinaryPrimitives.ReadInt32LittleEndian(unchanged.AsSpan(4));
+        Assert.AreEqual(2, projection.KgpMaterializationCount);
+        Assert.AreEqual(1, projection.RetainedImageCount);
+        Console.WriteLine(JsonSerializer.Serialize(new
+        {
+            placementCount,
+            formatBytes = pixels.Length,
+            snapshotAllocated,
+            materializationAllocated,
+            resourceUpdateAllocated,
+            unchangedAllocated,
+            updateFrameBytes = update.Length,
+            updateMetadataBytes,
+            unchangedFrameBytes = unchanged.Length,
+            unchangedMetadataBytes,
+            estimatedSnapshotAndProjectionBytesFor200Updates2394Frames =
+                200L * resourceUpdateAllocated + 2194L * unchangedAllocated + 2394L * snapshotAllocated
+        }));
+
+        void ApplyGeneration(byte generation)
+        {
+            pixels[0] = generation;
+            var output = new StringBuilder(KgpTestHelper.BuildCommand(
+                "a=t,f=32,s=800,v=400,o=z,i=1,q=2", Compress(pixels)));
+            for (var i = 0; i < placementCount; i++)
+                output.Append($"\x1b[{i / 80 + 1};{i % 80 + 1}H")
+                    .Append(KgpTestHelper.BuildCommand($"a=p,i=1,p={i + 1},c=1,r=1,C=1,q=2"));
+            terminal.ApplyTokens(AnsiTokenizer.Tokenize(output.ToString()));
+        }
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void Encode_SameIdGenerations_RetainsOnlyCurrentSharedResourcesAndDeletesToZero(bool compressed)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        var projection = new Hwt1RenderProjection();
+        var data = new byte[128 * 128 * 4];
+        for (var offset = 3; offset < data.Length; offset += 4)
+            data[offset] = 255;
+        var compression = compressed ? ",o=z" : "";
+        var root = compressed ? Compress(data) : data;
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize(
+            KgpTestHelper.BuildCommand($"a=T,f=32,s=128,v=128,i=1,p=1,c=1,r=1,C=1,q=2{compression}", root) +
+            KgpTestHelper.BuildCommand($"a=T,f=32,s=128,v=128,i=2,p=2,c=1,r=1,C=1,q=2{compression}", root)));
+        using var initialSnapshot = terminal.CreateSnapshot();
+        using var initial = Decode(projection.Encode(initialSnapshot, Capabilities, 0, 0, 0));
+        var sharedKey = initial.Metadata.RootElement.GetProperty("images")[0].GetProperty("key").GetString();
+        Assert.AreEqual(1, projection.RetainedImageCount);
+        Assert.AreEqual((long)data.Length, projection.RetainedImageBytes);
+
+        for (var generation = 1; generation <= 64; generation++)
+        {
+            for (var offset = 0; offset < data.Length; offset += 4)
+                data[offset] = (byte)generation;
+            terminal.ApplyTokens(AnsiTokenizer.Tokenize(KgpTestHelper.BuildCommand(
+                $"a=T,f=32,s=128,v=128,i=1,p=1,c=1,r=1,C=1,q=2{compression}",
+                compressed ? Compress(data) : data)));
+            using var snapshot = terminal.CreateSnapshot();
+            using var frame = Decode(projection.Encode(snapshot, Capabilities, 0, generation, generation));
+            var metadata = frame.Metadata.RootElement;
+            var retained = metadata.GetProperty("retainedImages").EnumerateArray()
+                .Select(key => key.GetString()).ToHashSet();
+            var placed = metadata.GetProperty("placements").EnumerateArray()
+                .Select(placement => placement.GetProperty("key").GetString()).ToHashSet();
+            Assert.IsTrue(retained.SetEquals(placed), $"Generation {generation} retained obsolete browser textures.");
+            Assert.AreEqual(2, retained.Count, "The unchanged second image still owns the original shared resource.");
+            Assert.IsTrue(retained.Contains(sharedKey));
+            Assert.AreEqual(1, metadata.GetProperty("images").GetArrayLength());
+            Assert.AreEqual(2, projection.RetainedImageCount);
+            Assert.AreEqual(2L * data.Length, projection.RetainedImageBytes);
+            TestSeq.AreEqual(data, frame.Pixels);
+        }
+        Assert.AreEqual(compressed ? 65 : 0, projection.KgpMaterializationCount);
+
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize(KgpTestHelper.BuildCommand("a=d,d=I,i=1,q=2")));
+        using (var snapshot = terminal.CreateSnapshot())
+        using (var frame = Decode(projection.Encode(snapshot, Capabilities, 0, 65, 65)))
+        {
+            Assert.AreEqual(1, projection.RetainedImageCount);
+            Assert.AreEqual((long)data.Length, projection.RetainedImageBytes);
+            Assert.AreEqual(sharedKey,
+                frame.Metadata.RootElement.GetProperty("retainedImages")[0].GetString());
+        }
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize(KgpTestHelper.BuildCommand("a=d,d=I,i=2,q=2")));
+        using (var snapshot = terminal.CreateSnapshot())
+        using (var frame = Decode(projection.Encode(snapshot, Capabilities, 0, 66, 66)))
+        {
+            Assert.AreEqual(0, projection.RetainedImageCount);
+            Assert.AreEqual(0L, projection.RetainedImageBytes);
+            Assert.AreEqual(0, frame.Metadata.RootElement.GetProperty("retainedImages").GetArrayLength());
+        }
+        projection.Clear();
+        Assert.AreEqual(0L, projection.RetainedImageBytes);
+        Assert.AreEqual((byte)0, initial.Pixels[0], "Returned frames remain caller-owned across replacement and deletion.");
+    }
+
+    [TestMethod]
+    public void Encode_CompressedOverBudget_RejectsBeforeAnyInflation()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        var pixels = new byte[4096 * 2048 * 4];
+        for (var i = 1; i <= 3; i++)
+        {
+            pixels[0] = (byte)i;
+            terminal.ApplyTokens(AnsiTokenizer.Tokenize(KgpTestHelper.BuildCommand(
+                $"a=T,f=32,s=4096,v=2048,o=z,i={i},c=1,r=1,C=1,q=2", Compress(pixels))));
+        }
+        using var snapshot = terminal.CreateSnapshot();
+        Assert.AreEqual(3, snapshot.KgpImages.Count);
+        var projection = new Hwt1RenderProjection();
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        var error = Assert.Throws<InvalidDataException>(() => projection.Encode(snapshot, Capabilities, 0, 1, 1));
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.Contains("64 MiB", error.Message);
+        Assert.AreEqual(0, projection.KgpMaterializationCount);
+        Assert.AreEqual(0, projection.RetainedImageCount);
+        Assert.AreEqual(0u, projection.Revision);
+        Assert.IsLessThan((long)pixels.Length, allocated, "Budget rejection must precede format-byte materialization.");
+    }
+
+    [TestMethod]
+    public void Encode_CompressedPngWithOversizedMetadata_RejectsPayloadBeforeInflation()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        var png = CreatePngWithMetadata(32 * 1024 * 1024, (byte)'a');
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize(KgpTestHelper.BuildCommand(
+            "a=T,f=100,o=z,i=1,c=1,r=1,C=1,q=2", Compress(png))));
+        using var snapshot = terminal.CreateSnapshot();
+        var image = TestSeq.Single(snapshot.KgpImages.Values);
+        Assert.AreEqual(3u, image.Width);
+        Assert.AreEqual((long)png.Length, image.ReservedDecodedBytes);
+        var projection = new Hwt1RenderProjection();
+        var before = GC.GetAllocatedBytesForCurrentThread();
+
+        var error = Assert.Throws<InvalidDataException>(() => projection.Encode(snapshot, Capabilities, 0, 1, 1));
+
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.Contains("PNG payload", error.Message);
+        Assert.IsLessThan((long)png.Length / 8, allocated);
+        Assert.AreEqual(0, projection.KgpMaterializationCount);
+        Assert.AreEqual(0u, projection.Revision);
+        Assert.AreEqual(0L, projection.RetainedImageBytes);
+    }
+
+    [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void Encode_CompressedPngMetadata_BoundsActiveAndReplacementPayloads(bool simultaneous)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        var projection = new Hwt1RenderProjection();
+        for (var i = 0; i < 3; i++)
+        {
+            var png = CreatePngWithMetadata(24 * 1024 * 1024, (byte)('a' + i));
+            terminal.ApplyTokens(AnsiTokenizer.Tokenize(KgpTestHelper.BuildCommand(
+                $"a=T,f=100,o=z,i={(simultaneous ? i + 1 : 1)},c=1,r=1,C=1,q=2", Compress(png))));
+            if (simultaneous)
+                continue;
+            using var snapshot = terminal.CreateSnapshot();
+            var frame = projection.Encode(snapshot, Capabilities, 0, i, i);
+            Assert.IsTrue(frame.AsSpan(frame.Length - png.Length).SequenceEqual(png));
+            Assert.AreEqual(1, projection.RetainedImageCount);
+            Assert.AreEqual((long)png.Length, projection.RetainedImageBytes,
+                "Replacement must release obsolete PNG payloads even when their textures are tiny.");
+        }
+        if (simultaneous)
+        {
+            using var snapshot = terminal.CreateSnapshot();
+            Assert.AreEqual(3, snapshot.KgpImages.Count);
+            var before = GC.GetAllocatedBytesForCurrentThread();
+            var error = Assert.Throws<InvalidDataException>(() => projection.Encode(snapshot, Capabilities, 0, 1, 1));
+            var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+            Assert.Contains("64 MiB", error.Message);
+            Assert.AreEqual(0, projection.KgpMaterializationCount);
+            Assert.AreEqual(0L, projection.RetainedImageBytes);
+            Assert.IsLessThan(1024L * 1024, allocated);
+        }
+        projection.Clear();
+        Assert.AreEqual(0L, projection.RetainedImageBytes);
+    }
+
+    private static byte[] CreatePngWithMetadata(int metadataBytes, byte fill)
+    {
+        var png = Convert.FromBase64String(
+            "iVBORw0KGgoAAAANSUhEUgAAAAMAAAADCAYAAABWKLW/AAAAEUlEQVR4nGP4z8DwH4YZcHIAXdcR79xPMRAAAAAASUVORK5CYII=");
+        var result = new byte[png.Length + metadataBytes + 12];
+        png.AsSpan(0, 33).CopyTo(result);
+        System.Buffers.Binary.BinaryPrimitives.WriteInt32BigEndian(result.AsSpan(33), metadataBytes);
+        "tEXt"u8.CopyTo(result.AsSpan(37));
+        result.AsSpan(41, metadataBytes).Fill(fill);
+        "Comment\0"u8.CopyTo(result.AsSpan(41));
+        var table = new uint[256];
+        for (uint i = 0; i < table.Length; i++)
+        {
+            var value = i;
+            for (var bit = 0; bit < 8; bit++)
+                value = (value & 1) != 0 ? (value >> 1) ^ 0xedb88320 : value >> 1;
+            table[i] = value;
+        }
+        var crc = uint.MaxValue;
+        foreach (var value in result.AsSpan(37, metadataBytes + 4))
+            crc = table[(crc ^ value) & 255] ^ (crc >> 8);
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt32BigEndian(result.AsSpan(41 + metadataBytes), ~crc);
+        png.AsSpan(33).CopyTo(result.AsSpan(45 + metadataBytes));
+        return result;
+    }
+
+    private static byte[] Compress(byte[] data)
+    {
+        using var output = new MemoryStream();
+        using (var zlib = new ZLibStream(output, CompressionLevel.Fastest, leaveOpen: true))
+            zlib.Write(data);
+        return output.ToArray();
+    }
 
     [TestMethod]
     public void Encode_Hyperlinks_PreservesWideCellsAndWrappedViewportRanges()
@@ -485,7 +803,7 @@ public class WebTerminalProjectionTests
             "\x1b_Ga=T,f=32,s=1,v=1,i=2,p=1,c=1,r=1,C=1,q=2;AAD//w==\x1b\\"));
         using var next = terminal.CreateSnapshot();
         using var delta = Decode(projection.Encode(next, Capabilities, 0, 2, 2));
-        Assert.AreEqual(2, delta.Metadata.RootElement.GetProperty("retainedImages").GetArrayLength());
+        Assert.AreEqual(1, delta.Metadata.RootElement.GetProperty("retainedImages").GetArrayLength());
         using var full = Decode(projection.Encode(next, Capabilities, 0, 2, 3, forceFull: true));
         Assert.AreEqual(1, full.Metadata.RootElement.GetProperty("retainedImages").GetArrayLength());
         Assert.AreEqual(1, full.Metadata.RootElement.GetProperty("images").GetArrayLength());


### PR DESCRIPTION
## Summary

Fixes #528.

- Validate and retain zlib-compressed Kitty images in `Hex1bTerminal`, using the existing image model and built-in `ZLibStream`.
- Keep compressed backing authoritative; each `KgpImageData.Data` read returns a fresh caller-owned array. Charge encoded retention plus conservative decoded capacity, with bounded input and complete validation.
- Preserve snapshot lifetimes and integrate compressed replay, animation, HMP1 replicas, HWT1 projection and SVG consumers.
- Suppress Unicode-placeholder glyph painting without removing authoritative cells/placements, and prune obsolete graphics resources while preserving shared and in-flight owners.
- Add reusable raw duplex capture/replay, malformed/chunked input, ownership/quota and browser regression coverage.

No public API signatures were added. Existing graphics options now constrain compressed KGP uploads; the new allocation behavior of `Data` is documented.

## Validation

- Unmodified pinned ProteinView `9b9a0790bc78f1d2a7c0923905049d27c67c05e2` with `4HHB.pdb` rendered via real WebTerminalDemo on WebGPU and WebGL2, with no placeholder boxes.
- 52 changing browser image presentations per backend; peak one 1,280,000-byte image texture.
- FullHD/HD/Braille transitions and 40 total direct/HMP1 reconnect cycles passed.
- Actual sustained runs observed 200 distinct image generations. Peak core storage: 88,367 encoded bytes + 1,280,000 reserved bytes; both store counters returned to zero after disposal.
- Strict placeholder fixture: 800/800 red pixels on both backends, with shared-resource preservation and native deletion checks.
- Local affected .NET suites: 2,435 passed, one opt-in case skipped. Web package: 196 passed. Release demo build passed.

These measurements precede the latest main merge; CI will validate the merged PR head. Raw application captures remain private; source-grounded findings and measured evidence are preserved in issue artifacts.

## Limits

Graphics ownership is bounded, but allocation churn remains significant. Captured live-host counters showed roughly 32–33 MB/s while paused; this change does not claim a process-memory cap or globally bound caller-retained snapshots. Actual reproduction covered one pinned application/model and macOS/Chromium environment, not an independently forced Sixel path or every browser/device.